### PR TITLE
fix(apifrontend,kubernautagent): port interactive-session batch + SSE grounding + metrics-drift fixes to v1.6 (#2093, #2095, #2099, #2101, #2104, #2106)

### DIFF
--- a/cmd/kubernautagent/routes.go
+++ b/cmd/kubernautagent/routes.go
@@ -328,8 +328,19 @@ func buildMCPCoreDeps(ctx context.Context, p mcpHandlerParams) (*mcpCoreDeps, er
 	// paths produce an audit trail, not just action=complete/cancel through InvestigateTool.
 	emitDisconnectAudit := newDisconnectAuditEmitter(auditStore, logger) //nolint:contextcheck // disconnect audit emitter fires asynchronously on session disconnect events, not tied to any single request
 
+	// #2100 (v1.6 clone #2101): SessionJanitor is a backstop sweep for
+	// interactive sessions that never reach an explicit Release path (e.g.
+	// a session whose owning goroutine panics or exits early before the
+	// TTL/inactivity checks in GetDriver ever run against it again) --
+	// without it, those sessions hold their Lease and activeCount slot
+	// until process restart, eroding interactive.maxConcurrentSessions
+	// capacity. Interval reuses cfg.Interactive.SessionTTL so the sweep
+	// never fires earlier than the TTL/inactivity paths already cover.
+	sessionJanitor := mcpkg.NewSessionJanitor(cfg.Interactive.SessionTTL, logger.WithName("session-janitor"))
+	go sessionJanitor.Run(ctx)
+
 	// Session management via K8s Leases (single-driver guarantee).
-	leaseMgr := buildMCPLeaseManager(ctrlCli, namespace, cfg, autoMgr, agentMetrics, logger, emitDisconnectAudit) //nolint:contextcheck // buildMCPLeaseManager wires session lease management once at startup; no parent request context exists yet
+	leaseMgr := buildMCPLeaseManager(ctrlCli, namespace, cfg, autoMgr, agentMetrics, logger, emitDisconnectAudit, sessionJanitor) //nolint:contextcheck // buildMCPLeaseManager wires session lease management once at startup; no parent request context exists yet
 
 	// Context reconstruction from DS audit events (best-effort).
 	recon := resolveContextReconstructor(ds, logger)
@@ -511,6 +522,7 @@ func buildMCPHandler(ctx context.Context, p mcpHandlerParams) (http.Handler, *mc
 		"reconstruction_spawner", true,
 		"notification_bus", true,
 		"session_drainer", true,
+		"session_janitor", true,
 	)
 
 	return mcpHandler, drainer
@@ -578,7 +590,7 @@ func newDisconnectAuditEmitter(auditStore audit.AuditStore, logger logr.Logger) 
 // buildMCPLeaseManager constructs the K8s-Lease-backed session manager
 // (single-driver guarantee) and reclaims any orphaned Leases left over from a
 // previous process instance.
-func buildMCPLeaseManager(ctrlCli ctrlclient.Client, namespace string, cfg *kaconfig.Config, autoMgr *session.Manager, agentMetrics *kametrics.Metrics, logger logr.Logger, emitDisconnectAudit func(string, string, string)) *mcpkg.LeaseSessionManager {
+func buildMCPLeaseManager(ctrlCli ctrlclient.Client, namespace string, cfg *kaconfig.Config, autoMgr *session.Manager, agentMetrics *kametrics.Metrics, logger logr.Logger, emitDisconnectAudit func(string, string, string), sessionJanitor *mcpkg.SessionJanitor) *mcpkg.LeaseSessionManager {
 	leaseOpts := []mcpkg.LeaseOption{
 		mcpkg.WithSessionTTL(cfg.Interactive.SessionTTL),
 		mcpkg.WithInactivityTimeout(cfg.Interactive.InactivityTimeout),
@@ -591,6 +603,7 @@ func buildMCPLeaseManager(ctrlCli ctrlclient.Client, namespace string, cfg *kaco
 			emitDisconnectAudit(sessionID, rrID, reason)
 			agentMetrics.RecordInteractiveSessionEnded()
 		}),
+		mcpkg.WithSessionJanitor(sessionJanitor),
 	}
 	leaseMgr := mcpkg.NewLeaseSessionManagerConcrete(ctrlCli, namespace, logger, leaseOpts...)
 

--- a/cmd/kubernautagent/routes.go
+++ b/cmd/kubernautagent/routes.go
@@ -340,7 +340,16 @@ func buildMCPCoreDeps(ctx context.Context, p mcpHandlerParams) (*mcpCoreDeps, er
 	go sessionJanitor.Run(ctx)
 
 	// Session management via K8s Leases (single-driver guarantee).
-	leaseMgr := buildMCPLeaseManager(ctrlCli, namespace, cfg, autoMgr, agentMetrics, logger, emitDisconnectAudit, sessionJanitor) //nolint:contextcheck // buildMCPLeaseManager wires session lease management once at startup; no parent request context exists yet
+	leaseMgr := buildMCPLeaseManager(mcpLeaseManagerDeps{ //nolint:contextcheck // buildMCPLeaseManager wires session lease management once at startup; no parent request context exists yet
+		ctrlCli:             ctrlCli,
+		namespace:           namespace,
+		cfg:                 cfg,
+		autoMgr:             autoMgr,
+		agentMetrics:        agentMetrics,
+		logger:              logger,
+		emitDisconnectAudit: emitDisconnectAudit,
+		sessionJanitor:      sessionJanitor,
+	})
 
 	// Context reconstruction from DS audit events (best-effort).
 	recon := resolveContextReconstructor(ds, logger)
@@ -350,7 +359,7 @@ func buildMCPCoreDeps(ctx context.Context, p mcpHandlerParams) (*mcpCoreDeps, er
 	eventStore := mcpkg.NewDelegatingEventStore()
 
 	// TimeoutManager: fires onExpire when a session goes inactive (SEC-04, HARM-03/04).
-	timeoutMgr := buildMCPTimeoutManager(cfg, autoMgr, leaseMgr, agentMetrics, logger, emitDisconnectAudit) //nolint:contextcheck // session Release must succeed on its own bounded context regardless of the caller's (drain/timeout/disconnect) context state
+	timeoutMgr := buildMCPTimeoutManager(cfg, autoMgr, leaseMgr, logger, emitDisconnectAudit) //nolint:contextcheck // session Release must succeed on its own bounded context regardless of the caller's (drain/timeout/disconnect) context state
 
 	// ReconstructionSpawner: rebuilds context and spawns autonomous investigation
 	// after an interactive session ends (INT-06, BR-INTERACTIVE-008).
@@ -587,27 +596,42 @@ func newDisconnectAuditEmitter(auditStore audit.AuditStore, logger logr.Logger) 
 	}
 }
 
+// mcpLeaseManagerDeps groups buildMCPLeaseManager's construction-time
+// dependencies (revive argument-limit: sessionJanitor, added for #2100 (v1.6
+// clone #2101), pushed the plain-parameter list to 8 -- follows the same
+// deps-struct pattern as mcpDisconnectHandlerDeps below).
+type mcpLeaseManagerDeps struct {
+	ctrlCli             ctrlclient.Client
+	namespace           string
+	cfg                 *kaconfig.Config
+	autoMgr             *session.Manager
+	agentMetrics        *kametrics.Metrics
+	logger              logr.Logger
+	emitDisconnectAudit func(string, string, string)
+	sessionJanitor      *mcpkg.SessionJanitor
+}
+
 // buildMCPLeaseManager constructs the K8s-Lease-backed session manager
 // (single-driver guarantee) and reclaims any orphaned Leases left over from a
 // previous process instance.
-func buildMCPLeaseManager(ctrlCli ctrlclient.Client, namespace string, cfg *kaconfig.Config, autoMgr *session.Manager, agentMetrics *kametrics.Metrics, logger logr.Logger, emitDisconnectAudit func(string, string, string), sessionJanitor *mcpkg.SessionJanitor) *mcpkg.LeaseSessionManager {
+func buildMCPLeaseManager(d mcpLeaseManagerDeps) *mcpkg.LeaseSessionManager {
 	leaseOpts := []mcpkg.LeaseOption{
-		mcpkg.WithSessionTTL(cfg.Interactive.SessionTTL),
-		mcpkg.WithInactivityTimeout(cfg.Interactive.InactivityTimeout),
-		mcpkg.WithMaxConcurrentSessions(cfg.Interactive.MaxConcurrentSessions),
+		mcpkg.WithSessionTTL(d.cfg.Interactive.SessionTTL),
+		mcpkg.WithInactivityTimeout(d.cfg.Interactive.InactivityTimeout),
+		mcpkg.WithMaxConcurrentSessions(d.cfg.Interactive.MaxConcurrentSessions),
 		mcpkg.WithSessionExpiredCallback(func(sessionID, rrID, reason string) {
 			// #1438: Emit terminal event BEFORE completing the HTTP session so
 			// EventLogBridge can forward it to AF before the channel closes.
-			autoMgr.EmitSessionEndedByRR(rrID, reason)
-			mcptools.CompleteHTTPSession(autoMgr, rrID, nil, logger, reason)
-			emitDisconnectAudit(sessionID, rrID, reason)
+			d.autoMgr.EmitSessionEndedByRR(rrID, reason)
+			mcptools.CompleteHTTPSession(d.autoMgr, rrID, nil, d.logger, reason)
+			d.emitDisconnectAudit(sessionID, rrID, reason)
 			// #2103 (v1.6 clone #2104): aiagent_mcp_interactive_sessions_active
 			// decrement moved into LeaseSessionManager.Release() itself (called
 			// by GetDriver just before this callback fires) -- see
 			// WithSessionEndedMetrics below. An explicit call here would
 			// double-decrement.
 		}),
-		mcpkg.WithSessionJanitor(sessionJanitor),
+		mcpkg.WithSessionJanitor(d.sessionJanitor),
 		// #2103 (v1.6 clone #2104): centralizes the
 		// aiagent_mcp_interactive_sessions_active decrement inside Release()
 		// itself, so every Release() caller -- InvestigateTool,
@@ -615,12 +639,12 @@ func buildMCPLeaseManager(ctrlCli ctrlclient.Client, namespace string, cfg *kaco
 		// backstop above, and this file's own TTL/inactivity/disconnect
 		// callbacks below -- keeps the gauge accurate without each needing
 		// its own metrics wiring.
-		mcpkg.WithSessionEndedMetrics(agentMetrics),
+		mcpkg.WithSessionEndedMetrics(d.agentMetrics),
 	}
-	leaseMgr := mcpkg.NewLeaseSessionManagerConcrete(ctrlCli, namespace, logger, leaseOpts...)
+	leaseMgr := mcpkg.NewLeaseSessionManagerConcrete(d.ctrlCli, d.namespace, d.logger, leaseOpts...)
 
 	if n := leaseMgr.ReconcileOrphanedLeases(context.Background()); n > 0 {
-		logger.Info("startup: reclaimed orphaned interactive Leases", "count", n)
+		d.logger.Info("startup: reclaimed orphaned interactive Leases", "count", n)
 	}
 	return leaseMgr
 }
@@ -629,7 +653,13 @@ func buildMCPLeaseManager(ctrlCli ctrlclient.Client, namespace string, cfg *kaco
 // when a session goes inactive (SEC-04, HARM-03/04): it snapshots the
 // correlation ID before releasing the lease, resolves the HTTP session so AA
 // stops polling user_driving, and emits the disconnect audit trail.
-func buildMCPTimeoutManager(cfg *kaconfig.Config, autoMgr *session.Manager, leaseMgr *mcpkg.LeaseSessionManager, agentMetrics *kametrics.Metrics, logger logr.Logger, emitDisconnectAudit func(string, string, string)) *mcpkg.TimeoutManager {
+//
+// #2103 (v1.6 clone #2104): no longer takes an agentMetrics parameter -- the
+// aiagent_mcp_interactive_sessions_active decrement this callback used to
+// call explicitly moved into LeaseSessionManager.Release() itself (via
+// buildMCPLeaseManager's WithSessionEndedMetrics), which leaseMgr.Release
+// below already invokes.
+func buildMCPTimeoutManager(cfg *kaconfig.Config, autoMgr *session.Manager, leaseMgr *mcpkg.LeaseSessionManager, logger logr.Logger, emitDisconnectAudit func(string, string, string)) *mcpkg.TimeoutManager {
 	return mcpkg.NewTimeoutManager(
 		cfg.Interactive.InactivityTimeout,
 		[]time.Duration{cfg.Interactive.InactivityTimeout - 2*time.Minute, cfg.Interactive.InactivityTimeout - 30*time.Second},

--- a/cmd/kubernautagent/routes.go
+++ b/cmd/kubernautagent/routes.go
@@ -601,9 +601,21 @@ func buildMCPLeaseManager(ctrlCli ctrlclient.Client, namespace string, cfg *kaco
 			autoMgr.EmitSessionEndedByRR(rrID, reason)
 			mcptools.CompleteHTTPSession(autoMgr, rrID, nil, logger, reason)
 			emitDisconnectAudit(sessionID, rrID, reason)
-			agentMetrics.RecordInteractiveSessionEnded()
+			// #2103 (v1.6 clone #2104): aiagent_mcp_interactive_sessions_active
+			// decrement moved into LeaseSessionManager.Release() itself (called
+			// by GetDriver just before this callback fires) -- see
+			// WithSessionEndedMetrics below. An explicit call here would
+			// double-decrement.
 		}),
 		mcpkg.WithSessionJanitor(sessionJanitor),
+		// #2103 (v1.6 clone #2104): centralizes the
+		// aiagent_mcp_interactive_sessions_active decrement inside Release()
+		// itself, so every Release() caller -- InvestigateTool,
+		// SelectWorkflowTool, CompleteNoActionTool, the SessionJanitor
+		// backstop above, and this file's own TTL/inactivity/disconnect
+		// callbacks below -- keeps the gauge accurate without each needing
+		// its own metrics wiring.
+		mcpkg.WithSessionEndedMetrics(agentMetrics),
 	}
 	leaseMgr := mcpkg.NewLeaseSessionManagerConcrete(ctrlCli, namespace, logger, leaseOpts...)
 
@@ -637,8 +649,10 @@ func buildMCPTimeoutManager(cfg *kaconfig.Config, autoMgr *session.Manager, leas
 			// KA-CRIT-2: Resolve the HTTP session so AA stops polling user_driving.
 			mcptools.CompleteHTTPSession(autoMgr, rrID, nil, logger, "inactivity_timeout")
 			emitDisconnectAudit(sessionID, rrID, "inactivity_timeout")
-			// T1-4: Decrement gauge on timeout expiry to prevent drift.
-			agentMetrics.RecordInteractiveSessionEnded()
+			// #2103 (v1.6 clone #2104): T1-4's gauge decrement moved into
+			// LeaseSessionManager.Release() itself (called by leaseMgr.Release
+			// just above) -- see WithSessionEndedMetrics. An explicit call
+			// here would double-decrement.
 		},
 	)
 }
@@ -719,8 +733,10 @@ func buildMCPDisconnectHandler(d mcpDisconnectHandlerDeps) *mcpkg.GracefulSessio
 
 		d.emitDisconnectAudit(interactiveSessionID, rrID, "disconnect")
 
-		// T1-4: Decrement gauge on disconnect to prevent drift.
-		d.agentMetrics.RecordInteractiveSessionEnded()
+		// #2103 (v1.6 clone #2104): T1-4's gauge decrement moved into
+		// LeaseSessionManager.Release() itself (called above) -- see
+		// WithSessionEndedMetrics. An explicit call here would
+		// double-decrement.
 
 		// Spawn reconstruction in background (best-effort, BR-INTERACTIVE-008).
 		go spawnReconstruction(d.reconSpawner, d.logger, rrID, interactiveSessionID, signalMeta)

--- a/docs/testing/2092-2094-2098-2100/TEST_PLAN.md
+++ b/docs/testing/2092-2094-2098-2100/TEST_PLAN.md
@@ -1,0 +1,231 @@
+# Test Plan: v1.5.6 QE Batch — present_decision Schema/Ordering, WatchTerminalEvents Leak, Interactive Session Janitor
+
+**Issues**: [#2092](https://github.com/jordigilh/kubernaut/issues/2092), [#2094](https://github.com/jordigilh/kubernaut/issues/2094), [#2098](https://github.com/jordigilh/kubernaut/issues/2098), [#2100](https://github.com/jordigilh/kubernaut/issues/2100) (all `v1.5.6`, `release/v1.5`)
+**Related (investigated, not in scope)**: #1995 (already fixed by merged PR #2000), #2096 (spiked and re-scoped as client/harness disconnect, not an AF bug — see GitHub comment on #2096)
+**Branch**: `fix/2092-2094-2098-2100-interactive-session-batch` (off `origin/release/v1.5` @ `bb2cf8c57`)
+**Created**: 2026-08-11
+**Status**: Implementation complete — all tiers green, pending PR review
+
+---
+
+## 1. Purpose
+
+Four independent QE-reported defects from the same live v1.5.6-rc2 acceptance run, batched into one branch/PR to save CI overhead (commits stay independently reviewable; no squash on merge). Two share a user-visible symptom (empty/escape-hatch decision despite a real, high-confidence workflow existing) via two distinct, independently-reproduced mechanisms; the other two are resource-leak/observability gaps discovered while investigating the same run.
+
+| Issue | Symptom | Mechanism |
+|---|---|---|
+| #2092 | `kubernaut_present_decision` fails JSON-schema validation, agent retries with empty `options` | `options` argument arrives JSON-double-encoded (native array wrapped again as a string) |
+| #2098 | `kubernaut_present_decision` renders an empty decision despite discovery succeeding moments later | Tool-call **ordering**: the model calls `present_decision` before `discover_workflows` in `full_remediation` mode |
+| #2094 | `WatchTerminalEvents` goroutine leaks indefinitely (confirmed live via pprof, 5-7+ minutes stuck); `AIAnalysis` CR stays `Investigating` past its own 10m timeout | No timer-based safety net in the watcher's `select` loop (by original design) — third instance of the same "wait forever" anti-pattern already fixed twice before (#1949/#1960, #2086/#2089) |
+| #2100 | `interactive.maxConcurrentSessions` capacity erodes monotonically under concurrent load until pod restart | `SessionJanitor` (the documented safety net) is fully implemented/unit-tested but never wired into the running server; `handleStart` can also acquire a lease and never roll it back when no investigation exists to attach it to |
+
+### Root Cause Detail
+
+**#2092** — `pkg/apifrontend/agent/phase_guard.go`'s `presentDecisionTool` `before`-callback branch calls `enforceGroundingGuard` but does nothing about `args["options"]`'s wire type. ADK's `functionTool.Run` (`google.golang.org/adk@v1.5.1/tool/functiontool/function.go:185-200`) calls `typeutil.ConvertToWithJSONSchema` immediately afterward, which re-marshals `args` to JSON, unmarshals into `map[string]any`, and validates that against the inferred schema (`internal/typeutil/convert.go:27-44`) — a JSON *string* value for a field whose schema says `type: array` fails `resolvedSchema.Validate(m)` before the handler (`HandlePresentDecision`) ever runs. Live evidence (issue #2092) confirms the model's `options` payload was fully correct in content, just double-encoded.
+
+**#2098** — Live evidence (issue #2098, RR `rr-6a97f7a00ba9-79ad53ed`) shows `kubernaut_present_decision` invoked and *succeeding* at `03:07:12`, then `kubernaut_discover_workflows` starting at `03:07:21` and completing at `03:07:44` — nine seconds too late. `newPhaseGuard`'s `presentDecisionTool` branch (`phase_guard.go:118-121`) has no ordering precondition at all; `checkpointGatedTools` (DD-AF-011, #1899) already gates `discover_workflows`/`select_workflow` behind consent flags but was never extended to gate `present_decision` on discovery having actually run.
+
+**#2094** — `pkg/apifrontend/tools/ka_investigate_mcp.go:961-985`'s `WatchTerminalEvents` `select` loop has exactly two exit conditions (`events` yields/closes, or `done` closes) and no timer. Its caller (`ka_investigate_mcp.go:585`) deliberately detaches the goroutine's context via `context.WithoutCancel` so it can outlive the originating tool call — meaning `ctx.Done()` firing was never a viable exit path even if it were checked. When the pool's `onRelease` callback never fires and no `session_ended` event ever arrives (confirmed live via pprof), the goroutine blocks forever.
+
+**#2100** — Two independent sub-defects converge on the same symptom:
+1. `SessionJanitor` (`internal/kubernautagent/mcp/disconnect_handler.go:190-261`) is a complete, ticker-based stale-session sweeper with its own passing UT/IT coverage (`disconnect_handler_test.go`'s `IT-KA-DES-005`/`006`), but `NewSessionJanitor(...)` has zero callers outside test files anywhere in the repository — confirmed via `grep -rn NewSessionJanitor --include=*.go .` returning only its definition and test files.
+2. `InvestigateTool.handleStart` (`internal/kubernautagent/mcp/tools/investigate.go:435-578`) calls `t.sessions.Takeover(...)` at line 480 (acquiring the Lease and incrementing `LeaseSessionManager.activeCount` unconditionally on success), then — in the specific branch where no autonomous session exists for the RR (line 549-561) — tries `reattachOrCreateFallback` then `ForceTransitionToUserDriving` as a last resort. If **both** fail, the function silently proceeds to `startTimeoutTracking` and returns success with an empty `InvestigationSessionID`, holding the lease with nothing behind it (matches `session_teardown.go`'s "CRITICAL: no session found for either completion path — AA will not receive result" log line). `KA`'s existing `TimeoutManager` (10-minute default inactivity timeout) does eventually reclaim this via `startTimeoutTracking`'s own callback, which is why live evidence shows leases lingering ~7-8 minutes rather than permanently — but this is incidental, not a designed safety net for this specific failure, and depends on `startTimeoutTracking` always being reached (not guaranteed for every `Takeover` caller, e.g. `handleTakeover`).
+
+## 2. Fix Design
+
+```mermaid
+flowchart TD
+    subgraph af2092["#2092: options schema"]
+        LLM["Model emits options as\nJSON string (double-encoded)"] --> BEFORE["phaseGuardBefore:\npresentDecisionTool branch"]
+        BEFORE --> REPAIR["repairPresentDecisionOptions:\njson.Unmarshal string into []any"]
+        REPAIR --> SCHEMA["functionTool.Run:\nConvertToWithJSONSchema"]
+        SCHEMA -->|"native array now"| HANDLER["HandlePresentDecision\n(artifact emitted, AU-3)"]
+    end
+    subgraph af2098["#2098: ordering"]
+        PD2["kubernaut_present_decision\ncalled"] --> GATE{"mode requires discovery\n(Phase2Blocked==false)\nAND not yet succeeded?"}
+        GATE -->|yes| REJECT["reject: call discover_workflows first\n(mirrors DD-AF-011 checkpointGatedTools)"]
+        GATE -->|no| BEFORE
+    end
+    subgraph af2094["#2094: watcher leak"]
+        WATCH["WatchTerminalEvents select loop"] --> T1["events: session_ended"]
+        WATCH --> T2["done: pool release"]
+        WATCH --> T3["NEW: safety-net timer\n(WatchTerminalEventsSafetyNet)"]
+        T3 --> LOG["Info log + goroutine exits\n(AU-3 evidence trail)"]
+    end
+    subgraph ka2100["#2100: session janitor"]
+        TAKEOVER["LeaseSessionManager.Takeover\nsuccess"] --> TRACK["janitor.Track(sessionID)"]
+        RELEASE["LeaseSessionManager.Release"] --> UNTRACK["janitor.Untrack(sessionID)"]
+        TRACK -->|"interval elapsed,\nnever untracked"| SWEEP["janitor.sweep -> onExpire -> Release\n(defense-in-depth backstop)"]
+        HS["handleStart: fallback exhausted\n(no autonomous session, no reattach,\nForceTransitionToUserDriving fails)"] --> IMMEDIATE["NEW: immediate Release\n+ fail-closed error"]
+    end
+```
+
+### #2092 — repair stringified `options` before schema validation
+
+`pkg/apifrontend/agent/phase_guard.go`'s `enforceGroundingGuard` already proves the exact technique needed: it mutates `args["rca"]`/`args["summary"]`/`args["options"]` in place, before `before`'s caller passes `args` on to `functionTool.Run`'s schema validation (this ordering is what makes `args["options"] = []any{}` on the ungrounded path already work today). Add a new step, `repairPresentDecisionOptions`, that runs in the **grounded** branch (the ungrounded branch already unconditionally overwrites `options` with a clean empty slice, so it needs no repair): if `args["options"]` is a `string`, attempt `json.Unmarshal` into `[]any`; on success, replace `args["options"]` with the parsed value; on failure (genuinely malformed JSON), leave it untouched so ADK's real schema validation still rejects it with a useful error — this must never silently mask a truly malformed payload as an empty-but-valid one.
+
+### #2098 — gate `present_decision` on discovery having run, in the modes where it's expected
+
+Add `session.StateKeyDiscoverWorkflowsSucceeded`, set `true` in `newPhaseGuard`'s `after`-callback's existing `isDiscoverWorkflows` success branch (`phase_guard.go:258-267`) and reset `false` alongside `StateKeyPhase2Blocked` on every fresh `kubernaut_investigate` (not `kubernaut_reconnect`, matching the existing asymmetry at line 300). In the `before`-callback's `presentDecisionTool` branch, before calling `enforceGroundingGuard`, reject the call (mirroring `errCheckpointBlocked`'s existing reject-with-retry pattern, not `enforceGroundingGuard`'s mutate-and-continue pattern) when `StateKeyPhase2Blocked == false` (i.e., this mode does **not** require a human-confirmation checkpoint before `discover_workflows` — true for `full_remediation`/`full_remediation_autonomous`, and also correctly excludes the #1918 `rcaConcludedNotActionable` override, since that forces `Phase2Blocked = true`) **and** `StateKeyDiscoverWorkflowsSucceeded != true`. Reusing `Phase2Blocked` (rather than re-deriving mode) means the gate automatically inherits the #1918 "RCA said not actionable" exemption for free — no duplicated mode logic.
+
+This mirrors DD-AF-011's proven pattern exactly: reject with a clear instruction, let the model self-correct by calling `discover_workflows` and retrying — the AU-3 "always emit an artifact" mandate is preserved because the retry (post-discovery) reaches `HandlePresentDecision` normally.
+
+### #2094 — bounded safety-net timer in `WatchTerminalEvents`
+
+Add an `atomic.Int64`-backed `watchTerminalEventsSafetyNetNs` (default 30 minutes) to `ka_investigate_mcp.go`, with a `SetWatchTerminalEventsSafetyNetForTest(d) (restore func())` test hook. A plain package `var` (the initial approach, mirroring `AwaitSessionTimeout`/`DefaultRegistryIdleTimeout` elsewhere in this package/`launcher`) was tried first but produces a genuine `-race` failure: `WatchTerminalEvents` reads the value from a newly-spawned goroutine with no happens-before relationship to a test's setup/teardown write, which `go test -race` correctly flags even though the wall-clock ordering is safe in practice. The atomic makes the read/write properly synchronized. Create a single `time.Timer` **before** the `select` loop (not `time.After` inside it, which would reset on every non-terminal event and defeat the bound), add a third `select` case on `safetyNet.C` that logs at `Info` (this is an expected-to-be-rare cleanup-path exit, not a user error) with `rr_id`/timeout context, and returns. 30 minutes is deliberately much larger than KA's own `TimeoutManager` inactivity timeout (~10m default) or `DefaultSessionTTL` (30m) so it never fires for a legitimately long-running session — it only bounds the case where the expected termination signal is truly lost.
+
+### #2100 — wire `SessionJanitor` + fail-closed lease release in `handleStart`
+
+1. `internal/kubernautagent/mcp/session_manager.go`: add `LeaseOption WithSessionJanitor(j *SessionJanitor)`, storing `m.janitor`. In `Takeover()`, immediately after the existing `m.activeCount.Add(1)` on the success path, call `m.janitor.Track(sessionID, time.Now(), func(id string) { _ = m.Release(id, "janitor_stale_lease") })` when `m.janitor != nil`. In `Release()`, after the existing `m.activeCount.Add(-1)`, call `m.janitor.Untrack(sessionID)` when `m.janitor != nil`. This is a chokepoint-level backstop covering every `Takeover`/`Release` caller, not just `handleStart`.
+2. `cmd/kubernautagent/main.go`'s `buildMCPHandler`: construct `janitor := mcpkg.NewSessionJanitor(cfg.Interactive.SessionTTL, logger.WithName("session-janitor"))`, add `mcpkg.WithSessionJanitor(janitor)` to the existing `leaseOpts` slice (before `NewLeaseSessionManagerConcrete` is called), and start `go janitor.Run(ctx)` using the function's existing `ctx` parameter (cancelled on shutdown, matching `session.Store.StartCleanupLoop`'s pattern). Add `"session_janitor": true` to the existing "MCP interactive mode fully wired" log line for consistency with the other component-wiring booleans already logged there.
+3. `internal/kubernautagent/mcp/tools/investigate.go`'s `handleStart`: in the specific branch where `reattachOrCreateFallback` returns `""` **and** `ForceTransitionToUserDriving` also fails (line 557-560), release the just-acquired lease immediately (`t.sessions.Release(sess.SessionID, "no_investigation_available")`) and return a new `ErrCodeNoInvestigationAvailable` error instead of silently continuing to `startTimeoutTracking`/returning success with an empty `InvestigationSessionID`. This directly closes the "AA will not receive result" CRITICAL log path at its source, independent of and faster than either the janitor or `TimeoutManager` backstops.
+
+### Rejected alternative
+
+Making `SessionJanitor`'s interval independently configurable from `SessionTTL` was considered, but `sweep()`'s existing implementation (`disconnect_handler.go:242-261`) already reuses a single `interval` field for both sweep frequency and staleness age — introducing a second config knob would require changing `SessionJanitor`'s own tested implementation for a batch-fix PR whose #2100 scope is "wire the existing component," not "redesign it." Reusing `cfg.Interactive.SessionTTL` (already the Lease's own declared maximum lifetime) as the janitor interval is both semantically correct (a session should never legitimately outlive its own TTL) and requires zero changes to `SessionJanitor`'s tested logic.
+
+## 3. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **SI-10** | Information Input Validation | #2092: a malformed-but-recoverable tool argument (JSON-double-encoded `options`) is validated and coerced to its correct native type instead of being blindly trusted or silently dropped to empty. |
+| **AC-6** | Least Privilege | #2098: extends DD-AF-011's existing harness-enforced phase-gating (least-privilege tool availability by session phase) to cover `present_decision`'s dependency on `discover_workflows` having run, for the autonomous modes where that ordering is load-bearing. |
+| **SI-11** | Error Handling | #2094: an unbounded wait on a lost termination signal is replaced with a bounded, logged exit — the failure is handled instead of silently hanging forever. #2100: `handleStart`'s previously-silent "no investigation to drive" case now fails closed with an explicit error and immediate resource release instead of returning a misleading success. |
+| **AU-3 / AU-12** | Audit Content / Audit Generation | #2094: the safety-net exit emits a structured, previously-nonexistent log entry recording the abnormal-exit reason and `rr_id`. #2100: `SessionJanitor.sweep()`'s existing "janitor: expiring stale session" log becomes a real, reachable audit signal once wired; `handleStart`'s new fail-closed path logs the release reason. |
+| **SC-5** | Denial of Service Protection | #2100: an unreclaimed, monotonically-growing set of orphaned interactive-session leases is a resource-exhaustion vector against `interactive.maxConcurrentSessions`'s own capacity guarantee — the janitor backstop and immediate fallback-release both close paths to that exhaustion. |
+
+## 4. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control / BR | Test File |
+|---|---|---|---|---|
+| UT-AF-2092-001 | Unit | `enforceGroundingGuard` (grounded path) repairs a JSON-encoded-string `options` argument into a native `[]any` before returning | SI-10, BR-AI-INTERACTIVE | `pkg/apifrontend/agent/present_decision_options_2092_test.go` |
+| UT-AF-2092-002 (regression guard) | Unit | `enforceGroundingGuard` leaves a genuinely malformed (non-JSON) `options` string untouched — proves the repair never masks truly invalid input as empty/valid | SI-10, SI-11 | `pkg/apifrontend/agent/present_decision_options_2092_test.go` |
+| UT-AF-2092-003 (regression guard) | Unit | `enforceGroundingGuard` leaves an already-native `[]any` `options` value untouched (no double-processing) | SI-10 | `pkg/apifrontend/agent/present_decision_options_2092_test.go` |
+| UT-AF-2092-004 (regression guard) | Unit | `enforceGroundingGuard` leaves an empty `options` string untouched (not coerced into an empty array), a distinct already-invalid case the repair must not mask either | SI-10, SI-11 | `pkg/apifrontend/agent/present_decision_options_2092_test.go` |
+| IT-AF-2092-001 | Integration | The real `functiontool.New`-wrapped `kubernaut_present_decision` tool, invoked through `newPhaseGuard`'s `before` callback then `tool.Run`, accepts a JSON-double-encoded `options` string end-to-end (proves the fix survives ADK's actual `ConvertToWithJSONSchema` validation, not just the callback in isolation) | SI-10, BR-AI-INTERACTIVE | `pkg/apifrontend/agent/present_decision_options_2092_it_test.go` |
+| IT-AF-2092-002 (regression guard) | Integration | The same real tool still rejects a genuinely malformed `options` string via ADK's actual schema validation after the `before` callback runs — proves the repair does not mask real errors end-to-end, not just at the callback-unit level | SI-11 | `pkg/apifrontend/agent/present_decision_options_2092_it_test.go` |
+| UT-AF-2098-001 | Unit | `presentDecisionTool`'s `before` callback rejects the call when `Phase2Blocked==false` and discovery has not yet succeeded, with a message instructing the model to call `discover_workflows` first | AC-6, BR-AI-INTERACTIVE | `pkg/apifrontend/agent/present_decision_ordering_2098_test.go` |
+| UT-AF-2098-002 | Unit | `discover_workflows`'s `after` callback sets `StateKeyDiscoverWorkflowsSucceeded=true` on success; a subsequent `present_decision` call is then allowed through | AC-6, BR-AI-INTERACTIVE | `pkg/apifrontend/agent/present_decision_ordering_2098_test.go` |
+| UT-AF-2098-003 (regression guard) | Unit | `present_decision` is **not** blocked when `Phase2Blocked==true` (plain `interactive` mode, or #1918's `rcaConcludedNotActionable` override) even though discovery never ran — proves the gate correctly exempts the legitimate "present decision without discovery" cases | AC-6 | `pkg/apifrontend/agent/present_decision_ordering_2098_test.go` |
+| UT-AF-2098-004 (regression guard) | Unit | A fresh `kubernaut_investigate` success resets `StateKeyDiscoverWorkflowsSucceeded` to `false`, so a second investigation in the same chat session can't inherit a stale "discovery already happened" flag from a prior RR | AC-6, SI-10 | `pkg/apifrontend/agent/present_decision_ordering_2098_test.go` |
+| IT-AF-2098-001 | Integration | Full `newPhaseGuard` before/after pair, driven in `discover_workflows` → `present_decision` and `present_decision`-before-`discover_workflows` orderings for `full_remediation` mode, proves the reject-then-retry sequence produces a successful decision only after discovery | AC-6, BR-AI-INTERACTIVE | `pkg/apifrontend/agent/present_decision_ordering_2098_it_test.go` |
+| UT-AF-2094-001 | Unit | `WatchTerminalEvents` exits via the safety-net timer (test-overridden to a few milliseconds) when neither `events` nor `done` ever fire, logging the exit | SI-11, AU-3 | `pkg/apifrontend/tools/watch_terminal_events_2094_test.go` |
+| UT-AF-2094-002 (regression guard) | Unit | `WatchTerminalEvents` still exits immediately on `session_ended` (happy path unaffected by the new timer) | SI-11 | `pkg/apifrontend/tools/watch_terminal_events_2094_test.go` |
+| UT-AF-2094-003 (regression guard) | Unit | `WatchTerminalEvents` still drains a buffered `session_ended` on `done` closing before the safety net (existing #1438 priority-drain behavior unaffected) | SI-11 | `pkg/apifrontend/tools/watch_terminal_events_2094_test.go` |
+| IT-AF-2094-001 | Integration | Full production path (`HandleInvestigationMCPWithRegistry` → pool inject → `go WatchTerminalEvents`) with the pool's `onRelease` never firing and no `session_ended` ever emitted — the watcher goroutine exits on its own within the bounded window instead of leaking, proven via a closed-channel signal at goroutine exit (mirrors existing `IT-AF-1438-020` pattern) | SI-11, AU-3 | `pkg/apifrontend/tools/terminal_event_2094_it_test.go` |
+| UT-KA-2100-001 | Unit | `SessionJanitor.Track` called on `LeaseSessionManager.Takeover` success; `Untrack` called on `Release` — proves the chokepoint wiring inside `session_manager.go` (not just the janitor's own pre-existing sweep logic), against a fake K8s client with real `coordination.k8s.io/Lease` objects | SC-5, AU-12 | `internal/kubernautagent/mcp/session_manager_janitor_2100_test.go` |
+| UT-KA-2100-002 | Unit | A session tracked via `Takeover` but never `Release`d is swept by the janitor after its interval elapses, and the sweep's `onExpire` callback actually calls `Release` (not just logs) — proves the backstop functions end-to-end at the `LeaseSessionManager` level | SC-5, AU-12 | `internal/kubernautagent/mcp/session_manager_janitor_2100_test.go` |
+| UT-KA-2100-003 | Unit | `handleStart`'s fallback-exhausted branch (`reattachOrCreateFallback` returns `""` and `ForceTransitionToUserDriving` fails) releases the just-acquired lease and returns `ErrCodeNoInvestigationAvailable` instead of silently succeeding | SI-11, SC-5 | `internal/kubernautagent/mcp/tools/investigate_2100_test.go` |
+| UT-KA-2100-004 (regression guard) | Unit | The sibling fallback branch (terminal autonomous session found, `reattachOrCreateFallback` returns `""`) still falls back to `investigationSessionID = autoSessionID` unchanged — proves the new fail-closed behavior is scoped only to the genuinely-empty case, not this already-valid fallback | SI-11 | `internal/kubernautagent/mcp/tools/investigate_2100_test.go` |
+| UT-KA-2100-005 (regression guard) | Unit | A same-user reconnect (`Takeover` called twice for the same `rrID`/user) does not double-`Track` or accidentally `Untrack` the still-active session | SC-5 | `internal/kubernautagent/mcp/session_manager_janitor_2100_test.go` |
+| IT-KA-2100-001 | Integration | `SessionJanitor` wired via the same `WithSessionJanitor` option `buildMCPHandler` uses, exercised against a real envtest API server and real `Lease` objects — `Takeover` success Tracks the session (Lease created), `Release` Untracks it and deletes the real Lease | SC-5, AU-12 | `test/integration/kubernautagent/mcp/session_janitor_wiring_2100_test.go` |
+| IT-KA-2100-002 | Integration | A session Tracked via `Takeover` but never `Release`d against the real envtest API server is reclaimed by the janitor's sweep — `GetDriver` no longer finds a driver and the real Lease object is deleted, closing the SC-5 capacity-exhaustion gap end-to-end | SC-5, AU-12 | `test/integration/kubernautagent/mcp/session_janitor_wiring_2100_test.go` |
+
+**Deviation from original plan**: the originally-planned `IT-KA-2100-002` ("a real `handleStart` call against an envtest API server ... releases its Lease immediately") was not implemented as a separate envtest scenario. `UT-KA-2100-003` already exercises `handleStart`'s fallback-exhausted branch through `InvestigateTool.Handle()` (its real production dispatch entry point, matching this package's own existing "IT-via-`Handle()`" convention in `handlestart_robustness_1440_it_test.go`), proving `Release(sess.SessionID, "no_investigation_available")` is called with the correct arguments; `LeaseSessionManager.Release`'s own real-Lease-deletion behavior is independently proven by both the pre-existing `UT-KA-703-I03` and the new `IT-KA-2100-001` above. Composing these three, already-passing tests gives full production-path coverage of `handleStart`'s fail-closed branch without standing up a second, largely-duplicate envtest scenario (proportionality judgment consistent with this same test file's own `discoveryHTTPCompleter` precedent: "Wiring that in IT is disproportionate").
+
+### Tier Coverage Rationale
+
+- **UT** covers each fix's decision logic in isolation: the schema-repair/no-mask distinction (#2092), the ordering-gate's precise Phase2Blocked-based scoping including its #1918 exemption (#2098), the safety-net timer's non-interference with existing exit paths (#2094), and the janitor Track/Untrack chokepoint plus `handleStart`'s new fail-closed branch (#2100).
+- **IT** proves each fix survives the real production dispatch path it must run inside: #2092 through ADK's actual `functiontool.New`-wrapped schema validator (a UT of `enforceGroundingGuard` alone cannot prove the repaired value actually satisfies `ConvertToWithJSONSchema`); #2098 through the full before/after callback pair in the exact ordering QE observed; #2094 through the real `HandleInvestigationMCPWithRegistry` → pool → goroutine dispatch chain (a UT calling `WatchTerminalEvents` directly cannot prove it's reachable/leak-prone from the real call site); #2100 through a real envtest `LeaseSessionManager` with real `coordination.k8s.io/Lease` objects and the actual `buildMCPHandler` wiring (a UT of `SessionJanitor` alone — which already existed and passed before this fix — is precisely the "prototyped, not implemented" gap this batch closes).
+- **E2E**: not added net-new. All four fixes close gaps within QE's already-E2E-covered `kubernaut-console` live-cluster acceptance suites (`approval-gate.spec.ts`, `full-remediation-default-regression.spec.ts`, the 12-way concurrent-load run); no new user-facing journey is introduced. Confirmation that these fixes resolve the original live symptoms is via QE's next acceptance run against this branch's images, not a new E2E suite in this repo.
+
+## 5. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `repairPresentDecisionOptions` | `newPhaseGuard`'s `before` callback, `presentDecisionTool` branch — itself registered as `llmagent.BeforeToolCallback` wherever the agent is built | `pkg/apifrontend/agent/phase_guard.go` (`enforceGroundingGuard`) | UT-AF-2092-001..003, IT-AF-2092-001 |
+| `StateKeyDiscoverWorkflowsSucceeded` set/read | `newPhaseGuard`'s `after` (`isDiscoverWorkflows` branch) and `before` (`presentDecisionTool` branch) | `pkg/apifrontend/session/consent.go` (const), `pkg/apifrontend/agent/phase_guard.go` (read/write) | UT-AF-2098-001..004, IT-AF-2098-001 |
+| `watchTerminalEventsSafetyNetNs` timer | `WatchTerminalEvents`, called from `HandleInvestigationMCPWithRegistry` (`ka_investigate_mcp.go:585-586`) | `pkg/apifrontend/tools/ka_investigate_mcp.go` | UT-AF-2094-001..003, IT-AF-2094-001 |
+| `SessionJanitor.Track`/`Untrack` | `LeaseSessionManager.Takeover`/`Release` | `internal/kubernautagent/mcp/session_manager.go` | UT-KA-2100-001, UT-KA-2100-002, UT-KA-2100-005, IT-KA-2100-001, IT-KA-2100-002 |
+| `NewSessionJanitor` + `WithSessionJanitor` + `go janitor.Run(ctx)` | `buildMCPHandler` (`cmd/kubernautagent/main.go`), itself called from `main()`'s server-startup sequence | `cmd/kubernautagent/main.go` | IT-KA-2100-001, IT-KA-2100-002 (exercise the same `WithSessionJanitor` production option against a real envtest API server) |
+| `ErrCodeNoInvestigationAvailable` + immediate `Release` | `InvestigateTool.handleStart`'s fallback-exhausted branch, dispatched from the `kubernaut_investigate` MCP tool handler registered in `buildMCPHandler` | `internal/kubernautagent/mcp/tools/investigate.go`, `internal/kubernautagent/mcp/tools/errors.go` | UT-KA-2100-003, UT-KA-2100-004 (through `InvestigateTool.Handle()`'s production dispatch path; composed with `UT-KA-703-I03`/`IT-KA-2100-001`'s proof that `Release` deletes the real Lease) |
+
+## 6. CHECKPOINT W Evidence
+
+Executed post-GREEN, 2026-08-11:
+
+```bash
+$ grep -n "repairPresentDecisionOptions" pkg/apifrontend/agent/phase_guard.go
+664:		repairPresentDecisionOptions(ctx, args)
+682:// repairPresentDecisionOptions defensively repairs args["options"] when it
+703:func repairPresentDecisionOptions(ctx tool.Context, args map[string]any) {
+
+$ grep -rn "StateKeyDiscoverWorkflowsSucceeded" pkg/apifrontend/
+pkg/apifrontend/agent/present_decision_ordering_2098_test.go:110,120  (test usages)
+pkg/apifrontend/agent/phase_guard.go:285   state.Set(..., true)   [discover_workflows after-callback success]
+pkg/apifrontend/agent/phase_guard.go:337   state.Set(..., false)  [kubernaut_investigate after-callback reset]
+pkg/apifrontend/agent/phase_guard.go:432   state.Get(...)         [presentDecisionRequiresDiscoveryFirst]
+pkg/apifrontend/session/consent.go:71      const declaration
+
+$ grep -n "watchTerminalEventsSafetyNetNs" pkg/apifrontend/tools/ka_investigate_mcp.go
+969:  var watchTerminalEventsSafetyNetNs atomic.Int64
+972:  watchTerminalEventsSafetyNetNs.Store(int64(30 * time.Minute))
+996:  safetyNetTimeout := time.Duration(watchTerminalEventsSafetyNetNs.Load())   [live in WatchTerminalEvents]
+
+$ grep -n "WithSessionJanitor\|janitor.Track\|janitor.Untrack\|m.janitor" internal/kubernautagent/mcp/session_manager.go
+143:  func WithSessionJanitor(j *SessionJanitor) LeaseOption { ... }
+285-291: m.janitor != nil { m.janitor.Track(...) }   [Takeover success path]
+332-334: m.janitor != nil { m.janitor.Untrack(...) } [Release path]
+
+$ grep -n "NewSessionJanitor\|WithSessionJanitor\|sessionJanitor" cmd/kubernautagent/main.go
+1298: sessionJanitor := mcpkg.NewSessionJanitor(cfg.Interactive.SessionTTL, logger.WithName("session-janitor"))
+1299: go sessionJanitor.Run(ctx)
+1314: mcpkg.WithSessionJanitor(sessionJanitor),   [passed into leaseOpts before NewLeaseSessionManagerConcrete]
+
+$ grep -rn "ErrCodeNoInvestigationAvailable" internal/kubernautagent/mcp/tools/*.go
+errors.go:150:      ErrCodeNoInvestigationAvailable = &MCPError{...}
+investigate.go:577: return InvestigateOutput{}, ErrCodeNoInvestigationAvailable   [handleStart fallback-exhausted branch]
+```
+
+All six components have confirmed production callers (`cmd/`/production business logic, not test files) and passing IT/UT evidence. No orphaned `pkg/`/`internal/` code introduced by this batch. CHECKPOINT W: **PASS**.
+
+## 7. Build Validation
+
+Executed 2026-08-11 (all via `make` targets per project convention):
+
+```bash
+$ go build ./...                                                    # PASS
+$ go vet ./...                                                      # PASS
+$ golangci-lint run --timeout=5m ./pkg/apifrontend/agent/... \
+    ./pkg/apifrontend/tools/... ./pkg/apifrontend/session/... \
+    ./internal/kubernautagent/mcp/... ./cmd/kubernautagent/...      # 0 issues
+
+$ make test-unit-kubernautagent          # 29 suites, SUCCESS (incl. UT-KA-2100-001..005)
+$ make test-unit-apifrontend             # 24 suites, SUCCESS (incl. all #2092/#2094/#2098 UT+IT)
+$ make test-integration-apifrontend      # 164/164 specs PASS (envtest + Podman DS)
+$ make test-integration-kubernautagent   # 14 suites PASS (envtest + Podman DS + Mock LLM),
+                                          #   incl. IT-KA-2100-001/002 against real Lease objects
+$ make test-integration-kubernautagent-interactive  # 25/25 interactive-labeled specs PASS
+```
+
+No regressions in any pre-existing suite. All new tests pass.
+
+## 8. Coverage Summary
+
+| Metric | Target | Actual |
+|---|---|---|
+| BR/Control coverage (SI-10, AC-6, SI-11, AU-3/AU-12, SC-5) | 100% | 100% — every control has at least one passing UT+IT pair |
+| Wiring Manifest rows with passing IT/UT evidence | 100% | 100% (6/6 rows, see Section 6) |
+| CHECKPOINT W (no orphaned code, all new symbols have production callers) | Pass | Pass |
+| Build (`go build ./...`, `go vet ./...`, `golangci-lint`) | Pass | Pass (0 issues) |
+| KA unit suite (`make test-unit-kubernautagent`) | Pass | Pass — 29 suites |
+| AF unit suite (`make test-unit-apifrontend`) | Pass | Pass — 24 suites |
+| AF integration suite (`make test-integration-apifrontend`) | Pass | Pass — 164/164 specs |
+| KA integration suite (`make test-integration-kubernautagent`) | Pass | Pass — 14 suites |
+| KA interactive integration suite (`make test-integration-kubernautagent-interactive`) | Pass | Pass — 25/25 specs |
+
+## 9. Out of Scope
+
+- **#1995** (`PooledToolCallTimeout` not unblocking a lost MCP response): preflight against `origin/release/v1.5`'s true tip confirmed PR #2000 already merged this fix; not part of this batch.
+- **#2096** (120s per-model-call timeout): spiked in isolation (`spike_2096_deadline_test.go`, since deleted) — `wrapWithTimeout` provides a fresh 120s budget per model call, disproving the original shared-deadline hypothesis; live log evidence showed `context canceled` (explicit cancellation), not `context deadline exceeded`, consistent with a client/test-harness disconnect rather than an AF bug. Findings posted as a GitHub comment on #2096 re-scoping it; not fixed in this batch.
+- **The not-yet-filed "orphaned RR on fallback session failure" finding**: superseded by QE's own independently-filed #2100, which covers the same root cause plus the `SessionJanitor` wiring gap; not filed as a separate issue per user direction.
+- **`session.Store`'s `MaxConcurrentInvestigations`/`runtime.session.maxConcurrentInvestigations` cap** (the mechanism that produced the live "maximum concurrent investigations reached" 500 errors before QE raised KA's configured limit from 10 to 20): confirmed to already have its own 60-minute `StartCleanupLoop` safety net (`internal/kubernautagent/session/store.go:340-353`) — a distinct concurrency cap from `interactive.maxConcurrentSessions`/`LeaseSessionManager`. Documented here as a known, lower-severity behavior per explicit user direction; no code change in this batch.
+- **Backport to `main`/`v1.6`**: not performed in this branch; #2094's issue body notes `main`'s `WatchTerminalEvents` (now `ka_investigate_bridge.go`, #1637/DD-AF-009) also lacks a timer despite its `EventRelay` enhancement — a `v1.6` clone issue should be filed separately if this fix is confirmed effective.
+
+## 10. Sign-off
+
+| Role | Name | Date | Signature |
+|---|---|---|---|
+| Author | AI Assistant | 2026-08-11 | pending |
+| Reviewer | Jordi Gil | | pending |
+| Approver | | | pending |

--- a/docs/testing/2103/TEST_PLAN.md
+++ b/docs/testing/2103/TEST_PLAN.md
@@ -1,0 +1,237 @@
+# Test Plan: #2103 — `aiagent_mcp_interactive_sessions_active` Gauge Drift
+
+## 1. Purpose
+
+`aiagent_mcp_interactive_sessions_active` (the Prometheus gauge tracking
+concurrent MCP interactive sessions) only ever decrements for two of the
+ways an interactive session can end — explicit `complete`/`cancel` — plus
+two callback paths owned directly by `cmd/kubernautagent/main.go`
+(disconnect-grace-period expiry, inactivity-timeout expiry via
+`TimeoutManager`). Every other completion path releases the real session
+(Lease + `LeaseSessionManager.activeCount`, both healthy) but never calls
+the matching `RecordInteractiveSessionEnded()`, so the gauge drifts upward
+and never reflects true concurrency. This is **not** a recurrence of
+#2100's capacity leak — the real Lease/activeCount bookkeeping is
+confirmed healthy; this is an observability-only bug.
+
+Discovered live-monitoring QE's #2100 validation run (PR #2102, images
+deployed with `SessionJanitor` wired).
+
+### Root Cause Detail
+
+`RecordInteractiveSessionEnded()` is not called from inside
+`LeaseSessionManager.Release()` itself — it is the *caller's*
+responsibility to call both `sessions.Release(...)` and the metrics
+decrement separately, and most callers of `Release()` don't have
+`agentMetrics` wired at all. Confirmed gaps (all verified directly against
+current code, not just the issue's live evidence):
+
+1. `CompleteNoActionTool.Handle` (`complete_no_action.go:194`, reason
+   `"complete_no_action"`) — struct has no `metrics` field.
+2. `SelectWorkflowTool`'s post-selection release goroutine
+   (`select_workflow.go:372`, reason `"workflow_selected"`) — struct has
+   no `metrics` field.
+3. `InvestigateTool`'s `no_matching_workflows` auto-close goroutine
+   (`investigate.go:1101-1138`, release at line 1133) — `InvestigateTool`
+   *does* have `t.metrics` (used elsewhere at lines 583-584, 850, 1271),
+   but this goroutine's closure doesn't capture or call it.
+4. `SessionJanitor`'s `onExpire` callback, added by #2100's own fix
+   (`session_manager.go:290-294`) — lives inside `LeaseSessionManager`, a
+   package with zero awareness of `agentMetrics`. #2100's new backstop
+   sweep path inherits this same gap.
+
+Correctly-decrementing paths (for contrast): `InvestigateTool.handleComplete`
+(investigate.go:850, `"complete"`), `handleCancel` (investigate.go:1271,
+`"explicit"`), `TimeoutManager`'s inactivity-expiry callback
+(`main.go:1356`, `"inactivity_timeout"`), `GracefulSessionClosedHandler`'s
+disconnect callback (`main.go:1415`, `"disconnect"`), and
+`WithSessionExpiredCallback` (`main.go:1312`, TTL/inactivity via
+`GetDriver`'s lazy check).
+
+## 2. Fix Design
+
+**Rejected alternative**: patch each of the 4 (and growing) gap call sites
+individually with their own `metrics ToolMetrics` field + option, mirroring
+`InvestigateTool`'s existing pattern. Rejected because it reintroduces the
+exact same gap for the *next* new completion path (this issue is itself
+evidence that per-call-site wiring doesn't scale — #2100's new janitor path
+inherited the gap on day one).
+
+**Chosen fix**: centralize the decrement *inside*
+`LeaseSessionManager.Release()` itself, paired with the existing
+`activeCount.Add(-1)`, via a new optional callback wired the same way
+`WithSessionExpiredCallback`/`WithSessionJanitor` already are:
+
+```go
+// SessionEndedMetrics is the minimal metrics surface LeaseSessionManager
+// needs to keep aiagent_mcp_interactive_sessions_active accurate for every
+// Release caller, current and future (#2103). Implemented structurally by
+// *metrics.Metrics (see tools.ToolMetrics for the parallel interface at
+// the tool-handler layer) -- defined locally here, rather than imported,
+// to avoid mcp importing metrics or tools (tools already imports mcp).
+type SessionEndedMetrics interface {
+    RecordInteractiveSessionEnded()
+}
+```
+
+`Release()` calls `m.sessionMetrics.RecordInteractiveSessionEnded()`
+immediately after `m.activeCount.Add(-1)`, guarded by nil-check, and
+**only** on the path that actually reaches that line (i.e. not on
+`ErrSessionNotFound`, not on a hard Lease-delete error) — so a
+double-`Release()` call never double-decrements.
+
+This single change automatically closes gaps #1–#4 above, since all four
+routes call `sessions.Release(...)` against the *same* shared
+`LeaseSessionManager` instance in `buildMCPHandler`. No per-tool `metrics`
+field is added to `CompleteNoActionTool` or `SelectWorkflowTool`, and
+`InvestigateTool`'s `no_matching_workflows` goroutine needs no capture
+change.
+
+**Redundant-call cleanup** (required to avoid double-decrementing once
+`Release()` handles it centrally):
+
+- `investigate.go` `handleComplete` (was line 849-851) and `handleCancel`
+  (was line 1270-1272): remove the explicit
+  `t.metrics.RecordInteractiveSessionEnded()` call — both already call
+  `t.sessions.Release(...)` just above.
+- `main.go`'s `WithSessionExpiredCallback` (was line 1312), `timeoutMgr`'s
+  inactivity callback (was line 1356), `disconnectHandler`'s callback (was
+  line 1415): remove the explicit `agentMetrics.RecordInteractiveSessionEnded()`
+  calls — all three already call `leaseMgr.Release(...)` (directly, or via
+  `GetDriver`'s lazy TTL/inactivity check) just above.
+
+**Started/Ended symmetry fix** (subtlety not called out in the original
+issue): `handleStart`'s fallback-exhausted branch (`#2100`'s own fix,
+`investigate.go:570`) calls `Release(sess.SessionID, "no_investigation_available")`
+on a lease for which `RecordInteractiveSessionStarted()` was **never**
+called (that call happens later, at the end of `handleStart`, only on the
+success path). Once `Release()` centrally decrements, this branch would
+decrement a gauge that was never incremented for that session, pushing it
+negative. Fix: move `t.metrics.RecordInteractiveSessionStarted()` to fire
+immediately after `Takeover()` confirms a genuinely new lease (i.e. after
+the `sess.Reconnected` check, which correctly still returns early without
+touching the gauge — no new lease was acquired for a reconnect), before any
+of the fallback logic that might immediately release it. This keeps
+Started/Ended paired with the lease's own lifecycle (`activeCount`'s own
+`Add(1)`/`Add(-1)` pair), which is more accurate than the previous
+behavior (a lease that lived for a few hundred ms before failing closed was
+never counted as "started" at all).
+
+## 3. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **SI-4** | System Monitoring | The core control: `aiagent_mcp_interactive_sessions_active` is an operational-monitoring signal (BR-KA-OBSERVABILITY-001); a monotonically-drifting gauge produces false-positive capacity alerts and masks the true concurrency the #2100 capacity guarantee depends on. |
+| **SI-11** | Error Handling | The Started/Ended symmetry fix ensures a fail-closed lease release (#2100's `no_investigation_available` path) is still correctly accounted for in the gauge instead of silently under/over-counting. |
+| **SC-5** | Denial of Service Protection | An operator/dashboard relying on this gauge to catch a *future* recurrence of #2100's capacity-exhaustion bug would be blind to it while the gauge is stuck climbing regardless of true load. |
+
+## 4. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-KA-2103-001 | Unit | `LeaseSessionManager.Release()` calls the wired `SessionEndedMetrics.RecordInteractiveSessionEnded()` exactly once on a successful release | SI-4 | `internal/kubernautagent/mcp/session_manager_metrics_2103_test.go` |
+| UT-KA-2103-002 (regression guard) | Unit | `Release()` on an unknown/already-released session ID returns `ErrSessionNotFound` and does **not** call the metrics callback (no phantom decrement) | SI-4 | `internal/kubernautagent/mcp/session_manager_metrics_2103_test.go` |
+| UT-KA-2103-003 (regression guard) | Unit | `Release()` with no `WithSessionEndedMetrics` wired (nil) does not panic — safe no-op, matching every pre-#2103 call site | SI-11 | `internal/kubernautagent/mcp/session_manager_metrics_2103_test.go` |
+| UT-KA-2103-004 (regression guard) | Unit | `InvestigateTool.handleComplete` (`action=complete`) no longer calls `metrics.RecordInteractiveSessionEnded()` directly — proves the responsibility fully moved to `LeaseSessionManager.Release()`, preventing double-decrement once combined with the real manager | SI-4 | `internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go` |
+| UT-KA-2103-005 (regression guard) | Unit | `InvestigateTool.handleCancel` (`action=cancel`) — same as UT-KA-2103-004 | SI-4 | `internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go` |
+| UT-KA-2103-006 | Unit | `handleStart` records `RecordInteractiveSessionStarted()` immediately after a successful (non-reconnect) `Takeover`, even on the fallback-exhausted branch that immediately releases the lease — proves Started/Ended stay paired now that Ended is centralized (prevents the gauge going negative) | SI-4, SI-11 | `internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go` |
+| UT-KA-2103-007 (regression guard) | Unit | `handleStart`'s `Reconnected` branch and `Takeover`-failure branches still do **not** call `RecordInteractiveSessionStarted()` — no new lease was actually acquired | SI-4 | `internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go` |
+| IT-KA-2103-001 | Integration | An explicit `Release()` call (reasons `complete_no_action`, `workflow_selected`, `no_matching_workflows` in sequence) against a real envtest `LeaseSessionManager` wired with `WithSessionEndedMetrics` decrements the metrics recorder exactly once per release — proves gaps #1–#3 all collapse to the same fixed chokepoint, using the exact `NewLeaseSessionManagerConcrete(..., WithSessionEndedMetrics(...))` construction `buildMCPHandler` uses in production | SI-4 | `test/integration/kubernautagent/mcp/session_manager_metrics_2103_it_test.go` |
+| IT-KA-2103-002 | Integration | `SessionJanitor`'s sweep-triggered `onExpire` → `Release(..., reason)` decrements the same wired metrics recorder against a real envtest API server (real `coordination.k8s.io/Lease` reclaimed) — closes gap #4 end-to-end, extending #2100's own `session_janitor_wiring_2100_test.go` IT pattern | SI-4, SC-5 | `test/integration/kubernautagent/mcp/session_manager_metrics_2103_it_test.go` |
+
+### Tier Coverage Rationale
+
+- **UT** covers the centralized decrement's logic in isolation (found/not-found/nil-metrics against a fake K8s client, mirroring #2100's own `session_manager_janitor_2100_test.go` precedent — no real API server needed since this fix touches zero K8s-API-specific behavior), plus the two `investigate.go` regression guards proving the old direct-call pattern is fully retired, plus the Started/Ended symmetry fix.
+- **IT** proves the fix against a real envtest API server using the identical `NewLeaseSessionManagerConcrete(..., WithSessionEndedMetrics(...))` construction path `buildMCPHandler` uses in production, exercising both call shapes that existed pre-fix: an explicit `Release()` call (the shape shared verbatim by `CompleteNoActionTool.Handle`, `SelectWorkflowTool`'s async goroutine, and `InvestigateTool`'s `no_matching_workflows` auto-close — CHECKPOINT W's grep evidence confirms all three call the same `sessions.Release(sessionID, reason)` signature on the one shared `SessionManager` instance `buildMCPHandler` constructs), and the `SessionJanitor`'s real sweep-triggered `onExpire` callback (gap #4), mirroring #2100's own precedent of proving `LeaseSessionManager`-internal wiring directly against envtest rather than requiring a full MCP-protocol round trip per caller. A UT of `Release()` alone (already covered above) cannot prove the `WithSessionEndedMetrics` option is actually threaded through `buildMCPHandler`'s `leaseOpts` to the one shared instance in production — CHECKPOINT W's grep evidence plus this IT together close that gap.
+- **E2E**: not added net-new. This is an observability-only fix (no functional/capacity behavior change); QE's next acceptance run against this branch's images is the confirmation path, not a new E2E suite in this repo.
+
+## 5. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `SessionEndedMetrics` interface + `sessionMetrics` field | `LeaseSessionManager.Release()` | `internal/kubernautagent/mcp/session_manager.go` | UT-KA-2103-001..003 |
+| `WithSessionEndedMetrics` option | `buildMCPHandler`'s `leaseOpts` (`cmd/kubernautagent/main.go`), passed `agentMetrics` | `cmd/kubernautagent/main.go`, `internal/kubernautagent/mcp/session_manager.go` | IT-KA-2103-001, IT-KA-2103-002 |
+| `handleStart`'s relocated `RecordInteractiveSessionStarted()` call | `InvestigateTool.Handle` (`action=start`), dispatched from the `kubernaut_investigate` MCP tool handler registered in `buildMCPHandler` | `internal/kubernautagent/mcp/tools/investigate.go` | UT-KA-2103-006, UT-KA-2103-007 |
+
+## 6. CHECKPOINT W Evidence
+
+```
+=== WithSessionEndedMetrics production callers ===
+cmd/kubernautagent/main.go:1324:		mcpkg.WithSessionEndedMetrics(agentMetrics),
+internal/kubernautagent/mcp/session_manager.go:177:func WithSessionEndedMetrics(m SessionEndedMetrics) LeaseOption {
+
+=== sessionMetrics.RecordInteractiveSessionEnded call site (the ONLY production call site) ===
+internal/kubernautagent/mcp/session_manager.go:374:	if m.sessionMetrics != nil {
+internal/kubernautagent/mcp/session_manager.go:375:		m.sessionMetrics.RecordInteractiveSessionEnded()
+
+=== Confirm no orphaned direct RecordInteractiveSessionEnded calls remain in cmd/ or internal/ ===
+(none outside session_manager.go:375 and metrics.go's own implementation — confirmed via
+ grep -rn "RecordInteractiveSessionEnded" cmd/ internal/ --include="*.go" | grep -v _test.go)
+
+=== All 4 original gap call sites now route through the one centralized Release() ===
+internal/kubernautagent/mcp/tools/select_workflow.go:372:   sessions.Release(sessionID, "workflow_selected")
+internal/kubernautagent/mcp/tools/investigate.go:582:      t.sessions.Release(sess.SessionID, "no_investigation_available")  (#2100 fail-closed path, unrelated reason string)
+internal/kubernautagent/mcp/tools/investigate.go:1147:     sessions.Release(sessionID, "no_matching_workflows")
+internal/kubernautagent/mcp/tools/complete_no_action.go:194: t.sessions.Release(driver.SessionID, "complete_no_action")
+```
+
+CHECKPOINT W: PASSED — `WithSessionEndedMetrics` has exactly one production caller
+(`cmd/kubernautagent/main.go`, wired into the same `leaseOpts` slice that constructs the
+one shared `LeaseSessionManager` instance `buildMCPHandler` hands to every tool), the
+decrement itself has exactly one call site (`Release()` line 375), and all four originally-
+reported gap paths (`complete_no_action`, `workflow_selected`, `no_matching_workflows`,
+`SessionJanitor.onExpire`) call `Release()` on that same shared instance — no orphaned
+`pkg`/`internal` code, no "TODO: wire later" deferred wiring.
+
+## 7. Build Validation
+
+Executed 2026-08-11:
+
+```bash
+$ go build ./...                                                          # PASS
+$ go vet ./...                                                            # PASS (no output)
+$ golangci-lint run --timeout=5m ./internal/kubernautagent/... \
+    ./cmd/kubernautagent/...                                              # 0 issues
+$ make test-unit-kubernautagent
+  # Ran 97 of 97 Specs — SUCCESS! 97 Passed | 0 Failed | 0 Pending | 0 Skipped
+  # (across all 29 KA unit suites; composite coverage 84.8%)
+$ make test-integration-kubernautagent-interactive
+  # Ran 27 of 103 Specs (label: interactive) — SUCCESS! 27 Passed | 0 Failed | 0 Pending
+  # includes both new IT-KA-2103-001 and IT-KA-2103-002
+```
+
+## 8. Coverage Summary
+
+- Unit: 97/97 specs passed across 29 KA unit suites; composite (merged) coverage 84.8%
+  of unit-testable statements in `internal/kubernautagent/...` (per
+  `make test-unit-kubernautagent`'s coverage report).
+- Integration: 27/27 specs passed for the `interactive` label subset (full
+  `test/integration/kubernautagent/mcp` package, envtest + Podman DataStorage + Mock LLM),
+  including the two new #2103 IT tests exercising the real `Release()` chokepoint and the
+  real `SessionJanitor` sweep against a live envtest API server.
+- No regressions introduced in any pre-existing #2100/#2098/#2094/#2092/#2105 test in the
+  same packages (all still passing in the same runs above).
+
+## 9. Out of Scope
+
+- Restructuring the pre-existing, seemingly-overlapping dual inactivity
+  mechanisms (`LeaseSessionManager.inactivityTimeout`'s lazy `GetDriver`
+  check vs. `TimeoutManager`'s proactive timer) — both already correctly
+  route through `Release()` and are unaffected by this centralization;
+  consolidating them is a separate, unrelated architectural question not
+  raised by this issue.
+- The `#1654`-style "transition to user-driving fails, not terminal"
+  branch in `handleTakeover` (investigate.go:656-659) that returns an
+  error without releasing the just-acquired lease — noticed while tracing
+  this issue's call graph, but out of scope: it is a potential *capacity*
+  leak (#2100's concern), not a *metrics* leak (#2103's concern), since
+  `RecordInteractiveSessionStarted()` was never called for it either. Flag
+  for separate triage if confirmed live.
+
+## 10. Sign-off
+
+| Role | Name | Date | Signature |
+|---|---|---|---|
+| Author | AI Assistant | 2026-08-11 | pending |
+| Reviewer | Jordi Gil | | pending |
+| Approver | | | pending |

--- a/internal/kubernautagent/mcp/disconnect_handler.go
+++ b/internal/kubernautagent/mcp/disconnect_handler.go
@@ -225,6 +225,17 @@ func (j *SessionJanitor) Untrack(sessionID string) {
 	delete(j.tracked, sessionID)
 }
 
+// TrackedForTest reports whether sessionID is currently tracked. Test-only
+// accessor exposing SessionJanitor's otherwise-private state (#2100) so
+// LeaseSessionManager's Track/Untrack chokepoint wiring can be asserted
+// directly, without waiting for a full sweep interval to elapse.
+func (j *SessionJanitor) TrackedForTest(sessionID string) bool {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	_, ok := j.tracked[sessionID]
+	return ok
+}
+
 // Run starts the janitor loop until ctx is cancelled.
 func (j *SessionJanitor) Run(ctx context.Context) {
 	ticker := time.NewTicker(j.interval)

--- a/internal/kubernautagent/mcp/drainer_test.go
+++ b/internal/kubernautagent/mcp/drainer_test.go
@@ -46,7 +46,7 @@ var _ = Describe("SessionDrainer — BR-OPS-013 graceful shutdown", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		namespace = "kubernaut-system"
+		namespace = testNamespace
 		logger = logr.Discard()
 
 		scheme = runtime.NewScheme()

--- a/internal/kubernautagent/mcp/session_manager.go
+++ b/internal/kubernautagent/mcp/session_manager.go
@@ -259,7 +259,7 @@ func (m *LeaseSessionManager) Takeover(ctx context.Context, rrID string, user Us
 		return nil, err
 	}
 
-	return m.registerNewInteractiveSession(sessionID, rrID, user), nil
+	return m.registerNewInteractiveSession(sessionID, rrID, user), nil //nolint:contextcheck // registerNewInteractiveSession's #2100 janitor.Track onExpire callback calls Release at an arbitrary future time (the sweep interval), detached from this Takeover request's ctx -- see drainer.go's identical Release call for the same rationale
 }
 
 // reconnectOrRejectExistingLease checks whether rrID already has an active

--- a/internal/kubernautagent/mcp/session_manager.go
+++ b/internal/kubernautagent/mcp/session_manager.go
@@ -86,6 +86,28 @@ type LeaseSessionManager struct {
 	// deployments/tests that don't wire one via WithSessionJanitor --
 	// Track/Untrack calls are no-ops in that case.
 	janitor *SessionJanitor
+
+	// sessionMetrics is the #2103 centralization point for
+	// aiagent_mcp_interactive_sessions_active: every Release caller used to
+	// be individually responsible for calling RecordInteractiveSessionEnded,
+	// and most never wired it (CompleteNoActionTool, SelectWorkflowTool,
+	// InvestigateTool's no_matching_workflows goroutine, and #2100's own new
+	// SessionJanitor onExpire callback all leaked this gauge). Wiring the
+	// decrement here instead, paired with activeCount's own Add(-1), makes
+	// every current and future Release() caller correct automatically. Nil
+	// in deployments/tests that don't wire one via WithSessionEndedMetrics --
+	// the call is a no-op in that case.
+	sessionMetrics SessionEndedMetrics
+}
+
+// SessionEndedMetrics is the minimal metrics surface LeaseSessionManager
+// needs to keep aiagent_mcp_interactive_sessions_active accurate for every
+// Release caller (#2103). Implemented structurally by *metrics.Metrics (see
+// tools.ToolMetrics for the parallel interface at the tool-handler layer) --
+// defined locally here, rather than imported, to avoid mcp importing
+// metrics or tools (tools already imports mcp, so the reverse would cycle).
+type SessionEndedMetrics interface {
+	RecordInteractiveSessionEnded()
 }
 
 type sessionEntry struct {
@@ -143,6 +165,20 @@ func (m *LeaseSessionManager) SetReconnectCallback(fn func(sessionID string)) {
 func WithSessionJanitor(j *SessionJanitor) LeaseOption {
 	return func(m *LeaseSessionManager) {
 		m.janitor = j
+	}
+}
+
+// WithSessionEndedMetrics wires the aiagent_mcp_interactive_sessions_active
+// decrement into Release() itself (#2103), so every current and future
+// Release() caller -- InvestigateTool, SelectWorkflowTool,
+// CompleteNoActionTool, the SessionJanitor backstop, and main.go's own
+// TTL/inactivity/disconnect callbacks -- keeps the gauge accurate without
+// needing its own metrics field.
+func WithSessionEndedMetrics(m SessionEndedMetrics) LeaseOption {
+	return func(mgr *LeaseSessionManager) {
+		if m != nil {
+			mgr.sessionMetrics = m
+		}
 	}
 }
 
@@ -366,6 +402,16 @@ func (m *LeaseSessionManager) Release(sessionID string, reason string) error {
 	m.sessions.Delete(sessionID)
 	m.rrIndex.Delete(entry.rrID)
 	m.activeCount.Add(-1)
+
+	// #2103: centralize the aiagent_mcp_interactive_sessions_active
+	// decrement here, paired with activeCount.Add(-1) above, so every
+	// current and future Release() caller keeps the gauge accurate. Only
+	// reached once the session is confirmed locally found and removed
+	// above -- a double-Release (ErrSessionNotFound) or a hard Lease-delete
+	// error never reaches this line, so this can never double-decrement.
+	if m.sessionMetrics != nil {
+		m.sessionMetrics.RecordInteractiveSessionEnded()
+	}
 
 	if m.janitor != nil {
 		m.janitor.Untrack(sessionID)

--- a/internal/kubernautagent/mcp/session_manager.go
+++ b/internal/kubernautagent/mcp/session_manager.go
@@ -77,6 +77,15 @@ type LeaseSessionManager struct {
 	logger            logr.Logger
 	onSessionExpired  func(sessionID, rrID, reason string) // called on TTL/inactivity auto-release
 	onReconnect       func(sessionID string)               // called when Takeover detects same-user reconnect
+
+	// janitor is the #2100 backstop: every session Takeover creates is
+	// Tracked here and Untracked on Release, so a session that never gets
+	// explicitly released (crash, panic, code path that returns early
+	// without calling Release) is still reclaimed by the janitor's sweep
+	// instead of leaking Lease capacity until process restart. Nil in
+	// deployments/tests that don't wire one via WithSessionJanitor --
+	// Track/Untrack calls are no-ops in that case.
+	janitor *SessionJanitor
 }
 
 type sessionEntry struct {
@@ -124,6 +133,17 @@ func WithSessionExpiredCallback(fn func(sessionID, rrID, reason string)) LeaseOp
 // in GracefulSessionClosedHandler (BR-INTERACTIVE-001).
 func (m *LeaseSessionManager) SetReconnectCallback(fn func(sessionID string)) {
 	m.onReconnect = fn
+}
+
+// WithSessionJanitor wires a SessionJanitor as a backstop for orphaned
+// sessions (#2100): every session Takeover creates is Tracked with the
+// janitor, and Untracked on Release, so sessions that are never explicitly
+// released are still reclaimed by the janitor's periodic sweep instead of
+// eroding interactive.maxConcurrentSessions capacity indefinitely.
+func WithSessionJanitor(j *SessionJanitor) LeaseOption {
+	return func(m *LeaseSessionManager) {
+		m.janitor = j
+	}
 }
 
 // NewLeaseSessionManager creates a LeaseSessionManager backed by the given K8s client.
@@ -300,6 +320,18 @@ func (m *LeaseSessionManager) registerNewInteractiveSession(sessionID, rrID stri
 	m.rrIndex.Store(rrID, sessionID)
 	m.activeCount.Add(1)
 
+	if m.janitor != nil {
+		// #2100: onExpire routes through the same Release path as every
+		// other exit (explicit complete/cancel, TTL, inactivity), so the
+		// Lease is deleted and activeCount decremented identically --
+		// the janitor is a backstop, not a parallel cleanup mechanism.
+		m.janitor.Track(sessionID, session.StartedAt, func(expiredID string) {
+			if err := m.Release(expiredID, "janitor_expired"); err != nil && !errors.Is(err, ErrSessionNotFound) {
+				m.logger.Error(err, "janitor: failed to release expired session", "session_id", expiredID)
+			}
+		})
+	}
+
 	m.logger.Info("interactive session started",
 		"session_id", sessionID,
 		"rr_id", rrID,
@@ -334,6 +366,10 @@ func (m *LeaseSessionManager) Release(sessionID string, reason string) error {
 	m.sessions.Delete(sessionID)
 	m.rrIndex.Delete(entry.rrID)
 	m.activeCount.Add(-1)
+
+	if m.janitor != nil {
+		m.janitor.Untrack(sessionID)
+	}
 
 	m.logger.Info("interactive session released",
 		"session_id", sessionID,

--- a/internal/kubernautagent/mcp/session_manager_janitor_2100_test.go
+++ b/internal/kubernautagent/mcp/session_manager_janitor_2100_test.go
@@ -51,7 +51,7 @@ var _ = Describe("LeaseSessionManager + SessionJanitor wiring — #2100", func()
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		namespace = "kubernaut-system"
+		namespace = testNamespace
 		logger = logr.Discard()
 
 		scheme := runtime.NewScheme()

--- a/internal/kubernautagent/mcp/session_manager_janitor_2100_test.go
+++ b/internal/kubernautagent/mcp/session_manager_janitor_2100_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+)
+
+// #2100: SessionJanitor was fully implemented and independently
+// unit/integration-tested (IT-KA-DES-005/006) but had zero production
+// callers -- confirmed via grep -rn NewSessionJanitor returning only its
+// own definition and test files. LeaseSessionManager.Takeover/Release never
+// called Track/Untrack, so the janitor's backstop sweep could never fire
+// for a real interactive session, no matter how long it leaked. These
+// tests prove the chokepoint wiring inside session_manager.go itself (not
+// just the janitor's own pre-existing sweep logic, which IT-KA-DES-005/006
+// already cover).
+var _ = Describe("LeaseSessionManager + SessionJanitor wiring — #2100", func() {
+	var (
+		ctx       context.Context
+		k8sClient client.Client
+		namespace string
+		logger    logr.Logger
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = "kubernaut-system"
+		logger = logr.Discard()
+
+		scheme := runtime.NewScheme()
+		Expect(coordinationv1.AddToScheme(scheme)).To(Succeed())
+		k8sClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+	})
+
+	Describe("UT-KA-2100-001: Takeover success Tracks the session; Release Untracks it", func() {
+		It("should register the session with the janitor on Takeover and deregister it on Release", func() {
+			janitor := mcpinternal.NewSessionJanitor(1*time.Hour, logger) // long interval: sweep must never fire in this test
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionJanitor(janitor))
+
+			user := mcpinternal.UserInfo{Username: "alice@example.com", Groups: []string{"sre"}}
+			sess, err := mgr.Takeover(ctx, "rr-2100-001", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(janitor.TrackedForTest(sess.SessionID)).To(BeTrue(),
+				"#2100: Takeover success must Track the session with the janitor (chokepoint wiring)")
+
+			Expect(mgr.Release(sess.SessionID, "test_done")).To(Succeed())
+			Expect(janitor.TrackedForTest(sess.SessionID)).To(BeFalse(),
+				"#2100: Release must Untrack the session so the janitor's backstop sweep never fires for a cleanly-released session")
+		})
+	})
+
+	Describe("UT-KA-2100-002: a session tracked via Takeover but never Released is reclaimed by the janitor's sweep", func() {
+		It("should have the janitor's onExpire callback call Release, deleting the Lease and clearing the driver", func() {
+			janitor := mcpinternal.NewSessionJanitor(50*time.Millisecond, logger)
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionJanitor(janitor))
+
+			janitorCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go janitor.Run(janitorCtx)
+
+			user := mcpinternal.UserInfo{Username: "bob@example.com", Groups: []string{"sre"}}
+			_, err := mgr.Takeover(ctx, "rr-2100-002", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() *mcpinternal.InteractiveSession {
+				driver, _ := mgr.GetDriver("rr-2100-002")
+				return driver
+			}, 2*time.Second, 20*time.Millisecond).Should(BeNil(),
+				"#2100: the orphaned session must be reclaimed by the janitor's backstop sweep -- GetDriver must no longer find a driver")
+
+			leaseList := &coordinationv1.LeaseList{}
+			Expect(k8sClient.List(ctx, leaseList, client.InNamespace(namespace))).To(Succeed())
+			Expect(leaseList.Items).To(BeEmpty(),
+				"#2100: the janitor's onExpire callback must have deleted the orphaned session's Lease via Release, not just logged")
+		})
+	})
+
+	Describe("UT-KA-2100-005 (regression guard): a same-user reconnect never touches the janitor", func() {
+		It("should not panic or double-track when Takeover's reconnect branch returns early", func() {
+			janitor := mcpinternal.NewSessionJanitor(1*time.Hour, logger)
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionJanitor(janitor))
+
+			user := mcpinternal.UserInfo{Username: "carol@example.com", Groups: []string{"sre"}}
+			first, err := mgr.Takeover(ctx, "rr-2100-002b", user)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(janitor.TrackedForTest(first.SessionID)).To(BeTrue())
+
+			second, err := mgr.Takeover(ctx, "rr-2100-002b", user)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(second.SessionID).To(Equal(first.SessionID), "same-user Takeover must reconnect, not create a new session")
+			Expect(janitor.TrackedForTest(first.SessionID)).To(BeTrue(),
+				"the reconnect branch must not accidentally Untrack the still-active session")
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/session_manager_metrics_2103_test.go
+++ b/internal/kubernautagent/mcp/session_manager_metrics_2103_test.go
@@ -62,7 +62,7 @@ var _ = Describe("LeaseSessionManager.Release centralized metrics decrement — 
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		namespace = "kubernaut-system"
+		namespace = testNamespace
 		logger = logr.Discard()
 
 		scheme := runtime.NewScheme()

--- a/internal/kubernautagent/mcp/session_manager_metrics_2103_test.go
+++ b/internal/kubernautagent/mcp/session_manager_metrics_2103_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+)
+
+// recordingSessionEndedMetrics captures RecordInteractiveSessionEnded calls
+// for assertion, implementing mcpinternal.SessionEndedMetrics.
+type recordingSessionEndedMetrics struct {
+	endedCount int
+}
+
+func (m *recordingSessionEndedMetrics) RecordInteractiveSessionEnded() {
+	m.endedCount++
+}
+
+// #2103: aiagent_mcp_interactive_sessions_active only ever decremented for
+// two of the ways an interactive session can end (explicit complete/cancel)
+// plus two callback paths owned directly by cmd/kubernautagent/main.go.
+// Every other completion path (complete_no_action, workflow_selected,
+// no_matching_workflows, and #2100's own new SessionJanitor backstop) called
+// LeaseSessionManager.Release() without ever decrementing the gauge, because
+// the decrement was the caller's responsibility and most callers never wired
+// agentMetrics at all. These tests prove the fix: centralizing the decrement
+// inside Release() itself, paired with the existing activeCount.Add(-1), so
+// every current and future Release() caller keeps the gauge accurate without
+// needing its own metrics field.
+var _ = Describe("LeaseSessionManager.Release centralized metrics decrement — #2103", func() {
+	var (
+		ctx       context.Context
+		k8sClient client.Client
+		namespace string
+		logger    logr.Logger
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = "kubernaut-system"
+		logger = logr.Discard()
+
+		scheme := runtime.NewScheme()
+		Expect(coordinationv1.AddToScheme(scheme)).To(Succeed())
+		k8sClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+	})
+
+	Describe("UT-KA-2103-001: Release calls the wired metrics callback exactly once on success", func() {
+		It("should decrement the metrics recorder when the session is found and released", func() {
+			metrics := &recordingSessionEndedMetrics{}
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionEndedMetrics(metrics))
+
+			user := mcpinternal.UserInfo{Username: "alice@example.com", Groups: []string{"sre"}}
+			sess, err := mgr.Takeover(ctx, "rr-2103-001", user)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metrics.endedCount).To(Equal(0), "must not decrement before Release is called")
+
+			Expect(mgr.Release(sess.SessionID, "complete_no_action")).To(Succeed())
+			Expect(metrics.endedCount).To(Equal(1),
+				"#2103: Release must call the wired SessionEndedMetrics exactly once, "+
+					"regardless of which caller/reason triggered it")
+		})
+	})
+
+	Describe("UT-KA-2103-002 (regression guard): Release on an unknown session ID never decrements", func() {
+		It("should return ErrSessionNotFound and leave the metrics recorder untouched", func() {
+			metrics := &recordingSessionEndedMetrics{}
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionEndedMetrics(metrics))
+
+			err := mgr.Release("nonexistent-session-id", "complete_no_action")
+			Expect(err).To(MatchError(mcpinternal.ErrSessionNotFound))
+			Expect(metrics.endedCount).To(Equal(0),
+				"#2103: a session that was never tracked (or already released) must not phantom-decrement the gauge")
+		})
+	})
+
+	Describe("UT-KA-2103-003 (regression guard): Release with no metrics wired does not panic", func() {
+		It("should complete the release successfully with a nil SessionEndedMetrics (matches every pre-#2103 call site)", func() {
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger)
+
+			user := mcpinternal.UserInfo{Username: "bob@example.com", Groups: []string{"sre"}}
+			sess, err := mgr.Takeover(ctx, "rr-2103-003", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(func() {
+				Expect(mgr.Release(sess.SessionID, "complete_no_action")).To(Succeed())
+			}).NotTo(Panic(), "#2103: WithSessionEndedMetrics is optional -- Release must stay nil-safe")
+		})
+	})
+
+	Describe("UT-KA-2103-004 (regression guard): a double Release only decrements once", func() {
+		It("should decrement exactly once even if Release is called twice for the same session ID", func() {
+			metrics := &recordingSessionEndedMetrics{}
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionEndedMetrics(metrics))
+
+			user := mcpinternal.UserInfo{Username: "carol@example.com", Groups: []string{"sre"}}
+			sess, err := mgr.Takeover(ctx, "rr-2103-004", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mgr.Release(sess.SessionID, "complete")).To(Succeed())
+			Expect(metrics.endedCount).To(Equal(1))
+
+			secondErr := mgr.Release(sess.SessionID, "explicit")
+			Expect(secondErr).To(MatchError(mcpinternal.ErrSessionNotFound))
+			Expect(metrics.endedCount).To(Equal(1),
+				"#2103: the second (redundant) Release call must not double-decrement")
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/session_manager_test.go
+++ b/internal/kubernautagent/mcp/session_manager_test.go
@@ -45,7 +45,7 @@ var _ = Describe("LeaseSessionManager — #703 BR-INTERACTIVE-002", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		namespace = "kubernaut-system"
+		namespace = testNamespace
 		logger = logr.Discard()
 
 		scheme = runtime.NewScheme()

--- a/internal/kubernautagent/mcp/suite_test.go
+++ b/internal/kubernautagent/mcp/suite_test.go
@@ -27,3 +27,9 @@ func TestMCPUnit(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Kubernaut Agent MCP Unit Suite")
 }
+
+// testNamespace is the shared fixture namespace for this package's fake-client
+// tests (drainer_test.go, session_manager_test.go, and the janitor/#2100 and
+// metrics/#2103 wiring tests) -- factored out once goconst flagged the fourth
+// independent literal occurrence.
+const testNamespace = "kubernaut-system"

--- a/internal/kubernautagent/mcp/tools/errors.go
+++ b/internal/kubernautagent/mcp/tools/errors.go
@@ -121,6 +121,36 @@ var (
 		Code:    "tool_budget_exhausted",
 		Message: "Investigation exceeded the maximum number of tool calls allowed",
 	}
+	// ErrCodeNoConversationContext is returned by discover_workflows when
+	// neither the session's stored RCA result, the live conversation, nor
+	// audit-trail reconstruction produced any content to extract an RCA
+	// from (#2023). Before this fix, this case returned a plain fmt.Errorf,
+	// which ErrorBoundary redacted to the generic ErrCodeInternalError —
+	// leaving the calling agent unable to distinguish "there is genuinely
+	// nothing to analyze" from "server bug", which in turn left room for
+	// the LLM to fabricate a plausible-sounding RCA/audit-trail narrative
+	// rather than surfacing the gap (SI-11).
+	ErrCodeNoConversationContext = &MCPError{
+		Code:    "no_conversation_context",
+		Message: "No investigation content available: no stored RCA, live conversation, or audit trail was found for this remediation",
+	}
+	// ErrCodeNoInvestigationAvailable is returned by handleStart when every
+	// fallback path for attaching an investigation to a newly-acquired
+	// interactive Lease has been exhausted: no running/terminal autonomous
+	// session exists for the RR, reattachOrCreateFallback's own fallback
+	// session creation failed, AND ForceTransitionToUserDriving also failed
+	// (#2100, v1.6 clone #2101). Before this fix, this case fell through to
+	// a silent "started" response with an empty InvestigationSessionID --
+	// the client held a Lease (eroding interactive.maxConcurrentSessions
+	// capacity) with nothing behind it, reclaimed only incidentally by
+	// TimeoutManager's ~10-minute inactivity window. Failing closed here
+	// (with an immediate lease Release) surfaces the genuine "nothing to
+	// drive" condition to the caller right away, instead of returning a
+	// misleading success the client has no way to detect.
+	ErrCodeNoInvestigationAvailable = &MCPError{
+		Code:    "no_investigation_available",
+		Message: "No investigation is available to attach an interactive session to for this remediation",
+	}
 )
 
 // ErrorBoundary wraps a tool handler error: if the error is already an MCPError

--- a/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_test.go
+++ b/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_test.go
@@ -40,6 +40,12 @@ type fallbackAutoMgr struct {
 	upgradeErr    error
 	upgradeCalled atomic.Int32
 
+	// forceErr configures ForceTransitionToUserDriving's return value.
+	// Defaults to nil (existing tests' assumed always-succeeds behavior);
+	// #2100's fallback-exhausted test sets this to force handleStart's new
+	// fail-closed branch.
+	forceErr error
+
 	startCalled atomic.Int32
 	startResult string
 	startErr    error
@@ -66,7 +72,7 @@ func (m *fallbackAutoMgr) TransitionToUserDriving(_ string, _ string, _ []string
 	return nil
 }
 func (m *fallbackAutoMgr) ForceTransitionToUserDriving(_ string, _ string, _ []string) error {
-	return nil
+	return m.forceErr
 }
 func (m *fallbackAutoMgr) UpgradeToInteractive(_ string, _ string, _ []string) error {
 	m.upgradeCalled.Add(1)

--- a/internal/kubernautagent/mcp/tools/investigate_2100_test.go
+++ b/internal/kubernautagent/mcp/tools/investigate_2100_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+)
+
+// #2100: QE's live evidence showed interactive.maxConcurrentSessions
+// capacity eroding monotonically under load. One of the two converging
+// root causes: handleStart's fallback-exhausted branch (no autonomous
+// session for the RR, reattachOrCreateFallback's own fallback session
+// creation fails, AND ForceTransitionToUserDriving also fails) silently
+// fell through to a "started" response with an empty
+// InvestigationSessionID -- holding the just-acquired Lease with nothing
+// behind it (matches session_teardown.go's "CRITICAL: no session found for
+// either completion path" log line). The only reclaim path was
+// TimeoutManager's ~10-minute inactivity timeout, which is why live
+// evidence showed leases lingering minutes rather than forever, not a
+// designed safety net for this specific failure.
+var _ = Describe("Fix #2100: handleStart fail-closed on fallback exhaustion", func() {
+
+	Describe("UT-KA-2100-003: handleStart releases the lease and fails closed when every fallback path is exhausted", func() {
+		It("should call Release and return ErrCodeNoInvestigationAvailable instead of silently succeeding with an empty InvestigationSessionID", func() {
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "lease-sess-2100-003",
+					CorrelationID: "rr-2100-003",
+				},
+			}
+			autoMgr := &fallbackAutoMgr{
+				findOK:   false, // no autonomous session at all for this RR
+				startErr: fmt.Errorf("simulated StartInvestigation failure"), // reattachOrCreateFallback -> ""
+				forceErr: fmt.Errorf("simulated ForceTransitionToUserDriving failure"),
+			}
+			completer := &reattachHTTPCompleter{found: false} // no existing user_driving session either
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr, mcptools.WithHTTPCompleter(completer))
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2100-003",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "sre-erin", Groups: []string{"sre-team"}})
+
+			Expect(err).To(HaveOccurred(), "#2100: must fail closed instead of returning a misleading success")
+			var mcpErr *mcptools.MCPError
+			Expect(errors.As(err, &mcpErr)).To(BeTrue())
+			Expect(mcpErr.Code).To(Equal("no_investigation_available"))
+			Expect(out).To(Equal(mcptools.InvestigateOutput{}))
+
+			releasedID, releasedReason := sessionMgr.getReleased()
+			Expect(releasedID).To(Equal("lease-sess-2100-003"),
+				"#2100: the just-acquired lease must be released immediately, not left to the janitor/TimeoutManager backstops")
+			Expect(releasedReason).To(Equal("no_investigation_available"))
+		})
+	})
+
+	Describe("UT-KA-2100-004 (regression guard): the terminal-session fallback branch is unaffected by the new fail-closed behavior", func() {
+		It("should still fall back to investigationSessionID = autoSessionID when reattachOrCreateFallback fails after UpgradeToInteractive reports terminal", func() {
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "lease-sess-2100-004",
+					CorrelationID: "rr-2100-004",
+				},
+			}
+			autoMgr := &fallbackAutoMgr{
+				findResult: "old-terminal-session-004",
+				findOK:     true,
+				upgradeErr: session.ErrSessionTerminal,
+				startErr:   fmt.Errorf("simulated StartInvestigation failure"), // reattachOrCreateFallback -> ""
+			}
+			completer := &reattachHTTPCompleter{found: false}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr, mcptools.WithHTTPCompleter(completer))
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2100-004",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "sre-frank", Groups: []string{"sre-team"}})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.InvestigationSessionID).To(Equal("old-terminal-session-004"),
+				"the terminal-session branch's own pre-existing autoSessionID fallback must remain unchanged by #2100's new fail-closed logic, "+
+					"which is scoped only to the genuinely-empty (no autonomous session at all) case")
+
+			releasedID, _ := sessionMgr.getReleased()
+			Expect(releasedID).To(BeEmpty(),
+				"the terminal-session branch must not release the lease -- it already has a valid (if stale) session to attach to")
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/tools/investigate_autonomous.go
+++ b/internal/kubernautagent/mcp/tools/investigate_autonomous.go
@@ -60,9 +60,9 @@ func (t *InvestigateTool) handleCancel(input InvestigateInput, user mcpinternal.
 
 	CompleteHTTPSession(t.httpCompleter, input.RRID, nil, t.logger, "cancel")
 
-	if t.metrics != nil {
-		t.metrics.RecordInteractiveSessionEnded()
-	}
+	// #2103 (v1.6 clone #2104): see handleComplete's matching comment
+	// (investigate_takeover.go) -- the gauge decrement is now centralized
+	// in LeaseSessionManager.Release().
 
 	t.sessionMu.Delete(input.RRID)
 	t.reconHistory.Delete(input.RRID)

--- a/internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go
+++ b/internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+)
+
+// #2103: aiagent_mcp_interactive_sessions_active's decrement moved from
+// InvestigateTool's own explicit RecordInteractiveSessionEnded() calls (in
+// handleComplete/handleCancel) into LeaseSessionManager.Release() itself,
+// so every Release() caller -- including complete_no_action, workflow
+// selection, and the no_matching_workflows auto-close, none of which ever
+// called it directly -- decrements the gauge automatically. These tests
+// guard against reintroducing a double-decrement: with the shared mock
+// SessionManager here (which does NOT itself call metrics, unlike the real
+// LeaseSessionManager post-#2103), handleComplete/handleCancel must show
+// ZERO direct RecordInteractiveSessionEnded calls.
+var _ = Describe("InvestigateTool metrics after centralization — #2103", func() {
+
+	Describe("UT-KA-2103-004 (regression guard): handleComplete no longer directly decrements the gauge", func() {
+		It("should not call RecordInteractiveSessionEnded itself -- that responsibility moved to LeaseSessionManager.Release", func() {
+			metrics := &recordingToolMetrics{}
+			sessionMgr := &mockSessionManager{
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2103-complete",
+					CorrelationID: "rr-2103-complete",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+				},
+				isActive: true,
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, mcptools.NopAutonomousManager{},
+				mcptools.WithToolMetrics(metrics))
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2103-complete",
+				Action: mcptools.ActionComplete,
+			}, mcpinternal.UserInfo{Username: "alice"})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("completed"))
+			Expect(sessionMgr.releasedID).To(Equal("sess-2103-complete"),
+				"Release must still be called -- only the direct metrics call moved")
+			Expect(metrics.sessionEnded).To(Equal(0),
+				"#2103: handleComplete must not call RecordInteractiveSessionEnded directly anymore -- "+
+					"the real LeaseSessionManager.Release() does it centrally now, and this mock does not "+
+					"simulate that, so a nonzero count here would mean a double-decrement in production")
+		})
+	})
+
+	Describe("UT-KA-2103-005 (regression guard): handleCancel no longer directly decrements the gauge", func() {
+		It("should not call RecordInteractiveSessionEnded itself -- same rationale as handleComplete", func() {
+			metrics := &recordingToolMetrics{}
+			sessionMgr := &mockSessionManager{
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2103-cancel",
+					CorrelationID: "rr-2103-cancel",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+				},
+				isActive: true,
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, mcptools.NopAutonomousManager{},
+				mcptools.WithToolMetrics(metrics))
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2103-cancel",
+				Action: mcptools.ActionCancel,
+			}, mcpinternal.UserInfo{Username: "alice"})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("cancelled"))
+			Expect(sessionMgr.releasedReason).To(Equal("explicit"))
+			Expect(metrics.sessionEnded).To(Equal(0),
+				"#2103: handleCancel must not call RecordInteractiveSessionEnded directly anymore")
+		})
+	})
+
+	Describe("UT-KA-2103-006: handleStart records Started immediately, even on the fallback-exhausted branch that releases the lease", func() {
+		It("should call RecordInteractiveSessionStarted before the #2100 fail-closed Release, keeping the gauge paired with activeCount", func() {
+			metrics := &recordingToolMetrics{}
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "lease-sess-2103-006",
+					CorrelationID: "rr-2103-006",
+				},
+			}
+			autoMgr := &fallbackAutoMgr{
+				findOK:   false,
+				startErr: fmt.Errorf("simulated StartInvestigation failure"),
+				forceErr: fmt.Errorf("simulated ForceTransitionToUserDriving failure"),
+			}
+			completer := &reattachHTTPCompleter{found: false}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithHTTPCompleter(completer), mcptools.WithToolMetrics(metrics))
+			_, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2103-006",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "sre-erin", Groups: []string{"sre-team"}})
+
+			Expect(err).To(HaveOccurred(), "#2100: this branch still fails closed")
+
+			releasedID, releasedReason := sessionMgr.getReleased()
+			Expect(releasedID).To(Equal("lease-sess-2103-006"))
+			Expect(releasedReason).To(Equal("no_investigation_available"))
+
+			Expect(metrics.sessionStarted).To(Equal(1),
+				"#2103: Takeover acquired a genuine new lease (activeCount.Add(1)) before this branch released "+
+					"it again -- RecordInteractiveSessionStarted must fire for that lease's brief lifetime so the "+
+					"now-centralized Release() decrement (which fires unconditionally) has a matching increment "+
+					"to pair with, instead of driving the gauge negative")
+		})
+	})
+
+	Describe("UT-KA-2103-007 (regression guard): Started is still not recorded when no new lease was acquired", func() {
+		It("should not call RecordInteractiveSessionStarted on a reconnect", func() {
+			metrics := &recordingToolMetrics{}
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "lease-sess-2103-007a",
+					CorrelationID: "rr-2103-007a",
+					Reconnected:   true,
+				},
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, mcptools.NopAutonomousManager{},
+				mcptools.WithToolMetrics(metrics))
+			_, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2103-007a",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "sre-erin", Groups: []string{"sre-team"}})
+
+			Expect(err).To(HaveOccurred(), "a reconnect on action=start returns the session_active error")
+			Expect(metrics.sessionStarted).To(Equal(0),
+				"#2103: a reconnect never acquires a new lease (Takeover returns early, no activeCount.Add(1)), "+
+					"so it must not record a Started that has no matching lease lifetime")
+		})
+
+		It("should not call RecordInteractiveSessionStarted when Takeover itself fails", func() {
+			metrics := &recordingToolMetrics{}
+			sessionMgr := &mockSessionManager{
+				takeoverErr: mcpinternal.ErrMaxSessionsReached,
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, mcptools.NopAutonomousManager{},
+				mcptools.WithToolMetrics(metrics))
+			_, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2103-007b",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "sre-erin", Groups: []string{"sre-team"}})
+
+			Expect(err).To(HaveOccurred())
+			Expect(metrics.sessionStarted).To(Equal(0),
+				"#2103: no lease was ever acquired when Takeover itself fails")
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/tools/investigate_start.go
+++ b/internal/kubernautagent/mcp/tools/investigate_start.go
@@ -55,7 +55,25 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 	// Skip when we just launched a pending session — its RCA goroutine will
 	// self-transition via InteractiveHold once complete.
 	if !launchedPending {
-		investigationSessionID = t.upgradeOrCreateInteractiveSession(ctx, input, user)
+		var exhausted bool
+		investigationSessionID, exhausted = t.upgradeOrCreateInteractiveSession(ctx, input, user)
+		if exhausted {
+			// #2100 (v1.6 clone #2101): both fallback paths are exhausted --
+			// release the just-acquired Lease immediately and fail closed
+			// instead of falling through to startTimeoutTracking/a
+			// "started" response with an empty InvestigationSessionID,
+			// which previously left the lease reclaimed only incidentally
+			// by TimeoutManager's ~10-minute inactivity window
+			// (interactive.maxConcurrentSessions capacity erosion).
+			if releaseErr := t.sessions.Release(sess.SessionID, "no_investigation_available"); releaseErr != nil {
+				t.logger.Error(releaseErr, "start: failed to release lease after exhausting all fallback paths",
+					"rr_id", input.RRID, "session_id", sess.SessionID)
+			}
+			if t.metrics != nil {
+				t.metrics.RecordInteractiveTakeover("start_failed")
+			}
+			return InvestigateOutput{}, ErrCodeNoInvestigationAvailable
+		}
 	}
 
 	if t.metrics != nil {
@@ -165,8 +183,16 @@ func (t *InvestigateTool) startInteractiveSession(ctx context.Context, input Inv
 // the existing one is terminal — reattaches to (or creates) a fresh
 // interactive session so the user is never left with a lease but no
 // investigation to drive (#1440 SC-24). Returns the resulting investigation
-// session ID.
-func (t *InvestigateTool) upgradeOrCreateInteractiveSession(ctx context.Context, input InvestigateInput, user mcpinternal.UserInfo) string {
+// session ID, and (#2100, v1.6 clone #2101) whether every fallback path was
+// exhausted with genuinely nothing for the caller to attach to -- true only
+// when no running session exists for this RR AND both the reattach-or-create
+// fallback and ForceTransitionToUserDriving failed. handleStart uses this
+// second value to fail closed (release the lease, return an actionable
+// error) instead of returning a hollow "started" response with an empty
+// InvestigationSessionID. The terminal-session branch below deliberately
+// never reports exhausted=true: it always has autoSessionID (a real,
+// non-empty session) to fall back to, matching pre-#2100 behavior.
+func (t *InvestigateTool) upgradeOrCreateInteractiveSession(ctx context.Context, input InvestigateInput, user mcpinternal.UserInfo) (string, bool) {
 	autoSessionID, found := t.autoMgr.FindByRemediationID(input.RRID)
 	if !found {
 		// No Running session exists for this RR — reattach to an existing
@@ -174,23 +200,27 @@ func (t *InvestigateTool) upgradeOrCreateInteractiveSession(ctx context.Context,
 		// a genuine placeholder, so the user is never left with a lease but
 		// no investigation.
 		if reattachedID := t.reattachOrCreateFallback(ctx, input.RRID, user); reattachedID != "" {
-			return reattachedID
+			return reattachedID, false
 		}
 		if forceErr := t.autoMgr.ForceTransitionToUserDriving(input.RRID, user.Username, user.Groups); forceErr != nil {
 			t.logger.Error(forceErr, "start: force-transition to user-driving (no running session found)",
 				"rr_id", input.RRID)
+			// #2100 (v1.6 clone #2101): both fallback paths are now
+			// exhausted -- there is genuinely no investigation this
+			// session could ever attach to.
+			return "", true
 		}
-		return ""
+		return "", false
 	}
 
 	upgradeErr := t.autoMgr.UpgradeToInteractive(autoSessionID, user.Username, user.Groups)
 	if upgradeErr == nil {
-		return autoSessionID
+		return autoSessionID, false
 	}
 	if !errors.Is(upgradeErr, session.ErrSessionTerminal) {
 		t.logger.Error(upgradeErr, "start: upgrade autonomous session to interactive",
 			"rr_id", input.RRID, "auto_session_id", autoSessionID)
-		return autoSessionID
+		return autoSessionID, false
 	}
 
 	if forceErr := t.autoMgr.ForceTransitionToUserDriving(input.RRID, user.Username, user.Groups); forceErr != nil {
@@ -200,9 +230,9 @@ func (t *InvestigateTool) upgradeOrCreateInteractiveSession(ctx context.Context,
 	// #1440 SC-24 / #1818: Terminal session — reattach to the real RCA (or a
 	// genuine placeholder) so the user always has an investigation to drive.
 	if reattachedID := t.reattachOrCreateFallback(ctx, input.RRID, user); reattachedID != "" {
-		return reattachedID
+		return reattachedID, false
 	}
-	return autoSessionID
+	return autoSessionID, false
 }
 
 // reattachOrCreateFallback resolves the investigation session the user

--- a/internal/kubernautagent/mcp/tools/investigate_start.go
+++ b/internal/kubernautagent/mcp/tools/investigate_start.go
@@ -70,21 +70,7 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 		var exhausted bool
 		investigationSessionID, exhausted = t.upgradeOrCreateInteractiveSession(ctx, input, user)
 		if exhausted {
-			// #2100 (v1.6 clone #2101): both fallback paths are exhausted --
-			// release the just-acquired Lease immediately and fail closed
-			// instead of falling through to startTimeoutTracking/a
-			// "started" response with an empty InvestigationSessionID,
-			// which previously left the lease reclaimed only incidentally
-			// by TimeoutManager's ~10-minute inactivity window
-			// (interactive.maxConcurrentSessions capacity erosion).
-			if releaseErr := t.sessions.Release(sess.SessionID, "no_investigation_available"); releaseErr != nil {
-				t.logger.Error(releaseErr, "start: failed to release lease after exhausting all fallback paths",
-					"rr_id", input.RRID, "session_id", sess.SessionID)
-			}
-			if t.metrics != nil {
-				t.metrics.RecordInteractiveTakeover("start_failed")
-			}
-			return InvestigateOutput{}, ErrCodeNoInvestigationAvailable
+			return InvestigateOutput{}, t.failStartOnFallbackExhausted(sess.SessionID, input.RRID)
 		}
 	}
 
@@ -101,6 +87,27 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 		Status:                 "started",
 		InvestigationSessionID: investigationSessionID,
 	}, nil
+}
+
+// failStartOnFallbackExhausted handles handleStart's fallback-exhausted
+// branch (#2100, v1.6 clone #2101): both the running-autonomous-session
+// upgrade and the fallback-session-creation path failed, so the just-acquired
+// Lease is released immediately and the request fails closed, instead of
+// falling through to startTimeoutTracking/a "started" response with an empty
+// InvestigationSessionID -- which previously left the lease reclaimed only
+// incidentally by TimeoutManager's ~10-minute inactivity window
+// (interactive.maxConcurrentSessions capacity erosion). Extracted out of
+// handleStart to keep its own nesting depth within this repo's complexity
+// limit (nestif).
+func (t *InvestigateTool) failStartOnFallbackExhausted(sessionID, rrID string) error {
+	if releaseErr := t.sessions.Release(sessionID, "no_investigation_available"); releaseErr != nil {
+		t.logger.Error(releaseErr, "start: failed to release lease after exhausting all fallback paths",
+			"rr_id", rrID, "session_id", sessionID)
+	}
+	if t.metrics != nil {
+		t.metrics.RecordInteractiveTakeover("start_failed")
+	}
+	return ErrCodeNoInvestigationAvailable
 }
 
 // launchPendingInteractiveSession launches a previously-deferred interactive

--- a/internal/kubernautagent/mcp/tools/investigate_start.go
+++ b/internal/kubernautagent/mcp/tools/investigate_start.go
@@ -48,6 +48,18 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 		return InvestigateOutput{}, startErr
 	}
 
+	// #2103 (v1.6 clone #2104): record Started as soon as startInteractiveSession
+	// confirms a genuinely new lease was acquired (activeCount.Add(1)) --
+	// before any fallback logic below that might immediately Release() it
+	// again (the exhausted branch a few lines down). Now that Release()
+	// centrally decrements aiagent_mcp_interactive_sessions_active (paired
+	// with its own activeCount.Add(-1)), Started/Ended must stay paired with
+	// the lease's own lifecycle -- otherwise that branch would decrement a
+	// gauge that was never incremented, driving it negative.
+	if t.metrics != nil {
+		t.metrics.RecordInteractiveSessionStarted()
+	}
+
 	// #1390: Upgrade running autonomous session in-place (Jump In) instead of
 	// cancelling and recreating. UpgradeToInteractive sets the atomic flag so
 	// the goroutine's next InteractiveHold check sees it, and store.Update's
@@ -77,7 +89,6 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 	}
 
 	if t.metrics != nil {
-		t.metrics.RecordInteractiveSessionStarted()
 		t.metrics.RecordInteractiveTakeover("start_success")
 	}
 

--- a/internal/kubernautagent/mcp/tools/investigate_takeover.go
+++ b/internal/kubernautagent/mcp/tools/investigate_takeover.go
@@ -219,9 +219,13 @@ func (t *InvestigateTool) handleComplete(input InvestigateInput, user mcpinterna
 
 	CompleteHTTPSession(t.httpCompleter, input.RRID, finalResult, t.logger, "complete")
 
-	if t.metrics != nil {
-		t.metrics.RecordInteractiveSessionEnded()
-	}
+	// #2103 (v1.6 clone #2104): the aiagent_mcp_interactive_sessions_active
+	// decrement moved into LeaseSessionManager.Release() itself (called
+	// above), paired with its own activeCount.Add(-1) -- centralizing it
+	// there closes the same gap for every other Release() caller
+	// (complete_no_action, workflow_selected, no_matching_workflows, the
+	// SessionJanitor backstop) that never had a metrics field to call this
+	// explicitly.
 
 	t.sessionMu.Delete(input.RRID)
 	t.reconHistory.Delete(input.RRID)

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -50,6 +50,16 @@ const errNoActiveDriver = "interactive session not active — you must call kube
 // option; this is defense-in-depth for the rare case a call slips through.
 const errCheckpointBlocked = "this action requires explicit user confirmation first -- wait for the user's next message before proceeding"
 
+// errDiscoveryRequiredBeforeDecision is returned by phaseGuardBefore's
+// #2098 (v1.6 clone #2099) ordering guard when kubernaut_present_decision is
+// attempted before kubernaut_discover_workflows has succeeded, in an
+// interaction mode where that ordering is load-bearing. Mirrors
+// errCheckpointBlocked's reject-and-let-the-model-retry pattern (DD-AF-011,
+// #1899) rather than enforceGroundingGuard's mutate-and-continue pattern:
+// unlike a fabrication risk, there is no honest content to substitute here,
+// so the correct remedy is for the model to call discover_workflows and retry.
+const errDiscoveryRequiredBeforeDecision = "kubernaut_discover_workflows has not been called yet -- call kubernaut_discover_workflows first, then retry kubernaut_present_decision"
+
 // noGroundedContentSummary is the fixed, honest payload #2047's (main clone
 // of #2023) grounding guard substitutes for present_decision's summary when
 // the most recent kubernaut_investigate produced no real content to
@@ -157,6 +167,14 @@ func phaseGuardBefore(ctx tool.Context, t tool.Tool, args map[string]any) (map[s
 	// AU-3 structured artifact is always emitted -- only a fabricated
 	// narrative is blocked.
 	if t.Name() == presentDecisionTool {
+		// #2098 (v1.6 clone #2099): reject-and-retry ordering guard,
+		// checked BEFORE the grounding guard runs -- a premature call must
+		// not even reach enforceGroundingGuard's mutation/masking logic.
+		if presentDecisionRequiresDiscoveryFirst(ctx.State()) {
+			logr.FromContextOrDiscard(ctx).Info("phase-guard blocked present_decision",
+				"tool", t.Name(), "reason", "discover_workflows_not_yet_succeeded")
+			return map[string]any{"error": errDiscoveryRequiredBeforeDecision}, nil
+		}
 		enforceGroundingGuard(ctx, args)
 		return nil, nil // nolint:nilnil
 	}
@@ -201,6 +219,45 @@ func driverIsActive(state adksession.State) bool {
 	}
 	b, ok := active.(bool)
 	return ok && b
+}
+
+// presentDecisionRequiresDiscoveryFirst implements #2098's (v1.6 clone
+// #2099) ordering guard: it reports whether kubernaut_present_decision must
+// be rejected because discover_workflows has not yet succeeded in this
+// driver session, in an interaction mode where that ordering actually
+// matters.
+//
+// Phase2Blocked == false means the declared mode does NOT gate
+// discover_workflows behind a human-confirmation checkpoint -- true for
+// full_remediation/full_remediation_autonomous, where the model is expected
+// to call discover_workflows autonomously before presenting a decision.
+// Reusing Phase2Blocked (rather than re-deriving interaction mode here)
+// means this gate automatically inherits #1918's rcaConcludedNotActionable
+// exemption for free: that override forces Phase2Blocked=true precisely
+// because no workflow discovery is expected in that case either.
+//
+// Fails open (never blocks) when state is nil or Phase2Blocked was never
+// set, matching InteractionModeInteractive's own fail-safe default
+// (interactionModeFromState) -- a present_decision call with no prior
+// investigate at all is enforceGroundingGuard's concern, not this gate's.
+func presentDecisionRequiresDiscoveryFirst(state adksession.State) bool {
+	if state == nil {
+		return false
+	}
+	phase2Blocked := true
+	if v, err := state.Get(session.StateKeyPhase2Blocked); err == nil {
+		if b, ok := v.(bool); ok {
+			phase2Blocked = b
+		}
+	}
+	if phase2Blocked {
+		return false
+	}
+	succeeded := false
+	if v, err := state.Get(session.StateKeyDiscoverWorkflowsSucceeded); err == nil {
+		succeeded, _ = v.(bool)
+	}
+	return !succeeded
 }
 
 // injectStoredRRID fills args["rr_id"] from session state when the caller
@@ -368,6 +425,11 @@ func recordDiscoverWorkflowsCheckpoint(ctx tool.Context) {
 	if err := state.Set(session.StateKeyPhase3Blocked, blocked); err != nil {
 		logger.Error(err, "phase-guard failed to persist phase3_blocked state")
 	}
+	// #2098 (v1.6 clone #2099): unblocks presentDecisionRequiresDiscoveryFirst's
+	// ordering guard for the remainder of this driver session.
+	if err := state.Set(session.StateKeyDiscoverWorkflowsSucceeded, true); err != nil {
+		logger.Error(err, "phase-guard failed to persist discover_workflows_succeeded state")
+	}
 }
 
 // recordDriverEntryState persists driver-active flag, rr_id, and session_id
@@ -418,6 +480,14 @@ func recordInteractionMode(state adksession.State, inputArgs, resp map[string]an
 	if err := state.Set(session.StateKeyInteractionMode, mode); err != nil {
 		logger.Error(err, "phase-guard failed to persist interaction mode")
 	}
+
+	// #2098 (v1.6 clone #2099): a fresh investigation must not inherit a
+	// discover_workflows_succeeded flag left by a prior RR in the same chat
+	// session.
+	if err := state.Set(session.StateKeyDiscoverWorkflowsSucceeded, false); err != nil {
+		logger.Error(err, "phase-guard failed to reset discover_workflows_succeeded state")
+	}
+
 	blocked := mode == session.InteractionModeInteractive
 
 	// #1918: harness-enforced actionability gate. Independent of the

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -790,9 +790,18 @@ func substituteGroundedRCA(state adksession.State, args map[string]any) {
 // execution-time args (defense-in-depth for the unblocked path, and for any
 // non-SSE consumer of the tool's own FunctionResponse) -- the two calls are
 // idempotent over the same underlying args map.
+// Both returns below are (nil, nil), per ADK's own AfterModelCallback
+// contract (google.golang.org/adk@v1.5.1/internal/llminternal/base_flow.go's
+// runAfterModelCallbacks): "(nil, nil) means no override -- the original
+// llmResponse/llmResponseErr flow through unchanged", as opposed to a
+// generically ambiguous nil-value success/lost-error. There is nothing to
+// sanitize when the model itself errored or returned no content (first
+// return), and the loop above already did its job by mutating
+// llmResponse.Content.Parts[*].FunctionCall.Args in place -- no replacement
+// response object is needed (second return).
 func sanitizePresentDecisionResponse(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseErr error) (*model.LLMResponse, error) {
 	if llmResponseErr != nil || llmResponse == nil || llmResponse.Content == nil {
-		return nil, nil
+		return nil, nil //nolint:nilerr,nilnil // see doc comment above: not an error path, ADK's own "no override" sentinel
 	}
 	for _, part := range llmResponse.Content.Parts {
 		if part == nil || part.FunctionCall == nil || part.FunctionCall.Name != presentDecisionTool {
@@ -803,7 +812,7 @@ func sanitizePresentDecisionResponse(ctx agent.CallbackContext, llmResponse *mod
 		}
 		enforceGroundingGuard(ctx, part.FunctionCall.Args)
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil // see doc comment above: ADK's own "no override" sentinel, not an ambiguous nil-value success
 }
 
 // enforceGroundingGuard implements #2047's (main clone of #2023) harness-side

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -21,7 +21,9 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/model"
 	adksession "google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
 
@@ -55,9 +57,8 @@ const errCheckpointBlocked = "this action requires explicit user confirmation fi
 // attempted before kubernaut_discover_workflows has succeeded, in an
 // interaction mode where that ordering is load-bearing. Mirrors
 // errCheckpointBlocked's reject-and-let-the-model-retry pattern (DD-AF-011,
-// #1899) rather than enforceGroundingGuard's mutate-and-continue pattern:
-// unlike a fabrication risk, there is no honest content to substitute here,
-// so the correct remedy is for the model to call discover_workflows and retry.
+// #1899): the real tool handler never runs, and the model is expected to
+// call discover_workflows and retry.
 const errDiscoveryRequiredBeforeDecision = "kubernaut_discover_workflows has not been called yet -- call kubernaut_discover_workflows first, then retry kubernaut_present_decision"
 
 // noGroundedContentSummary is the fixed, honest payload #2047's (main clone
@@ -167,15 +168,23 @@ func phaseGuardBefore(ctx tool.Context, t tool.Tool, args map[string]any) (map[s
 	// AU-3 structured artifact is always emitted -- only a fabricated
 	// narrative is blocked.
 	if t.Name() == presentDecisionTool {
-		// #2098 (v1.6 clone #2099): reject-and-retry ordering guard,
-		// checked BEFORE the grounding guard runs -- a premature call must
-		// not even reach enforceGroundingGuard's mutation/masking logic.
+		// #2098 (v1.6 clone #2099): enforceGroundingGuard also runs
+		// unconditionally here, before the ordering check below, even
+		// though this call may end up rejected -- defense-in-depth for the
+		// tool's own execution-time args (matters for the unblocked path
+		// and any non-SSE consumer of HandlePresentDecision's
+		// FunctionResponse). This is NOT what makes the AU-3 SSE artifact
+		// itself honest, though: sanitizePresentDecisionResponse (an
+		// AfterModelCallback, registered in root.go) is what actually
+		// closes that loop -- see its doc comment for why a
+		// BeforeToolCallback mutation alone is too late for that purpose
+		// (#2105, v1.6 clone #2106; E2E-AF-1396-001).
+		enforceGroundingGuard(ctx, args)
 		if presentDecisionRequiresDiscoveryFirst(ctx.State()) {
 			logr.FromContextOrDiscard(ctx).Info("phase-guard blocked present_decision",
 				"tool", t.Name(), "reason", "discover_workflows_not_yet_succeeded")
 			return map[string]any{"error": errDiscoveryRequiredBeforeDecision}, nil
 		}
-		enforceGroundingGuard(ctx, args)
 		return nil, nil // nolint:nilnil
 	}
 
@@ -755,6 +764,48 @@ func substituteGroundedRCA(state adksession.State, args map[string]any) {
 	}
 }
 
+// sanitizePresentDecisionResponse is an AfterModelCallback (registered in
+// root.go's AfterModelCallbacks) that applies enforceGroundingGuard's
+// grounding sanitization directly to the model's own raw
+// kubernaut_present_decision FunctionCall.Args, in place, immediately after
+// the model responds -- BEFORE ADK finalizes and yields that response as an
+// SSE event.
+//
+// #2105-regression (v1.6 clone #2106; E2E-AF-1396-001: ToolCallsCount 19
+// instead of the grounded 0): part_converter.go's emitDecisionEvent builds
+// the AU-3 decision artifact straight from this same FunctionCall (by
+// reference -- google.golang.org/adk@v1.5.1/internal/llminternal/base_flow.go's
+// runOneStep calls yield(modelResponseEvent, ...) at the point the model's
+// turn is finalized, and only afterwards calls handleFunctionCalls, which is
+// what invokes BeforeToolCallback/phaseGuardBefore). enforceGroundingGuard
+// mutating args from phaseGuardBefore -- the ONLY place it ran before this
+// callback existed -- therefore always ran too late to affect what the
+// client had already received for that artifact; it only ever reached
+// HandlePresentDecision's own FunctionResponse, which #1408 deliberately
+// suppresses from the SSE stream in favor of this FunctionCall-based
+// artifact. This callback closes that gap by running the identical
+// sanitization at the one point in the pipeline that precedes the yield.
+//
+// phaseGuardBefore still also calls enforceGroundingGuard on the tool's
+// execution-time args (defense-in-depth for the unblocked path, and for any
+// non-SSE consumer of the tool's own FunctionResponse) -- the two calls are
+// idempotent over the same underlying args map.
+func sanitizePresentDecisionResponse(ctx agent.CallbackContext, llmResponse *model.LLMResponse, llmResponseErr error) (*model.LLMResponse, error) {
+	if llmResponseErr != nil || llmResponse == nil || llmResponse.Content == nil {
+		return nil, nil
+	}
+	for _, part := range llmResponse.Content.Parts {
+		if part == nil || part.FunctionCall == nil || part.FunctionCall.Name != presentDecisionTool {
+			continue
+		}
+		if part.FunctionCall.Args == nil {
+			part.FunctionCall.Args = map[string]any{}
+		}
+		enforceGroundingGuard(ctx, part.FunctionCall.Args)
+	}
+	return nil, nil
+}
+
 // enforceGroundingGuard implements #2047's (main clone of #2023) harness-side
 // fabrication guard. Immediately before kubernaut_present_decision executes,
 // it checks whether the most recent kubernaut_investigate call (tracked via
@@ -775,7 +826,14 @@ func substituteGroundedRCA(state adksession.State, args map[string]any) {
 // overwritten with the exact structured facts KA's kubernaut_investigate
 // response reported, rather than trusting the LLM's own transcription of
 // those same facts into present_decision -- see substituteGroundedRCA.
-func enforceGroundingGuard(ctx tool.Context, args map[string]any) {
+//
+// #2105 (v1.6 clone #2106): takes agent.CallbackContext (rather than
+// tool.Context) so the identical sanitization can run from both this
+// function's original BeforeToolCallback call site (phaseGuardBefore) and
+// sanitizePresentDecisionResponse's AfterModelCallback call site above --
+// agent.CallbackContext is the narrower interface both ADK callback types
+// satisfy (State() is all this function needs).
+func enforceGroundingGuard(ctx agent.CallbackContext, args map[string]any) {
 	if args == nil {
 		return
 	}
@@ -849,7 +907,7 @@ func NewPhaseGuardWithRegistryForTest(registry *launcher.ActiveContextRegistry) 
 // actionable error) when the string is empty or does not parse as a JSON
 // array -- this must never mask genuinely malformed input as an
 // empty-but-valid payload (SI-11).
-func repairPresentDecisionOptions(ctx tool.Context, args map[string]any) {
+func repairPresentDecisionOptions(ctx agent.CallbackContext, args map[string]any) {
 	raw, ok := args["options"].(string)
 	if !ok {
 		return

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -720,6 +720,10 @@ func enforceGroundingGuard(ctx tool.Context, args map[string]any) {
 	}
 	if grounded {
 		substituteGroundedRCA(state, args)
+		// #2092 (v1.6 clone #2093): repair a JSON-double-encoded options
+		// payload before ADK's schema validation runs -- see
+		// repairPresentDecisionOptions' own doc comment.
+		repairPresentDecisionOptions(ctx, args)
 		return
 	}
 
@@ -752,4 +756,44 @@ func NewPhaseGuardWithRegistryForTest(registry *launcher.ActiveContextRegistry) 
 	func(tool.Context, tool.Tool, map[string]any, map[string]any, error) (map[string]any, error),
 ) {
 	return newPhaseGuard(registry)
+}
+
+// repairPresentDecisionOptions defensively repairs args["options"] when it
+// arrives as a JSON-encoded string instead of the native array
+// present_decision's schema requires (#2092): live evidence showed a model
+// emitting a fully-correct options payload, just double-encoded -- the
+// array serialized once, then that whole JSON blob wrapped again as a
+// string value. ADK's functionTool.Run (ConvertToWithJSONSchema,
+// google.golang.org/adk@v1.5.1/tool/functiontool/function.go) re-marshals
+// args and validates the result against the inferred schema immediately
+// after this callback returns, and a string where the schema declares
+// "type: array" fails that validation before HandlePresentDecision ever
+// runs -- the same "mutate args before schema validation" ordering
+// enforceGroundingGuard already relies on for rca/summary/options above.
+//
+// Only called from the grounded branch: the ungrounded branch above already
+// unconditionally overwrites options with a clean empty slice, so it can
+// never carry a stringified value in the first place.
+//
+// Left untouched (and thus still schema-rejected, surfacing a real,
+// actionable error) when the string is empty or does not parse as a JSON
+// array -- this must never mask genuinely malformed input as an
+// empty-but-valid payload (SI-11).
+func repairPresentDecisionOptions(ctx tool.Context, args map[string]any) {
+	raw, ok := args["options"].(string)
+	if !ok {
+		return
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return
+	}
+	var parsed []any
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		logr.FromContextOrDiscard(ctx).Info(
+			"present_decision options arrived as a string that is not valid JSON; leaving as-is for schema validation to reject",
+			"error", err.Error())
+		return
+	}
+	args["options"] = parsed
 }

--- a/pkg/apifrontend/agent/present_decision_options_2092_it_test.go
+++ b/pkg/apifrontend/agent/present_decision_options_2092_it_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/tool"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// runnableTool matches the unexported ADK runnableTool interface via
+// structural typing (same technique root_test.go's findTool already relies
+// on in this package) so this IT test can invoke the real,
+// schema-validating functiontool.New-constructed present_decision tool
+// directly -- the exact tool tools.NewPresentDecisionTool wires into
+// NewRootAgent's tool list in production.
+type runnableTool interface {
+	Run(ctx tool.Context, args any) (map[string]any, error)
+}
+
+// IT #2092: unlike present_decision_options_2092_test.go (which only
+// asserts on args mutation), this proves the repaired options value
+// actually survives ADK's real JSON-schema validation
+// (typeutil.ConvertToWithJSONSchema, invoked inside functionTool.Run) --
+// the exact step live evidence showed rejecting a JSON-double-encoded
+// options string before HandlePresentDecision ever ran. It mirrors
+// google.golang.org/adk's internal/llminternal/base_flow.go
+// Flow.callTool call sequence verbatim: BeforeToolCallbacks run first
+// (mutating fArgs in place), THEN tool.Run is invoked with the
+// (possibly-mutated) same map -- with neither step mocked out here.
+var _ = Describe("IT #2092 — present_decision options repair through real ADK schema validation", func() {
+	It("IT-AF-2092-001 (SI-10, SI-11): a JSON-double-encoded options string survives real functiontool.New schema validation once phaseGuardBefore repairs it", func() {
+		presentTool, err := tools.NewPresentDecisionTool()
+		Expect(err).NotTo(HaveOccurred())
+		runnable, ok := presentTool.(runnableTool)
+		Expect(ok).To(BeTrue(), "kubernaut_present_decision must implement the runnable Run(ctx, args) contract")
+
+		state := newMapState()
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "alice", Groups: []string{"sre"},
+		})
+		toolCtx := statefulToolContext{
+			fakeToolContext: fakeToolContext{Context: ctx},
+			state:           state,
+		}
+		before, after := NewPhaseGuardForTest()
+
+		// Ground the session exactly as a real kubernaut_investigate success
+		// would, so enforceGroundingGuard takes the passthrough branch this
+		// fix targets (the fail-closed ungrounded branch already forces
+		// options to a clean []any{} and can never carry a stringified
+		// value in the first place).
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-2092-it", "status": "completed",
+			"summary": "Deployment stuck in CrashLoopBackOff after a bad command override.",
+		}, nil)
+
+		optionsJSON := `[{"workflow_id":"wf-1","name":"crashloop-rollback-v1",` +
+			`"description":"Roll back to the previous known-good revision","recommended":true}]`
+		args := map[string]any{
+			"session_id": "sess-2092-it",
+			"summary":    "Root cause identified: bad command override.",
+			"rca": map[string]any{
+				"severity":   "critical",
+				"confidence": 0.9,
+				"target":     "Deployment/checkout-service",
+			},
+			"options": optionsJSON,
+		}
+
+		cbResult, cbErr := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(cbErr).NotTo(HaveOccurred())
+		Expect(cbResult).To(BeNil(), "present_decision must still be allowed to execute (AU-3 artifact mandate)")
+
+		result, runErr := runnable.Run(toolCtx, args)
+		Expect(runErr).NotTo(HaveOccurred(),
+			"#2092: real ADK schema validation (ConvertToWithJSONSchema) must accept the repaired native array -- "+
+				"before this fix, a JSON-double-encoded options string reached this point unmodified and was rejected here")
+		Expect(result).NotTo(BeNil())
+		Expect(result["presented"]).To(Equal(true))
+
+		message, _ := result["message"].(string)
+		Expect(message).To(ContainSubstring("crashloop-rollback-v1"),
+			"the repaired option must actually reach HandlePresentDecision's output, not just pass schema validation")
+	})
+
+	It("IT-AF-2092-002 (SI-11, regression guard): a genuinely malformed options string still fails real schema validation, proving the repair does not mask real errors", func() {
+		presentTool, err := tools.NewPresentDecisionTool()
+		Expect(err).NotTo(HaveOccurred())
+		runnable, ok := presentTool.(runnableTool)
+		Expect(ok).To(BeTrue())
+
+		state := newMapState()
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "alice", Groups: []string{"sre"},
+		})
+		toolCtx := statefulToolContext{
+			fakeToolContext: fakeToolContext{Context: ctx},
+			state:           state,
+		}
+		before, after := NewPhaseGuardForTest()
+
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-2092-it-2", "status": "completed",
+			"summary": "Deployment stuck in CrashLoopBackOff after a bad command override.",
+		}, nil)
+
+		args := map[string]any{
+			"session_id": "sess-2092-it-2",
+			"summary":    "Root cause identified.",
+			"rca": map[string]any{
+				"severity":   "critical",
+				"confidence": 0.9,
+				"target":     "Deployment/checkout-service",
+			},
+			"options": "this is not valid JSON at all {{{",
+		}
+
+		_, cbErr := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(cbErr).NotTo(HaveOccurred())
+
+		_, runErr := runnable.Run(toolCtx, args)
+		Expect(runErr).To(HaveOccurred(),
+			"a genuinely malformed options string must still be rejected by real schema validation, not silently masked as valid")
+	})
+})

--- a/pkg/apifrontend/agent/present_decision_options_2092_test.go
+++ b/pkg/apifrontend/agent/present_decision_options_2092_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/tool"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+)
+
+// #2092: live evidence showed a model emitting kubernaut_present_decision's
+// "options" argument as a JSON-encoded string (the array serialized once,
+// then the whole blob wrapped again as a string value) instead of a native
+// JSON array. ADK's functionTool.Run (ConvertToWithJSONSchema) rejects this
+// before HandlePresentDecision ever runs, and the agent's observed fallback
+// was to retry with empty options -- masking a real, high-confidence
+// workflow discovery as a false "no matching workflows". These tests prove
+// phaseGuardBefore repairs the stringified value in place, using the same
+// "mutate args before schema validation" technique #2023's grounding guard
+// already relies on for rca/summary/options.
+var _ = Describe("Phase Guard — present_decision options repair (#2092)", func() {
+	var (
+		state   *mapState
+		toolCtx tool.Context
+		before  func(tool.Context, tool.Tool, map[string]any) (map[string]any, error)
+		after   func(tool.Context, tool.Tool, map[string]any, map[string]any, error) (map[string]any, error)
+	)
+
+	BeforeEach(func() {
+		state = newMapState()
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "alice", Groups: []string{"sre"},
+		})
+		toolCtx = statefulToolContext{
+			fakeToolContext: fakeToolContext{Context: ctx},
+			state:           state,
+		}
+		before, after = NewPhaseGuardForTest()
+
+		// Ground the session so enforceGroundingGuard's options-passthrough
+		// branch is exercised (the ungrounded branch already unconditionally
+		// resets options to []any{}, so it needs no repair).
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-2092", "status": "completed",
+			"summary": "Deployment stuck in CrashLoopBackOff after a bad command override.",
+		}, nil)
+	})
+
+	It("UT-AF-2092-001 (SI-10): repairs a JSON-double-encoded options string into a native array", func() {
+		optionsJSON := `[{"workflow_id":"wf-1","name":"crashloop-rollback-v1","recommended":true},` +
+			`{"workflow_id":"wf-2","name":"rollback-deployment-v1"}]`
+		args := map[string]any{
+			"session_id": "sess-2092",
+			"summary":    "Root cause identified.",
+			"options":    optionsJSON,
+		}
+
+		result, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil(), "present_decision must still be allowed to execute (AU-3 artifact mandate)")
+
+		options, ok := args["options"].([]any)
+		Expect(ok).To(BeTrue(), "options must become a native []any, not remain a JSON string")
+		Expect(options).To(HaveLen(2))
+
+		first, ok := options[0].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(first["workflow_id"]).To(Equal("wf-1"))
+		Expect(first["name"]).To(Equal("crashloop-rollback-v1"))
+		Expect(first["recommended"]).To(Equal(true))
+	})
+
+	It("UT-AF-2092-002 (SI-10, SI-11, regression guard): leaves a genuinely malformed options string untouched", func() {
+		args := map[string]any{
+			"session_id": "sess-2092",
+			"summary":    "Root cause identified.",
+			"options":    "this is not valid JSON at all {{{",
+		}
+
+		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(args["options"]).To(Equal("this is not valid JSON at all {{{"),
+			"a genuinely malformed options string must be left as-is so ADK's real schema validation "+
+				"still rejects it with a useful error, instead of being silently masked as an empty-but-valid array")
+	})
+
+	It("UT-AF-2092-003 (regression guard): leaves an already-native options array untouched", func() {
+		args := map[string]any{
+			"session_id": "sess-2092",
+			"summary":    "Root cause identified.",
+			"options": []any{
+				map[string]any{"workflow_id": "wf-1", "name": "crashloop-rollback-v1"},
+			},
+		}
+
+		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		options, ok := args["options"].([]any)
+		Expect(ok).To(BeTrue())
+		Expect(options).To(HaveLen(1))
+		first, _ := options[0].(map[string]any)
+		Expect(first["workflow_id"]).To(Equal("wf-1"), "an already-native options array must not be double-processed")
+	})
+
+	It("UT-AF-2092-004 (regression guard): an empty options string is left untouched, not coerced to an empty array", func() {
+		args := map[string]any{
+			"session_id": "sess-2092",
+			"summary":    "Root cause identified.",
+			"options":    "",
+		}
+
+		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(args["options"]).To(Equal(""),
+			"an empty string is a distinct, already-ADK-schema-invalid case this repair should not mask either")
+	})
+})

--- a/pkg/apifrontend/agent/present_decision_ordering_2098_it_test.go
+++ b/pkg/apifrontend/agent/present_decision_ordering_2098_it_test.go
@@ -64,11 +64,19 @@ var _ = Describe("IT #2098 — present_decision ordering guard through the full 
 		Expect(invErr).NotTo(HaveOccurred())
 
 		// --- Ordering violation: present_decision called before discovery ---
+		// rca carries a fabricated tool_calls_count (mirroring a mock/hallucinated
+		// LLM payload) to prove the #2105 (v1.6 clone #2106) fix below: even though this
+		// call is rejected, part_converter.go's emitDecisionEvent reads these
+		// SAME args (by reference) directly off the model's raw FunctionCall to
+		// build the AU-3 SSE decision artifact, independent of this before
+		// callback's block/allow outcome -- so grounding must still sanitize
+		// args in place before the ordering check runs (E2E-AF-1396-001).
 		prematureArgs := map[string]any{
 			"session_id": "sess-2098-it",
 			"summary":    "should never reach HandlePresentDecision",
 			"rca": map[string]any{
 				"severity": "critical", "confidence": 0.9, "target": "Deployment/checkout-service",
+				"tool_calls_count": 19, "llm_turns": 17,
 			},
 			"options": []any{},
 		}
@@ -76,6 +84,14 @@ var _ = Describe("IT #2098 — present_decision ordering guard through the full 
 		Expect(cbErr).NotTo(HaveOccurred())
 		Expect(cbResult).NotTo(BeNil(), "the premature call must be rejected by the before callback")
 		Expect(cbResult["error"]).To(ContainSubstring("kubernaut_discover_workflows"))
+
+		rcaMap, ok := prematureArgs["rca"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(rcaMap["tool_calls_count"]).To(Equal(0),
+			"#2105 (v1.6 clone #2106): enforceGroundingGuard must still zero the fabricated tool_calls_count in place "+
+				"even when the call is rejected by the #2098 ordering guard, since the SSE decision artifact is "+
+				"built from these same (by-reference) args regardless of this callback's block/allow outcome")
+		Expect(rcaMap["llm_turns"]).To(Equal(0))
 
 		// --- Corrected ordering: discover_workflows runs, then retry ---
 		_, dwErr := after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil,

--- a/pkg/apifrontend/agent/present_decision_ordering_2098_it_test.go
+++ b/pkg/apifrontend/agent/present_decision_ordering_2098_it_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// IT #2098: drives the full newPhaseGuard before/after pair (the exact
+// callbacks root.go wires into NewRootAgent's BeforeToolCallbacks/
+// AfterToolCallbacks) through both orderings QE's live evidence and this
+// fix's regression concern cover, for full_remediation mode
+// (StateKeyPhase2Blocked == false): present_decision called first (must be
+// rejected, never reaching the real schema-validated tool), then
+// discover_workflows succeeding and present_decision retried (must reach
+// HandlePresentDecision and produce a real decision artifact).
+var _ = Describe("IT #2098 — present_decision ordering guard through the full phase-guard callback pair", func() {
+	It("IT-AF-2098-001 (AC-6): present_decision is rejected before discover_workflows, then succeeds once discovery has run, in full_remediation mode", func() {
+		presentTool, err := tools.NewPresentDecisionTool()
+		Expect(err).NotTo(HaveOccurred())
+		runnable, ok := presentTool.(runnableTool)
+		Expect(ok).To(BeTrue())
+
+		state := newMapState()
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "alice", Groups: []string{"sre"},
+		})
+		toolCtx := statefulToolContext{
+			fakeToolContext: fakeToolContext{Context: ctx},
+			state:           state,
+		}
+		before, after := NewPhaseGuardForTest()
+
+		// A real kubernaut_investigate success declaring full_remediation:
+		// sets Phase2Blocked=false (autonomous discovery expected) and
+		// grounds the session for enforceGroundingGuard.
+		_, invErr := after(toolCtx, fakeTool{name: "kubernaut_investigate"},
+			map[string]any{"rr_id": "rr-2098-it", "interaction_mode": session.InteractionModeFullRemediation},
+			map[string]any{
+				"session_id": "sess-2098-it", "rr_id": "rr-2098-it", "status": "completed",
+				"summary": "Deployment stuck in CrashLoopBackOff after a bad command override.",
+			}, nil)
+		Expect(invErr).NotTo(HaveOccurred())
+
+		// --- Ordering violation: present_decision called before discovery ---
+		prematureArgs := map[string]any{
+			"session_id": "sess-2098-it",
+			"summary":    "should never reach HandlePresentDecision",
+			"rca": map[string]any{
+				"severity": "critical", "confidence": 0.9, "target": "Deployment/checkout-service",
+			},
+			"options": []any{},
+		}
+		cbResult, cbErr := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, prematureArgs)
+		Expect(cbErr).NotTo(HaveOccurred())
+		Expect(cbResult).NotTo(BeNil(), "the premature call must be rejected by the before callback")
+		Expect(cbResult["error"]).To(ContainSubstring("kubernaut_discover_workflows"))
+
+		// --- Corrected ordering: discover_workflows runs, then retry ---
+		_, dwErr := after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil,
+			map[string]any{"workflows": []any{map[string]any{"workflow_id": "wf-1", "name": "crashloop-rollback-v1"}}}, nil)
+		Expect(dwErr).NotTo(HaveOccurred())
+
+		retryArgs := map[string]any{
+			"session_id": "sess-2098-it",
+			"summary":    "Root cause identified: bad command override.",
+			"rca": map[string]any{
+				"severity": "critical", "confidence": 0.9, "target": "Deployment/checkout-service",
+			},
+			"options": []any{
+				map[string]any{
+					"workflow_id": "wf-1", "name": "crashloop-rollback-v1",
+					"description": "Roll back to the previous known-good revision", "recommended": true,
+				},
+			},
+		}
+		cbResult2, cbErr2 := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, retryArgs)
+		Expect(cbErr2).NotTo(HaveOccurred())
+		Expect(cbResult2).To(BeNil(), "the retry after discover_workflows succeeded must be allowed through")
+
+		result, runErr := runnable.Run(toolCtx, retryArgs)
+		Expect(runErr).NotTo(HaveOccurred())
+		Expect(result["presented"]).To(Equal(true))
+
+		message, _ := result["message"].(string)
+		Expect(message).To(ContainSubstring("crashloop-rollback-v1"),
+			"the real decision must reach the user only after the correct discover_workflows -> present_decision ordering")
+	})
+})

--- a/pkg/apifrontend/agent/present_decision_ordering_2098_test.go
+++ b/pkg/apifrontend/agent/present_decision_ordering_2098_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/tool"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+)
+
+// #2098: live evidence (RR rr-6a97f7a00ba9-79ad53ed) showed
+// kubernaut_present_decision invoked and succeeding nine seconds before
+// kubernaut_discover_workflows even started in full_remediation mode --
+// the model rendered an empty decision despite a real workflow being
+// discovered moments later. newPhaseGuard's presentDecisionTool branch had
+// no ordering precondition at all. These tests prove a new before-callback
+// gate rejects present_decision (instructing the model to call
+// discover_workflows first) in exactly the modes where that ordering is
+// load-bearing (StateKeyPhase2Blocked == false), while never blocking the
+// legitimate cases where discover_workflows is skipped by design
+// (interactive mode, or #1918's rcaConcludedNotActionable override --
+// both of which force Phase2Blocked == true).
+var _ = Describe("Phase Guard — present_decision ordering guard (#2098)", func() {
+	var (
+		state   *mapState
+		toolCtx tool.Context
+		before  func(tool.Context, tool.Tool, map[string]any) (map[string]any, error)
+		after   func(tool.Context, tool.Tool, map[string]any, map[string]any, error) (map[string]any, error)
+	)
+
+	BeforeEach(func() {
+		state = newMapState()
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "alice", Groups: []string{"sre"},
+		})
+		toolCtx = statefulToolContext{
+			fakeToolContext: fakeToolContext{Context: ctx},
+			state:           state,
+		}
+		before, after = NewPhaseGuardForTest()
+	})
+
+	It("UT-AF-2098-001 (AC-6): rejects present_decision when Phase2Blocked==false and discover_workflows has not yet succeeded", func() {
+		Expect(state.Set(session.StateKeyPhase2Blocked, false)).To(Succeed())
+
+		args := map[string]any{
+			"session_id": "sess-2098",
+			"summary":    "should not be reached",
+		}
+		result, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil(), "present_decision must be rejected before discover_workflows has run")
+
+		errMsg, ok := result["error"].(string)
+		Expect(ok).To(BeTrue())
+		Expect(errMsg).To(ContainSubstring("kubernaut_discover_workflows"),
+			"the rejection must instruct the model to call discover_workflows first, mirroring DD-AF-011's reject-and-retry pattern")
+	})
+
+	It("UT-AF-2098-002 (AC-6): a successful discover_workflows call unblocks a subsequent present_decision call", func() {
+		Expect(state.Set(session.StateKeyPhase2Blocked, false)).To(Succeed())
+
+		_, dwErr := after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil,
+			map[string]any{"workflows": []any{map[string]any{"workflow_id": "wf-1"}}}, nil)
+		Expect(dwErr).NotTo(HaveOccurred())
+
+		args := map[string]any{"session_id": "sess-2098", "summary": "root cause identified"}
+		result, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil(), "present_decision must be allowed once discover_workflows has succeeded")
+	})
+
+	It("UT-AF-2098-003 (regression guard): present_decision is not blocked when Phase2Blocked==true even though discover_workflows never ran", func() {
+		Expect(state.Set(session.StateKeyPhase2Blocked, true)).To(Succeed())
+
+		args := map[string]any{"session_id": "sess-2098", "summary": "no remediation warranted"}
+		result, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil(),
+			"interactive mode (and #1918's rcaConcludedNotActionable override) both force Phase2Blocked=true and "+
+				"legitimately skip discover_workflows -- the ordering gate must not block these")
+	})
+
+	It("UT-AF-2098-004 (regression guard): a fresh kubernaut_investigate success resets discover_workflows_succeeded to false", func() {
+		Expect(state.Set(session.StateKeyPhase2Blocked, false)).To(Succeed())
+		_, dwErr := after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil,
+			map[string]any{"workflows": []any{}}, nil)
+		Expect(dwErr).NotTo(HaveOccurred())
+
+		v, getErr := state.Get(session.StateKeyDiscoverWorkflowsSucceeded)
+		Expect(getErr).NotTo(HaveOccurred())
+		Expect(v).To(Equal(true))
+
+		_, invErr := after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-2098-2", "rr_id": "rr-2", "status": "completed",
+			"summary": "a new, unrelated investigation",
+		}, nil)
+		Expect(invErr).NotTo(HaveOccurred())
+
+		v2, getErr2 := state.Get(session.StateKeyDiscoverWorkflowsSucceeded)
+		Expect(getErr2).NotTo(HaveOccurred())
+		Expect(v2).To(Equal(false),
+			"a second investigation in the same chat session must not inherit a stale success flag from a prior RR")
+	})
+})

--- a/pkg/apifrontend/agent/present_decision_response_sanitize_2105_test.go
+++ b/pkg/apifrontend/agent/present_decision_response_sanitize_2105_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/genai"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+)
+
+// #2105 (v1.6 clone #2106; E2E-AF-1396-001 regression from #2098):
+// part_converter.go's emitDecisionEvent builds the AU-3 SSE decision
+// artifact directly from the model's raw kubernaut_present_decision
+// FunctionCall, which ADK streams to the client BEFORE BeforeToolCallback
+// (phaseGuardBefore/enforceGroundingGuard) ever runs -- see
+// sanitizePresentDecisionResponse's doc comment (phase_guard.go) for the
+// exact ADK call sequence proving this ordering. These tests prove this
+// AfterModelCallback sanitizes the model's raw FunctionCall.Args in place,
+// at the one point in the pipeline that runs before that yield, so the
+// emitted decision artifact is grounded/honest regardless of whether the
+// tool call is later blocked (#2098) or succeeds.
+var _ = Describe("sanitizePresentDecisionResponse AfterModelCallback (#2105, v1.6 clone #2106)", func() {
+	newCtx := func(state *mapState) *statefulCallbackContext {
+		return &statefulCallbackContext{
+			stubCallbackContext: &stubCallbackContext{Context: context.Background()},
+			state:               state,
+		}
+	}
+
+	presentDecisionResponse := func(fabricatedToolCallsCount, fabricatedLLMTurns int) *model.LLMResponse {
+		return &model.LLMResponse{
+			Content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{
+						FunctionCall: &genai.FunctionCall{
+							Name: presentDecisionTool,
+							Args: map[string]any{
+								"session_id": "sess-2105",
+								"summary":    "Root cause identified: bad command override.",
+								"rca": map[string]any{
+									"severity": "critical", "confidence": 0.9,
+									"target":           "Deployment/checkout-service",
+									"tool_calls_count": fabricatedToolCallsCount,
+									"llm_turns":        fabricatedLLMTurns,
+								},
+								"options": []any{},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	It("UT-AF-2105-001 (AU-3): zeros a fabricated tool_calls_count/llm_turns on the raw FunctionCall.Args when grounded", func() {
+		state := newMapState()
+		Expect(state.Set(session.StateKeyGroundedContentAvailable, true)).To(Succeed())
+
+		resp := presentDecisionResponse(19, 17)
+		out, err := sanitizePresentDecisionResponse(newCtx(state), resp, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeNil(), "must mutate in place and return nil to let ADK use the original (now-sanitized) response")
+
+		fc := resp.Content.Parts[0].FunctionCall
+		rcaMap, ok := fc.Args["rca"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(rcaMap["tool_calls_count"]).To(Equal(0),
+			"the model's fabricated count must be zeroed on the SAME object ADK streams to the SSE client")
+		Expect(rcaMap["llm_turns"]).To(Equal(0))
+	})
+
+	It("UT-AF-2105-002 (regression guard): overwrites args with the honest no-data payload when ungrounded", func() {
+		state := newMapState() // StateKeyGroundedContentAvailable never set -> ungrounded
+
+		resp := presentDecisionResponse(19, 17)
+		out, err := sanitizePresentDecisionResponse(newCtx(state), resp, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeNil())
+
+		fc := resp.Content.Parts[0].FunctionCall
+		Expect(fc.Args["summary"]).To(Equal(noGroundedContentSummary))
+		Expect(fc.Args["rca"]).To(Equal(emptyRCAPayload))
+	})
+
+	It("UT-AF-2105-003 (regression guard): leaves unrelated FunctionCalls untouched", func() {
+		state := newMapState()
+		resp := &model.LLMResponse{
+			Content: &genai.Content{
+				Parts: []*genai.Part{
+					{FunctionCall: &genai.FunctionCall{Name: "kubernaut_investigate", Args: map[string]any{"name": "pod-1"}}},
+				},
+			},
+		}
+
+		out, err := sanitizePresentDecisionResponse(newCtx(state), resp, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeNil())
+		Expect(resp.Content.Parts[0].FunctionCall.Args).To(Equal(map[string]any{"name": "pod-1"}),
+			"only kubernaut_present_decision FunctionCalls are sanitized")
+	})
+
+	It("UT-AF-2105-004 (regression guard): handles a nil/errored/contentless response without panicking", func() {
+		state := newMapState()
+
+		out, err := sanitizePresentDecisionResponse(newCtx(state), nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeNil())
+
+		out, err = sanitizePresentDecisionResponse(newCtx(state), &model.LLMResponse{}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeNil())
+
+		out, err = sanitizePresentDecisionResponse(newCtx(state), presentDecisionResponse(19, 17), context.DeadlineExceeded)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeNil())
+	})
+})

--- a/pkg/apifrontend/agent/root.go
+++ b/pkg/apifrontend/agent/root.go
@@ -89,6 +89,7 @@ func NewRootAgent(cfg AgentConfig, opts ...Option) (agent.Agent, []tool.Tool, er
 		Instruction:          cfg.Instruction,
 		InstructionProvider:  cfg.InstructionProvider,
 		BeforeModelCallbacks: []llmagent.BeforeModelCallback{historySanitizer, checkpointToolFilter},
+		AfterModelCallbacks:  []llmagent.AfterModelCallback{sanitizePresentDecisionResponse},
 		BeforeToolCallbacks:  beforeCallbacks,
 		AfterToolCallbacks:   []llmagent.AfterToolCallback{afterMetrics, afterAudit, afterPhase, afterLog},
 	})

--- a/pkg/apifrontend/session/consent.go
+++ b/pkg/apifrontend/session/consent.go
@@ -55,6 +55,21 @@ const (
 	// kubernaut_select_workflow may run.
 	StateKeyPhase3Blocked = "af_phase3_blocked"
 
+	// StateKeyDiscoverWorkflowsSucceeded records whether
+	// kubernaut_discover_workflows has completed successfully at least
+	// once in the current driver session (#2098). phase_guard.go's
+	// before-callback reads this to reject a premature
+	// kubernaut_present_decision call in interaction modes that don't
+	// otherwise gate discover_workflows behind a human-confirmation
+	// checkpoint (StateKeyPhase2Blocked == false --
+	// full_remediation/full_remediation_autonomous). Reset to false on
+	// every fresh kubernaut_investigate (never kubernaut_reconnect,
+	// matching StateKeyPhase2Blocked/StateKeyInteractionMode's own
+	// investigate-only reset) so a second investigation in the same chat
+	// session can't inherit a stale "discovery already happened" flag
+	// from a prior RemediationRequest.
+	StateKeyDiscoverWorkflowsSucceeded = "af_discover_workflows_succeeded"
+
 	// StateKeyGroundedContentAvailable records whether the most recent
 	// kubernaut_investigate call produced real, groundable RCA content
 	// (#2047, main clone of #2023). phase_guard.go's harness-enforced

--- a/pkg/apifrontend/tools/ka_investigate_bridge.go
+++ b/pkg/apifrontend/tools/ka_investigate_bridge.go
@@ -21,7 +21,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
+
+	"github.com/go-logr/logr"
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
@@ -420,12 +423,42 @@ func emitEventToA2A(ctx context.Context, evt ka.InvestigationEvent, text string)
 	}
 }
 
+// watchTerminalEventsSafetyNetNs bounds how long WatchTerminalEvents will
+// wait for a terminal event before giving up (#2094, v1.6 clone #2095). It
+// is deliberately much larger than KA's own inactivity timeout (~10m
+// default) or DefaultSessionTTL (30m per ka/session_pool.go) so it never
+// fires for a legitimately long-running session -- it only bounds the case
+// where the expected session_ended/done signal is truly lost (a pool
+// onRelease callback that never fires, or a dropped events channel). Stored
+// as an atomic.Int64 (nanoseconds) rather than a plain var: WatchTerminalEvents
+// reads it from a newly-spawned goroutine with no happens-before
+// relationship to a test's setup/teardown, so a plain var would be a data
+// race under -race whenever a test overrides it via
+// SetWatchTerminalEventsSafetyNetForTest while a previously-spawned watcher
+// goroutine is still starting up.
+var watchTerminalEventsSafetyNetNs atomic.Int64
+
+func init() {
+	watchTerminalEventsSafetyNetNs.Store(int64(30 * time.Minute))
+}
+
+// SetWatchTerminalEventsSafetyNetForTest overrides the WatchTerminalEvents
+// safety-net timeout for the duration of a test. Test-only. Returns a
+// restore function that must be deferred to reset the previous value.
+func SetWatchTerminalEventsSafetyNetForTest(d time.Duration) (restore func()) {
+	prev := watchTerminalEventsSafetyNetNs.Swap(int64(d))
+	return func() { watchTerminalEventsSafetyNetNs.Store(prev) }
+}
+
 // WatchTerminalEvents watches a residual event channel for events arriving
 // on a pooled MCP session after handoff. When a session_ended event is
 // received, it emits a terminal TaskStatusUpdateEvent to the A2A queue via
 // the EventBridge in ctx and exits. Exits deterministically on:
-// session_ended received, events closed, or done closed (pool
-// Release/EvictIdle/DrainAll). No timer-based safety net. #1438, SI-4.
+// session_ended received, events closed, done closed (pool
+// Release/EvictIdle/DrainAll), or the safety-net timer
+// (watchTerminalEventsSafetyNetNs) elapsing (#2094, v1.6 clone #2095). The
+// safety-net timer is created once, before the loop, so a steady stream of
+// non-terminal events cannot indefinitely postpone the deadline.
 //
 // relay is non-nil only for entries handed off via KASessionPool.InjectVerified
 // (#1637/DD-AF-009). When a pooled call (kubernaut_message,
@@ -437,6 +470,10 @@ func emitEventToA2A(ctx context.Context, evt ka.InvestigationEvent, text string)
 // relay.Current() is nil), behavior is unchanged from #1438: non-terminal
 // events are dropped, and the terminal event uses the watcher's own ctx.
 func WatchTerminalEvents(ctx context.Context, events <-chan ka.InvestigationEvent, rrID string, done <-chan struct{}, relay *ka.EventRelay) {
+	safetyNetTimeout := time.Duration(watchTerminalEventsSafetyNetNs.Load())
+	safetyNet := time.NewTimer(safetyNetTimeout)
+	defer safetyNet.Stop()
+
 	for {
 		select {
 		case evt, ok := <-events:
@@ -450,6 +487,11 @@ func WatchTerminalEvents(ctx context.Context, events <-chan ka.InvestigationEven
 			relayLiveEvent(relay, evt) //nolint:contextcheck // relayLiveEvent deliberately ignores the watcher's own ctx and sources relay.Current() instead -- the whole point is to relay onto whichever pooled call's ctx is currently in flight, not the watcher's detached one
 		case <-done:
 			drainBufferedTerminalEvent(relayCtxOrDefault(relay, ctx), events)
+			return
+		case <-safetyNet.C:
+			logr.FromContextOrDiscard(ctx).Info(
+				"WatchTerminalEvents: safety-net timeout reached without a terminal event; exiting to prevent goroutine leak",
+				"rr_id", rrID, "timeout", safetyNetTimeout)
 			return
 		}
 	}

--- a/pkg/apifrontend/tools/terminal_event_2094_it_test.go
+++ b/pkg/apifrontend/tools/terminal_event_2094_it_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// countWatchTerminalEventsGoroutines returns the number of currently running
+// goroutines executing tools.WatchTerminalEvents, by scanning a full stack
+// dump. Used by IT-AF-2094-001 to prove the production-spawned watcher
+// goroutine actually exits, rather than relying on an indirect signal.
+func countWatchTerminalEventsGoroutines() int {
+	buf := make([]byte, 4<<20)
+	n := runtime.Stack(buf, true)
+	return bytes.Count(buf[:n], []byte("tools.WatchTerminalEvents("))
+}
+
+var _ = Describe("IT #2094 — WatchTerminalEvents safety net through production path", func() {
+
+	It("IT-AF-2094-001 (SI-11, AU-3): watcher spawned via HandleInvestigationMCPWithRegistry exits on its own when the terminal signal is permanently lost", func() {
+		defer tools.SetWatchTerminalEventsSafetyNetForTest(30 * time.Millisecond)()
+
+		// Unbuffered and never written to: simulates a pool onRelease
+		// callback that never fires and a KA session that never emits
+		// session_ended -- the exact live #2094 hang scenario.
+		eventCh := make(chan ka.InvestigationEvent)
+		sess := &mockPoolSession{}
+
+		mockMCP := &ka.MockMCPClient{
+			StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+				return &ka.StartInvestigationResult{
+					SessionID: "sess-it-2094-001",
+					Status:    "started",
+					Events:    eventCh,
+					Closer:    func() {},
+					Session:   sess,
+				}, nil
+			},
+		}
+
+		pool := ka.NewKASessionPool(ka.PoolConfig{
+			Factory: func(_ context.Context) (ka.PoolSession, error) {
+				return &mockPoolSession{}, nil
+			},
+			MaxEntries: 10,
+			Logger:     logr.Discard(),
+		})
+
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-it-2094-001", "ctx-it-2094-001", nil)
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		before := countWatchTerminalEventsGoroutines()
+
+		_, err := tools.HandleInvestigationMCPWithRegistry(
+			ctx, &tools.InvestigateConfig{
+				MCPClient: mockMCP,
+				Pool:      pool,
+			}, tools.InvestigateMCPArgs{RRID: "rr-it-2094-001"},
+			true, "alice",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// 2s (rather than a tighter window) absorbs scheduling jitter under
+		// -race and full-suite CPU contention: this assertion only proves
+		// the goroutine was spawned at all, so a generous window costs
+		// nothing but flakiness-resistance.
+		Eventually(countWatchTerminalEventsGoroutines, 2*time.Second, 5*time.Millisecond).Should(
+			BeNumerically(">", before),
+			"production path must have spawned the real WatchTerminalEvents goroutine")
+
+		// #2094: before the fix, nothing in this scenario ever unblocks the
+		// watcher (no onRelease call, no session_ended, and watchCtx is
+		// detached via context.WithoutCancel so this outer ctx's own
+		// timeout is irrelevant to it). It must rely entirely on the
+		// safety-net timer (shortened to 30ms above) to exit.
+		Eventually(countWatchTerminalEventsGoroutines, 3*time.Second, 10*time.Millisecond).Should(
+			Equal(before),
+			"#2094: WatchTerminalEvents spawned via the real production path must exit on its own "+
+				"once the safety-net timer fires, instead of leaking forever when the terminal signal is lost")
+	})
+})

--- a/pkg/apifrontend/tools/watch_terminal_events_2094_test.go
+++ b/pkg/apifrontend/tools/watch_terminal_events_2094_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// #2094: WatchTerminalEvents previously had no timer-based safety net -- a
+// lost session_ended event (pool onRelease callback never firing, dropped
+// events channel) left the goroutine blocked forever. These tests prove a
+// bounded safety-net timer exists and does not regress the two pre-existing
+// deterministic exit paths (#1438).
+var _ = Describe("WatchTerminalEvents safety-net timer — #2094", func() {
+	var restoreSafetyNet func()
+
+	BeforeEach(func() {
+		restoreSafetyNet = tools.SetWatchTerminalEventsSafetyNetForTest(30 * time.Millisecond)
+	})
+
+	AfterEach(func() {
+		restoreSafetyNet()
+	})
+
+	It("UT-AF-2094-001 (SI-11, AU-3): exits via the safety-net timer when neither events nor done ever fire", func() {
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2094-001", "ctx-2094-001", nil)
+
+		events := make(chan ka.InvestigationEvent)
+		done := make(chan struct{})
+
+		exited := make(chan struct{})
+		go func() {
+			tools.WatchTerminalEvents(ctx, events, "rr-2094-001", done, nil)
+			close(exited)
+		}()
+
+		Eventually(exited, 2*time.Second, 5*time.Millisecond).Should(BeClosed(),
+			"#2094: WatchTerminalEvents must exit on its own once the safety-net timer fires, "+
+				"instead of blocking forever on a lost terminal signal")
+	})
+
+	It("UT-AF-2094-002 (regression guard): still exits immediately on session_ended, safety net does not interfere", func() {
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2094-002", "ctx-2094-002", nil)
+
+		events := make(chan ka.InvestigationEvent, 1)
+		done := make(chan struct{})
+		events <- ka.InvestigationEvent{Type: ka.EventTypeSessionEnded, Phase: "inactivity_timeout"}
+
+		exited := make(chan struct{})
+		go func() {
+			tools.WatchTerminalEvents(ctx, events, "rr-2094-002", done, nil)
+			close(exited)
+		}()
+
+		// Must exit well before the (shortened) safety-net window elapses,
+		// proving the happy path is unaffected by the new timer.
+		Eventually(exited, 15*time.Millisecond, time.Millisecond).Should(BeClosed(),
+			"session_ended must still exit the watcher immediately, not wait for the safety net")
+
+		Expect(queue.Events()).NotTo(BeEmpty(), "AU-3: terminal status event must still be emitted")
+	})
+
+	It("UT-AF-2094-003 (regression guard): still drains a buffered session_ended on done closing before the safety net", func() {
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2094-003", "ctx-2094-003", nil)
+
+		events := make(chan ka.InvestigationEvent, 1)
+		done := make(chan struct{})
+		events <- ka.InvestigationEvent{Type: ka.EventTypeSessionEnded, Phase: "disconnect"}
+		close(done)
+
+		exited := make(chan struct{})
+		go func() {
+			tools.WatchTerminalEvents(ctx, events, "rr-2094-003", done, nil)
+			close(exited)
+		}()
+
+		Eventually(exited, 15*time.Millisecond, time.Millisecond).Should(BeClosed(),
+			"#1438 priority-drain on done closing must still exit immediately, not wait for the safety net")
+
+		Expect(queue.Events()).NotTo(BeEmpty(), "AU-3: drained session_ended must still be emitted")
+	})
+})

--- a/test/integration/kubernautagent/mcp/session_janitor_wiring_2100_test.go
+++ b/test/integration/kubernautagent/mcp/session_janitor_wiring_2100_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+)
+
+// #2100: IT-KA-DES-005/006 (disconnect_handler_test.go) already prove
+// SessionJanitor's own Track/sweep/Untrack logic in isolation — but
+// NewSessionJanitor had zero production callers (confirmed via
+// grep -rn NewSessionJanitor --include=*.go .), so that coverage never
+// proved the janitor could ever fire for a real interactive session.
+// These tests exercise the actual chokepoint wiring added to
+// LeaseSessionManager.Takeover/Release (session_manager.go's
+// WithSessionJanitor option) against a real envtest API server and real
+// coordination.k8s.io/Lease objects — the same wiring buildMCPHandler
+// (cmd/kubernautagent/main.go) uses in production.
+var _ = Describe("LeaseSessionManager + SessionJanitor wiring IT — #2100 SC-5/AU-12", Label("integration", "interactive"), func() {
+
+	Describe("IT-KA-2100-001: Takeover Tracks the session with the janitor; Release Untracks it (real Lease)", func() {
+		It("should leave no Lease behind after a clean Release, and never let the janitor fire for it", func() {
+			nsName := uniqueNamespace("janitor-2100-001")
+			createNamespace(context.Background(), sharedK8sClient, nsName)
+
+			logger := logr.Discard()
+			// Long interval: the janitor must never sweep during this test —
+			// proves Release's Untrack call, not the sweep's own expiry logic
+			// (already covered by IT-KA-DES-005/006).
+			janitor := mcpinternal.NewSessionJanitor(1*time.Hour, logger)
+			janitorCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go janitor.Run(janitorCtx)
+
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(sharedK8sClient, nsName, logger,
+				mcpinternal.WithSessionJanitor(janitor))
+
+			user := mcpinternal.UserInfo{Username: "sre-2100-001@example.com", Groups: []string{"sre"}}
+			sess, err := mgr.Takeover(context.Background(), "rr-2100-001", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(janitor.TrackedForTest(sess.SessionID)).To(BeTrue(),
+				"#2100: Takeover success must Track the session with the janitor via the real production wiring path")
+
+			leaseList := &coordinationv1.LeaseList{}
+			Expect(sharedK8sClient.List(context.Background(), leaseList, client.InNamespace(nsName))).To(Succeed())
+			Expect(leaseList.Items).To(HaveLen(1), "Takeover must still create the real Lease as before")
+
+			Expect(mgr.Release(sess.SessionID, "test_done")).To(Succeed())
+			Expect(janitor.TrackedForTest(sess.SessionID)).To(BeFalse(),
+				"#2100: Release must Untrack the session so the janitor never fires for a cleanly-released session")
+
+			leaseList = &coordinationv1.LeaseList{}
+			Expect(sharedK8sClient.List(context.Background(), leaseList, client.InNamespace(nsName))).To(Succeed())
+			Expect(leaseList.Items).To(BeEmpty(), "Release must still delete the real Lease as before")
+		})
+	})
+
+	Describe("IT-KA-2100-002: a session Tracked via Takeover but never Released is reclaimed by the janitor sweep (real Lease deleted)", func() {
+		It("should have the janitor's onExpire route through Release, deleting the real Lease object", func() {
+			nsName := uniqueNamespace("janitor-2100-002")
+			createNamespace(context.Background(), sharedK8sClient, nsName)
+
+			logger := logr.Discard()
+			janitor := mcpinternal.NewSessionJanitor(100*time.Millisecond, logger)
+			janitorCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go janitor.Run(janitorCtx)
+
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(sharedK8sClient, nsName, logger,
+				mcpinternal.WithSessionJanitor(janitor))
+
+			user := mcpinternal.UserInfo{Username: "sre-2100-002@example.com", Groups: []string{"sre"}}
+			_, err := mgr.Takeover(context.Background(), "rr-2100-002", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() *mcpinternal.InteractiveSession {
+				driver, _ := mgr.GetDriver("rr-2100-002")
+				return driver
+			}, 5*time.Second, 50*time.Millisecond).Should(BeNil(),
+				"#2100: the orphaned session must be reclaimed by the janitor's backstop sweep")
+
+			leaseList := &coordinationv1.LeaseList{}
+			Expect(sharedK8sClient.List(context.Background(), leaseList, client.InNamespace(nsName))).To(Succeed())
+			Expect(leaseList.Items).To(BeEmpty(),
+				"#2100: the janitor's onExpire callback must have deleted the real Lease object via Release, closing the SC-5 capacity-exhaustion gap")
+		})
+	})
+})

--- a/test/integration/kubernautagent/mcp/session_manager_metrics_2103_it_test.go
+++ b/test/integration/kubernautagent/mcp/session_manager_metrics_2103_it_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp_test
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+)
+
+// recordingSessionEndedMetricsIT is a concurrency-safe SessionEndedMetrics
+// recorder for IT assertions -- the SessionJanitor's sweep (IT-KA-2103-002)
+// fires the callback from its own background goroutine, so a plain int
+// counter would race with the test's read.
+type recordingSessionEndedMetricsIT struct {
+	endedCount atomic.Int64
+}
+
+func (m *recordingSessionEndedMetricsIT) RecordInteractiveSessionEnded() {
+	m.endedCount.Add(1)
+}
+
+// #2103: aiagent_mcp_interactive_sessions_active drifted upward over time
+// because several production Release() callers -- CompleteNoActionTool,
+// SelectWorkflowTool's async release, InvestigateTool's no_matching_workflows
+// auto-close, and the SessionJanitor's onExpire backstop -- released the
+// underlying Lease correctly but never called RecordInteractiveSessionEnded,
+// so the gauge never came back down even though capacity was reclaimed.
+//
+// The fix centralizes the decrement inside LeaseSessionManager.Release()
+// itself (WithSessionEndedMetrics), so every current and future caller gets
+// it for free. These IT tests exercise that production wiring against a
+// real envtest API server and real coordination.k8s.io/Lease objects -- the
+// same wiring buildMCPHandler (cmd/kubernautagent/main.go) uses -- covering
+// both call shapes that existed pre-fix:
+//   - an explicit Release() call from a tool handler (stands in for
+//     complete_no_action / workflow_selected / no_matching_workflows, which
+//     all bottom out in the same mgr.Release(sessionID, reason) call with
+//     only the reason string differing)
+//   - the SessionJanitor's onExpire callback, which also routes through
+//     Release() (janitor_expired)
+var _ = Describe("LeaseSessionManager + SessionEndedMetrics wiring IT — #2103 SI-4 (metrics integrity)", Label("integration", "interactive"), func() {
+
+	Describe("IT-KA-2103-001: an explicit Release call decrements the wired gauge exactly once (complete_no_action / workflow_selected / no_matching_workflows shape)", func() {
+		It("should call RecordInteractiveSessionEnded exactly once per real Release, regardless of the reason string", func() {
+			nsName := uniqueNamespace("metrics-2103-001")
+			createNamespace(context.Background(), sharedK8sClient, nsName)
+
+			logger := logr.Discard()
+			metrics := &recordingSessionEndedMetricsIT{}
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(sharedK8sClient, nsName, logger,
+				mcpinternal.WithSessionEndedMetrics(metrics))
+
+			for i, reason := range []string{"complete_no_action", "workflow_selected", "no_matching_workflows"} {
+				user := mcpinternal.UserInfo{Username: "sre-2103-001@example.com", Groups: []string{"sre"}}
+				sess, err := mgr.Takeover(context.Background(), "rr-2103-001", user)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(mgr.Release(sess.SessionID, reason)).To(Succeed())
+				Expect(metrics.endedCount.Load()).To(Equal(int64(i+1)),
+					"#2103: Release(reason=%q) must call the wired SessionEndedMetrics through the real "+
+						"production chokepoint, same as every other Release() caller", reason)
+			}
+		})
+	})
+
+	Describe("IT-KA-2103-002: the SessionJanitor's onExpire sweep decrements the wired gauge too (janitor_expired shape)", func() {
+		It("should have the janitor's backstop Release call the wired SessionEndedMetrics, closing the original SI-4 gap", func() {
+			nsName := uniqueNamespace("metrics-2103-002")
+			createNamespace(context.Background(), sharedK8sClient, nsName)
+
+			logger := logr.Discard()
+			metrics := &recordingSessionEndedMetricsIT{}
+			janitor := mcpinternal.NewSessionJanitor(100*time.Millisecond, logger)
+			janitorCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go janitor.Run(janitorCtx)
+
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(sharedK8sClient, nsName, logger,
+				mcpinternal.WithSessionJanitor(janitor),
+				mcpinternal.WithSessionEndedMetrics(metrics))
+
+			user := mcpinternal.UserInfo{Username: "sre-2103-002@example.com", Groups: []string{"sre"}}
+			_, err := mgr.Takeover(context.Background(), "rr-2103-002", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(metrics.endedCount.Load()).To(Equal(int64(0)), "must not decrement before the janitor sweeps")
+
+			Eventually(func() *mcpinternal.InteractiveSession {
+				driver, _ := mgr.GetDriver("rr-2103-002")
+				return driver
+			}, 5*time.Second, 50*time.Millisecond).Should(BeNil(),
+				"#2100: the orphaned session must be reclaimed by the janitor's backstop sweep")
+
+			Eventually(func() int64 {
+				return metrics.endedCount.Load()
+			}, 5*time.Second, 50*time.Millisecond).Should(Equal(int64(1)),
+				"#2103: the janitor's onExpire callback routes through the same Release() chokepoint, "+
+					"so it must decrement the gauge too -- pre-fix this path never did, driving the metric-only drift")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Ports the fixes from #2102 and #2107 (both merged to `release/v1.5`) forward to `main` (`v1.6`), closing the `v1.6` clone issues for all six tracks:

- **Track 1 (#2093, clone of #2092)** -- `kubernaut_present_decision` failed ADK schema validation when a model double-JSON-encoded an otherwise-correct `options` array. `repairPresentDecisionOptions` repairs it back to a native array inside the existing grounding-guard callback, before ADK's schema check runs. Malformed/unparseable strings are left untouched so schema validation still surfaces a real error (SI-11).
- **Track 2 (#2099, clone of #2098)** -- `kubernaut_present_decision` was callable before `kubernaut_discover_workflows` ever ran in `full_remediation`/`full_remediation_autonomous` modes. `presentDecisionRequiresDiscoveryFirst` adds a reject-and-retry ordering guard backed by a new `StateKeyDiscoverWorkflowsSucceeded` session-state flag.
- **Track 3 (#2095, clone of #2094)** -- `WatchTerminalEvents` (a detached, `context.WithoutCancel` goroutine) had no exit path if its underlying stream went silent without erroring, observed under QE load testing as a goroutine leak. Adds a 30-minute (test-overridable) `time.NewTimer` safety net as an additional exit condition.
- **Track 4 (#2101, clone of #2100)** -- `interactive.maxConcurrentSessions` capacity eroded under QE's concurrent-session load test. Two independent leaks fixed: `SessionJanitor` (fully implemented, never wired) is now constructed and wired into `LeaseSessionManager` via `Track`/`Untrack`; `InvestigateTool.handleStart`'s fallback-exhausted branch now releases its just-acquired Lease immediately and fails closed with `ErrCodeNoInvestigationAvailable` instead of returning a hollow "started" response.
- **Track 5 (#2106, clone of #2105)** -- the AU-3 `present_decision` SSE decision artifact was built directly from the model's raw `FunctionCall`, which ADK yields to the client *before* any `BeforeToolCallback` (where grounding sanitization ran) is ever invoked -- leaving ungrounded `tool_calls_count`/`llm_turns` in the emitted artifact. Adds `sanitizePresentDecisionResponse`, a new `AfterModelCallback` that applies the same grounding sanitization directly to the model's response immediately after it responds, before ADK finalizes and streams the SSE event.
- **Track 6 (#2104, clone of #2103)** -- `aiagent_mcp_interactive_sessions_active` only decremented on explicit complete/cancel and two `main.go`-owned callbacks; every other completion path (`complete_no_action`, `workflow_selected`, `no_matching_workflows`, and Track 4's own new `SessionJanitor` backstop) leaked the gauge (observability-only; real Lease/`activeCount` bookkeeping was unaffected). Centralizes the decrement inside `LeaseSessionManager.Release()` itself via a new `WithSessionEndedMetrics` option.

## Business Requirement

`BR-INTERACTIVE-007`, `BR-INTERACTIVE-008`, `BR-AUDIT-005`, `BR-WORKFLOW-004`

## Changes

Identical fixes to #2102/#2107, cherry-picked from `release/v1.5` and reconciled against `main`'s independent divergence since the branch point. `main` had already refactored several of the touched files, so the incoming changes were manually re-applied to their `main`-branch equivalents rather than the conflict being resolved mechanically:

- `WatchTerminalEvents` moved from `pkg/apifrontend/tools/ka_investigate_mcp.go` to `pkg/apifrontend/tools/ka_investigate_bridge.go` -- Track 3's safety-net timer was re-applied there.
- `buildMCPHandler` moved from `cmd/kubernautagent/main.go` to `cmd/kubernautagent/routes.go` -- Track 4's `SessionJanitor` wiring and Track 6's `WithSessionEndedMetrics` wiring were re-applied there.
- `InvestigateTool.handleStart` moved from `internal/kubernautagent/mcp/tools/investigate.go` to `investigate_start.go` (with `handleComplete`/`handleCancel` split into `investigate_takeover.go`/`investigate_autonomous.go`) -- Track 4's fail-closed fallback-exhausted branch and Track 6's `RecordInteractiveSessionStarted`/`RecordInteractiveSessionEnded` symmetry fix were re-applied across these three files.
- `pkg/apifrontend/agent/phase_guard.go` had already independently grown overlapping grounding logic on `main` from earlier backports -- Track 1/2/5's guards were reconciled to coexist with `main`'s existing `substituteGroundedRCA` call rather than either side being dropped.
- Two `release/v1.5` commits for Track 5 (`315cd0691`/`a3e2f8151`) originally mislabeled the fix as `#2103` before a follow-up commit corrected it to `#2105` -- both are folded into this port's single Track 5 commit, referenced directly as `#2105`/`#2106` from the start.

All new test files (UT+IT, one per track) ported unchanged in behavior; test plans ported unchanged from `docs/testing/2092-2094-2098-2100/TEST_PLAN.md` and `docs/testing/2103/TEST_PLAN.md`.

Closes #2093, Closes #2099, Closes #2095, Closes #2101, Closes #2106, Closes #2104

## Test Plan

- [x] `go build ./...`, `go vet ./...` -- clean
- [x] `make test-unit-kubernautagent` -- 110/110 specs passing (34 suites)
- [x] `make test-unit-apifrontend` -- all specs passing (25 suites, 80.1% composite coverage)
- [x] `make test-integration-kubernautagent-interactive` -- 27/27 `interactive`-labeled specs passing, including the ported Track 4/6 IT tests (`IT-KA-2100-001/002`, `IT-KA-2103-001/002`) against real envtest `Lease` objects
- [x] `gofmt -l` clean on all files touched by this port
- [x] No new lint errors introduced

**FedRAMP control objectives**: SI-11 (schema validation, no silent masking), SI-4/SC-5 (session capacity/observability integrity), AU-3/AU-12 (audit artifact grounding).

## Checklist

- [x] Tests written following TDD (RED-GREEN-REFACTOR) -- history preserved via cherry-pick from `release/v1.5`, re-applied where files moved
- [x] All errors handled and logged
- [x] Documentation already present (test plans ported unchanged)
- [x] No breaking changes