### PR TITLE
fix: batch-port final 2 bucket-B v1.6 issues from release/v1.5 (#2086/#2089)

### DIFF
--- a/internal/kubernautagent/investigator/gate_keepalive_2088_test.go
+++ b/internal/kubernautagent/investigator/gate_keepalive_2088_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// firstToolCallStartToolName scans events for the first EventTypeToolCallStart
+// and returns its "tool_name" field, or ("", false) if none was emitted.
+func firstToolCallStartToolName(events []session.InvestigationEvent) (string, bool) {
+	for i := range events {
+		if events[i].Type != session.EventTypeToolCallStart {
+			continue
+		}
+		var data map[string]interface{}
+		if json.Unmarshal(events[i].Data, &data) != nil {
+			continue
+		}
+		toolName, _ := data["tool_name"].(string)
+		return toolName, true
+	}
+	return "", false
+}
+
+// #2088 (main port of #2086, BR-INTERACTIVE-010, FedRAMP SI-4):
+// sameKindValidationGate, apiVersionValidationGate, and
+// RunRCAExtractionFromConversation each issue a second, non-streamed
+// llm.ChatWithParams call that emits zero events to the investigation sink
+// for the duration of that LLM round-trip. Live-cluster forensics on
+// rr-cc99762025f0-5977eb36 (release/v1.5, #2086) showed this silent gap
+// (~87s in the observed incident) exceeds AF's 60s bridge-inactivity timeout
+// (bridgeEventsCollectSummary), causing AF to falsely report the interactive
+// investigation as "completed" with an empty RCA -- the driving agent then
+// never calls discover_workflows. These specs drive a real Investigator
+// through its real production event-sink wiring and prove each of the 3
+// silent call sites now emits an EventTypeToolCallStart keepalive (which
+// resets AF's inactivity timer without polluting the RCA summary) before
+// issuing its retry/extraction LLM call.
+var _ = Describe("#2088: silent gate-retry LLM calls must emit a keepalive to the investigation sink", func() {
+
+	Describe("UT-KA-2088-001: sameKindValidationGate emits a keepalive during its retry LLM call", func() {
+		It("should emit an EventTypeToolCallStart event around the gate-retry LLM call so AF's bridge inactivity timer resets (#2088)", func() {
+			eventCh := make(chan session.InvestigationEvent, 64)
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "api-server-xyz",
+				Name:         "api-server-xyz",
+				Namespace:    "production",
+				Severity:     "critical",
+				Message:      "Pod OOMKilled repeatedly",
+			}
+
+			mockClient := &gateMockLLMClient{
+				responses: []llm.ChatResponse{
+					// Turn 1: RCA target kind == signal.ResourceKind ("Pod") -> same-kind gate fires.
+					{Message: llm.Message{Role: "assistant", Content: `{
+						"rca_summary":"Pod OOMKilled",
+						"confidence":0.85,
+						"remediation_target":{"kind":"Pod","name":"api-server-xyz","namespace":"production"}
+					}`}},
+					// Gate retry: LLM re-targets the parent Deployment. This is the silent,
+					// non-streamed llm.ChatWithParams call the fix wraps with a keepalive.
+					{Message: llm.Message{Role: "assistant", Content: `{
+						"rca_summary":"Deployment memory limit too low",
+						"confidence":0.85,
+						"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production","api_version":"apps/v1"}
+					}`}},
+					gateWfToolResp(`{"workflow_id":"increase-memory-limit","confidence":0.9}`),
+				},
+			}
+
+			logger := logr.Discard()
+			store := &gateRecordingAuditStore{}
+			builder, _ := prompt.NewBuilder()
+			enricher := enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, store, logger)
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: parser.NewResultParser(),
+				Enricher: enricher, AuditStore: store, Logger: logger,
+				MaxTurns: 15, PhaseTools: investigator.DefaultPhaseToolMap(),
+			})
+
+			go func() {
+				_, _ = inv.Investigate(ctx, signal)
+				close(eventCh)
+			}()
+
+			events := collectEvents(eventCh)
+			toolName, found := firstToolCallStartToolName(events)
+			Expect(found).To(BeTrue(),
+				"UT-KA-2088-001: sameKindValidationGate's silent retry LLM call must emit a keepalive "+
+					"EventTypeToolCallStart event, or AF's bridge-inactivity timer (60s) can starve during "+
+					"the LLM round-trip and falsely report the investigation as completed (#2088)")
+			Expect(toolName).NotTo(BeEmpty(),
+				"UT-KA-2088-001: keepalive event must carry a non-empty tool_name so AF's "+
+					"FormatEventForUser can render status text once the tool_name/tool key mismatch is "+
+					"fixed (#2090)")
+		})
+	})
+
+	Describe("UT-KA-2088-002: apiVersionValidationGate emits a keepalive during its retry LLM call", func() {
+		It("should emit an EventTypeToolCallStart event around the gate-retry LLM call so AF's bridge inactivity timer resets (#2088)", func() {
+			eventCh := make(chan session.InvestigationEvent, 64)
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "etcd-operator-xyz",
+				Name:         "etcd-operator-xyz",
+				Namespace:    "demo-operator",
+				Severity:     "critical",
+				Message:      "RBAC denial on wrong API group",
+			}
+
+			mockClient := &gateMockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{
+						"rca_summary":"Subscription etcd needs restart",
+						"confidence":0.85,
+						"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+					}`}},
+					// Gate retry: LLM provides api_version. Silent, non-streamed
+					// llm.ChatWithParams call the fix wraps with a keepalive.
+					{Message: llm.Message{Role: "assistant", Content: `{
+						"rca_summary":"Subscription etcd needs restart",
+						"confidence":0.85,
+						"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator","api_version":"operators.coreos.com/v1alpha1"}
+					}`}},
+					gateWfToolResp(`{"workflow_id":"restart-sub","confidence":0.9}`),
+				},
+			}
+
+			logger := logr.Discard()
+			store := &gateRecordingAuditStore{}
+			builder, _ := prompt.NewBuilder()
+			enricher := enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, store, logger)
+			resolver := investigator.NewMapperScopeResolver(newAmbiguousSubscriptionMapper())
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: parser.NewResultParser(),
+				Enricher: enricher, AuditStore: store, Logger: logger,
+				MaxTurns: 15, PhaseTools: investigator.DefaultPhaseToolMap(), ScopeResolver: resolver,
+			})
+
+			go func() {
+				_, _ = inv.Investigate(ctx, signal)
+				close(eventCh)
+			}()
+
+			events := collectEvents(eventCh)
+			toolName, found := firstToolCallStartToolName(events)
+			Expect(found).To(BeTrue(),
+				"UT-KA-2088-002: apiVersionValidationGate's silent retry LLM call must emit a keepalive "+
+					"EventTypeToolCallStart event, or AF's bridge-inactivity timer (60s) can starve during "+
+					"the LLM round-trip and falsely report the investigation as completed (#2088)")
+			Expect(toolName).NotTo(BeEmpty(),
+				"UT-KA-2088-002: keepalive event must carry a non-empty tool_name so AF's "+
+					"FormatEventForUser can render status text once the tool_name/tool key mismatch is "+
+					"fixed (#2090)")
+		})
+	})
+
+	Describe("UT-KA-2088-003: RunRCAExtractionFromConversation emits a keepalive during its extraction LLM call", func() {
+		It("should emit an EventTypeToolCallStart event around the extraction LLM call so AF's bridge inactivity timer resets (#2088)", func() {
+			eventCh := make(chan session.InvestigationEvent, 64)
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			mockClient := &gateMockLLMClient{
+				responses: []llm.ChatResponse{
+					// discover_workflows extraction call: silent, non-streamed
+					// llm.ChatWithParams call the fix wraps with a keepalive.
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_extract", Name: investigator.SubmitResultToolName, Arguments: `{
+								"rca_summary":"OOMKilled",
+								"confidence":0.9,
+								"remediation_target":{"kind":"Deployment","name":"api","namespace":"ns","api_version":"apps/v1"}
+							}`},
+						},
+					},
+				},
+			}
+
+			logger := logr.Discard()
+			store := &gateRecordingAuditStore{}
+			builder, _ := prompt.NewBuilder()
+			enricher := enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, store, logger)
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: parser.NewResultParser(),
+				Enricher: enricher, AuditStore: store, Logger: logger,
+				MaxTurns: 15, PhaseTools: investigator.DefaultPhaseToolMap(),
+			})
+
+			messages := []llm.Message{
+				{Role: "user", Content: "investigate this pod"},
+				{Role: "assistant", Content: "Looking at the pod, it appears to be OOMKilled."},
+			}
+
+			result, err := inv.RunRCAExtractionFromConversation(ctx, messages, "corr-2088-003")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			close(eventCh)
+
+			events := collectEvents(eventCh)
+			toolName, found := firstToolCallStartToolName(events)
+			Expect(found).To(BeTrue(),
+				"UT-KA-2088-003: RunRCAExtractionFromConversation's silent extraction LLM call must emit "+
+					"a keepalive EventTypeToolCallStart event, or AF's bridge-inactivity timer (60s) can "+
+					"starve during the LLM round-trip while an operator is waiting on kubernaut_discover_workflows (#2088)")
+			Expect(toolName).NotTo(BeEmpty(),
+				"UT-KA-2088-003: keepalive event must carry a non-empty tool_name so AF's "+
+					"FormatEventForUser can render status text once the tool_name/tool key mismatch is "+
+					"fixed (#2090)")
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -447,6 +447,13 @@ func (inv *Investigator) RunRCAExtractionFromConversation(ctx context.Context, m
 		Tools:    submitOnlyTools,
 	}
 
+	// #2088 (main port of #2086): this extraction call is non-streamed and
+	// emits no sink events for its duration. discover_workflows callers can
+	// wait through this call while AF's bridge-inactivity timer is running,
+	// so a keepalive is required to prevent AF from falsely reporting
+	// completion.
+	emitGateRetryKeepalive(ctx, "extracting_rca_from_conversation")
+
 	resp, err := llm.ChatWithParams(ctx, client, req, runtimeParams)
 	if err != nil {
 		return nil, fmt.Errorf("RCA extraction LLM call: %w", err)

--- a/internal/kubernautagent/investigator/investigator_gates.go
+++ b/internal/kubernautagent/investigator/investigator_gates.go
@@ -130,6 +130,16 @@ func (inv *Investigator) retryForSameKind(ctx context.Context, result *katypes.I
 	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages)
 	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
+	// #2088 (main port of #2086): this gate-retry LLM call is non-streamed
+	// (llm.ChatWithParams), so it emits zero sink events for the duration of
+	// the round-trip. A slow/retried backend call here can outlast AF's
+	// bridge-inactivity timeout, causing AF to falsely report the
+	// investigation as "completed" while the driving agent never calls
+	// discover_workflows. This keepalive resets that timer without
+	// polluting the RCA summary (EventTypeToolCallStart is never
+	// concatenated into summary text).
+	emitGateRetryKeepalive(ctx, "revalidating_remediation_target")
+
 	resp, err := llm.ChatWithParams(ctx, client, llm.ChatRequest{
 		Messages: retryMessages,
 		Tools:    submitOnlyRCATools(),
@@ -309,6 +319,11 @@ func (inv *Investigator) retryForAPIVersion(ctx context.Context, p retryForAPIVe
 	gateEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
 	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages)
 	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
+
+	// #2088 (main port of #2086): same silent-gap risk as retryForSameKind
+	// above -- this retry LLM call is non-streamed and emits no sink events
+	// during the round-trip.
+	emitGateRetryKeepalive(ctx, "resolving_api_version_ambiguity")
 
 	resp, retryErr := llm.ChatWithParams(ctx, client, llm.ChatRequest{
 		Messages: retryMessages,

--- a/internal/kubernautagent/investigator/investigator_loop.go
+++ b/internal/kubernautagent/investigator/investigator_loop.go
@@ -500,6 +500,22 @@ func emitToSink(ctx context.Context, eventType string, turn int, phase string, d
 	}
 }
 
+// emitGateRetryKeepalive emits an EventTypeToolCallStart keepalive around a
+// silent, non-streamed llm.ChatWithParams call (#2088, main port of #2086:
+// sameKindValidationGate, apiVersionValidationGate,
+// RunRCAExtractionFromConversation). Turn 0 is a sentinel -- these calls
+// happen outside runLLMLoop's normal turn counting. EventTypeToolCallStart is
+// used (not EventTypeReasoningDelta/TokenDelta) specifically because
+// bridgeEventsCollectSummary only accumulates the latter two into the RCA
+// summary returned to the driving agent; using a text-accumulating event type
+// would splice placeholder status text directly into the summary
+// (spike-discovered regression, see UT-AF-2086-006).
+func emitGateRetryKeepalive(ctx context.Context, toolName string) {
+	emitToSink(ctx, session.EventTypeToolCallStart, 0, string(katypes.PhaseRCA), map[string]interface{}{
+		"tool_name": toolName,
+	})
+}
+
 // emitCancellationAudit emits an investigation-level cancellation event
 // carrying the phase, turn, token usage, and accumulated messages at the point
 // of cancellation. Enriched per COR-2 (token cost attribution), AUD-4

--- a/internal/kubernautagent/investigator/tool_call_start_wire_contract_2090_test.go
+++ b/internal/kubernautagent/investigator/tool_call_start_wire_contract_2090_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	afka "github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	aftools "github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+)
+
+// IT-AF-2090-030 (main port of #2086 Fix 5, FedRAMP SI-4: status text must
+// actually reach the operator): proves the real tool_call_start event KA
+// puts on the wire (via the actual emitToSink call site in runLLMLoop, not a
+// hand-built fixture) is consumable by AF's production FormatEventForUser,
+// closing the loop across the KA/AF package boundary. Regression target:
+// #2089/#2090 -- KA emits key "tool_name" (investigator's emitToSink calls)
+// but AF's FormatEventForUser read "tool", so genuine "Calling
+// kubectl_get..." status text never rendered in production; AF's own unit
+// tests passed only because they hand-constructed fixtures with the (wrong)
+// "tool" key, never exercising the real KA emission path.
+var _ = Describe("IT-AF-2090-030: tool_call_start wire contract between KA and AF", func() {
+	It("round-trips a real KA tool_call_start event through AF's FormatEventForUser and produces the display text", func() {
+		eventCh := make(chan session.InvestigationEvent, 64)
+		ctx := session.WithEventSink(context.Background(), eventCh)
+
+		mockClient := &cancelAwareMockClient{
+			responses: []llm.ChatResponse{
+				{
+					Message: llm.Message{Role: "assistant", Content: "investigating..."},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Pod","name":"test","namespace":"default"}`},
+					},
+					Usage: llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+				},
+				{
+					Message: llm.Message{
+						Role:    "assistant",
+						Content: `{"rca_summary":"pod OOM killed","confidence":0.9}`,
+					},
+					Usage: llm.TokenUsage{PromptTokens: 200, CompletionTokens: 100, TotalTokens: 300},
+				},
+			},
+		}
+
+		inv := streamTestInvestigator(mockClient)
+		go func() {
+			_, _ = inv.Investigate(ctx, streamSignal)
+			close(eventCh)
+		}()
+
+		events := collectEvents(eventCh)
+
+		var kaEvent *session.InvestigationEvent
+		for i := range events {
+			if events[i].Type == session.EventTypeToolCallStart {
+				kaEvent = &events[i]
+				break
+			}
+		}
+		Expect(kaEvent).NotTo(BeNil(), "KA must emit a tool_call_start event for the LLM-requested tool call")
+
+		// Simulate the actual wire hop: KA's InvestigationEvent is marshaled to
+		// JSON for the MCP LoggingMessage transport, then AF unmarshals the raw
+		// bytes into its own wire-compatible ka.InvestigationEvent type.
+		wireBytes, err := json.Marshal(kaEvent)
+		Expect(err).NotTo(HaveOccurred())
+
+		var afEvent afka.InvestigationEvent
+		Expect(json.Unmarshal(wireBytes, &afEvent)).To(Succeed())
+
+		displayText := aftools.FormatEventForUser(afEvent)
+		Expect(displayText).To(Equal("Calling kubectl_describe..."),
+			"AF's production FormatEventForUser must extract the tool name KA put on the wire under "+
+				"the \"tool_name\" key; a field-name mismatch here means real tool-call status text "+
+				"never renders in production (#2089/#2090)")
+	})
+})

--- a/internal/kubernautagent/mcp/tools/deferred_investigation_log_2088_test.go
+++ b/internal/kubernautagent/mcp/tools/deferred_investigation_log_2088_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+)
+
+// levelCaptureSink records every Info/Error call with its level, so tests
+// can assert the exact log level chosen for a given message. Unlike
+// logCaptureSink-style helpers (which discard Error calls entirely), this
+// sink is needed to prove a log entry was downgraded from Error to Info,
+// not merely that some Info entry exists.
+type levelCaptureSink struct {
+	entries []levelLogEntry
+}
+
+type levelLogEntry struct {
+	level string // "info" or "error"
+	msg   string
+}
+
+func (s *levelCaptureSink) Init(logr.RuntimeInfo)                  {}
+func (s *levelCaptureSink) Enabled(int) bool                       { return true }
+func (s *levelCaptureSink) WithValues(...interface{}) logr.LogSink { return s }
+func (s *levelCaptureSink) WithName(string) logr.LogSink           { return s }
+func (s *levelCaptureSink) Error(_ error, msg string, _ ...interface{}) {
+	s.entries = append(s.entries, levelLogEntry{level: "error", msg: msg})
+}
+func (s *levelCaptureSink) Info(_ int, msg string, _ ...interface{}) {
+	s.entries = append(s.entries, levelLogEntry{level: "info", msg: msg})
+}
+
+// levelFor returns the level of the first captured entry whose message
+// contains msg, or ("", false) if none was captured.
+func (s *levelCaptureSink) levelFor(msg string) (string, bool) {
+	for _, e := range s.entries {
+		if e.msg == msg {
+			return e.level, true
+		}
+	}
+	return "", false
+}
+
+// #2088 (main port of #2086, BR-INTERACTIVE-010, FedRAMP AU-3): handleStart's
+// launch-deferred log line was previously always logged at Error level, even
+// though session.ErrSessionNotPending is a benign, expected race -- it fires
+// when the driving agent retries kubernaut_investigate action=start after a
+// prior call already launched the deferred session (exactly the kind of
+// retry #2086's false-"completed" report could trigger). An Error-level log
+// for an expected, harmless race pollutes on-call alerting/dashboards with
+// false-positive noise. Genuine failures (e.g. the deferred function itself
+// is missing) must remain at Error.
+var _ = Describe("#2088: LaunchDeferredInvestigation benign-retry log level", func() {
+
+	Describe("UT-KA-2088-006: benign ErrSessionNotPending race logs at Info, not Error", func() {
+		It("should log the launch-deferred failure at Info level when the session was already launched by a concurrent retry", func() {
+			sink := &levelCaptureSink{}
+			logger := logr.New(sink)
+
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2088-006",
+					CorrelationID: "rr-2088-006",
+				},
+			}
+			autoMgr := &interactiveAutoMgr{
+				pendingResult: "http-sess-2088-006",
+				pendingOK:     true,
+				launchErr:     session.ErrSessionNotPending,
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+			auditStore := &recordingAuditStore{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithAuditStore(auditStore, logger),
+			)
+
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2088-006",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "charlie"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("started"))
+
+			level, found := sink.levelFor("start: failed to launch deferred investigation")
+			Expect(found).To(BeTrue(),
+				"UT-KA-2088-006: expected a launch-deferred log line to be emitted")
+			Expect(level).To(Equal("info"),
+				"UT-KA-2088-006: session.ErrSessionNotPending is a benign, expected retry race (#2088) "+
+					"and must not be logged at Error level, or on-call alerting/dashboards accumulate "+
+					"false-positive noise from routine driving-agent retries")
+		})
+	})
+
+	Describe("UT-KA-2088-006b: genuine launch failures remain at Error level (regression guard)", func() {
+		It("should still log at Error level for a non-benign launch failure", func() {
+			sink := &levelCaptureSink{}
+			logger := logr.New(sink)
+
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2088-006b",
+					CorrelationID: "rr-2088-006b",
+				},
+			}
+			autoMgr := &interactiveAutoMgr{
+				pendingResult: "http-sess-2088-006b",
+				pendingOK:     true,
+				launchErr:     errors.New("deferred investigation function unexpectedly nil"),
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+			auditStore := &recordingAuditStore{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithAuditStore(auditStore, logger),
+			)
+
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2088-006b",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "charlie"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("started"))
+
+			level, found := sink.levelFor("start: failed to launch deferred investigation")
+			Expect(found).To(BeTrue(),
+				"UT-KA-2088-006b: expected a launch-deferred log line to be emitted")
+			Expect(level).To(Equal("error"),
+				"UT-KA-2088-006b: a genuine, unexpected launch failure must remain at Error level so "+
+					"real incidents are not silently downgraded alongside the benign retry race")
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/tools/investigate_start.go
+++ b/internal/kubernautagent/mcp/tools/investigate_start.go
@@ -126,8 +126,21 @@ func (t *InvestigateTool) launchPendingInteractiveSession(input InvestigateInput
 		return false, ""
 	}
 	if launchErr := t.autoMgr.LaunchDeferredInvestigation(pendingID); launchErr != nil {
-		t.logger.Error(launchErr, "start: failed to launch deferred investigation",
-			"rr_id", input.RRID, "pending_session_id", pendingID)
+		// #2088 (main port of #2086): session.ErrSessionNotPending is a
+		// benign, expected race -- it fires when the driving agent retries
+		// action=start after a prior call already launched the deferred
+		// session (e.g. a retry after a false-"completed" report from
+		// #2086 could trigger this). Logging this at Error level pollutes
+		// on-call alerting with false-positive noise for routine retries;
+		// genuine failures (missing deferred function, unknown session)
+		// stay at Error.
+		if errors.Is(launchErr, session.ErrSessionNotPending) {
+			t.logger.Info("start: failed to launch deferred investigation",
+				"rr_id", input.RRID, "pending_session_id", pendingID, "reason", launchErr.Error())
+		} else {
+			t.logger.Error(launchErr, "start: failed to launch deferred investigation",
+				"rr_id", input.RRID, "pending_session_id", pendingID)
+		}
 		return false, ""
 	}
 	return true, pendingID

--- a/pkg/aianalysis/handlers/investigating.go
+++ b/pkg/aianalysis/handlers/investigating.go
@@ -929,7 +929,40 @@ func (h *InvestigatingHandler) handleSessionIncidentResult(ctx context.Context, 
 	if err == nil {
 		h.setRetryCount(analysis, 0)
 	}
+
+	// #2088 (main port of #2086 Fix 4): KA's own session inactivity timeout
+	// (e.g. a 10-minute interactive-session idle limit) completes with no
+	// InvestigationResult ever produced. KA synthesizes a placeholder for
+	// this (synthesizeNilResult's default branch,
+	// internal/kubernautagent/server/handler.go) with has_workflow=false and
+	// human_review_reason="" -- ProcessIncidentResponse cannot distinguish
+	// this from a genuine "investigated and found no matching workflow"
+	// conclusion, so it always classifies both identically as
+	// SubReason=NoMatchingWorkflows. That is misleading: the investigation
+	// never actually reached a conclusion. Correct the classification here
+	// (response_processor.go stays untouched -- this fix's blast radius is
+	// contained to this file). FedRAMP AU-3 (truthful audit content) / SI-11
+	// (accurate error handling).
+	if analysis.Status.SubReason == "NoMatchingWorkflows" && isSessionTimedOutWithoutResult(resp) {
+		analysis.Status.SubReason = "InvestigationInconclusive"
+		analysis.Status.HumanReviewReason = "investigation_inconclusive"
+		analysis.Status.Message = "KA session completed without producing a result " +
+			"(likely an inactivity timeout); the investigation did not reach a conclusion"
+	}
+
 	return result, err
+}
+
+// isSessionTimedOutWithoutResult reports whether resp is KA's nil-result
+// synthesis placeholder rather than a genuine investigation outcome. #2088
+// (main port of #2086): this is the only signal available on the wire that
+// distinguishes "the session completed without KA ever producing a result"
+// (e.g. an inactivity timeout) from "KA investigated and concluded no
+// workflow matches" -- synthesizeNilResult's default branch always sets
+// exactly this Analysis text with Confidence 0 and no other fields
+// populated.
+func isSessionTimedOutWithoutResult(resp *agentclient.IncidentResponse) bool {
+	return resp.Analysis == "Investigation completed without result" && resp.Confidence == 0
 }
 
 // handleSessionPollFailed handles poll results where investigation has failed on KA side.

--- a/pkg/aianalysis/investigating_handler_session_test.go
+++ b/pkg/aianalysis/investigating_handler_session_test.go
@@ -379,6 +379,55 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-KA-064)", func(
 			})
 		})
 
+		// IT-AA-2088-020 (main port of #2086 Fix 4): Poll completed via KA's
+		// own inactivity timeout, which synthesizes a nil result
+		// (has_workflow=false, human_review_reason=""). Must not be
+		// misclassified identically to a genuine "no matching workflows"
+		// conclusion. Driven through the real reconcile entry point
+		// (handler.Handle), not a direct call to handleSessionIncidentResult,
+		// so this proves the wiring end-to-end.
+		Context("IT-AA-2088-020: Poll completed via KA inactivity timeout (nil result, no human_review_reason)", func() {
+			It("should classify as InvestigationInconclusive, not NoMatchingWorkflows (#2088 Fix 4)", func() {
+				analysis := createSessionTestAnalysis()
+				analysis.Status.KASession = &aianalysisv1.KASession{
+					ID:         "session-timeout-001",
+					Generation: 0,
+					CreatedAt:  &metav1.Time{Time: time.Now().Add(-600 * time.Second)},
+				}
+
+				mockClient.WithSessionPollStatus("completed")
+				// #2088: mirrors KA's synthesizeNilResult default branch
+				// (internal/kubernautagent/server/handler.go) -- the exact
+				// wire shape produced when a user-driving session's own
+				// 10-minute inactivity timeout fires with no
+				// InvestigationResult ever set: has_workflow=false,
+				// human_review_reason="" (left unset), confidence=0.
+				mockClient.WithResponse(&agentclient.IncidentResponse{
+					IncidentID:       "session-timeout-001",
+					Analysis:         "Investigation completed without result",
+					NeedsHumanReview: agentclient.NewOptBool(false),
+					Confidence:       0,
+					Timestamp:        "2026-04-03T00:00:00Z",
+					Warnings:         []string{},
+				})
+
+				_, err := handler.Handle(ctx, analysis)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseFailed))
+				// #2088 Fix 4: must NOT be misclassified as a genuine "no
+				// matching workflows found" conclusion -- KA's investigation
+				// never reached one. FedRAMP AU-3 (truthful audit content) /
+				// SI-11 (accurate error handling).
+				Expect(analysis.Status.SubReason).NotTo(Equal("NoMatchingWorkflows"),
+					"#2088: a session that timed out with no result must not be reported as a genuine no-match conclusion")
+				Expect(analysis.Status.SubReason).To(Equal("InvestigationInconclusive"),
+					"#2088: distinguishable classification for a session that completed without producing any result")
+				Expect(analysis.Status.Message).NotTo(Equal("No workflow selected for remediation"),
+					"#2088: message must reflect the true timeout/no-result cause, not the generic no-match message")
+			})
+		})
+
 		// UT-AA-064-007: Polling interval is constant across all polls
 		// BR-AA-KA-064.8: Constant interval -- polling is not error recovery.
 		// Every poll uses the same configured interval regardless of PollCount.

--- a/pkg/apifrontend/tools/ka_investigate_bridge.go
+++ b/pkg/apifrontend/tools/ka_investigate_bridge.go
@@ -352,7 +352,13 @@ func FormatEventForUser(evt ka.InvestigationEvent) string {
 	case ka.EventTypeTokenDelta:
 		return extractJSONField(evt.Data, "delta")
 	case ka.EventTypeToolCallStart:
-		toolName := extractJSONField(evt.Data, "tool")
+		// #2090 (main port of #2089): KA's real emission (investigator's
+		// emitToSink calls, e.g. runLLMLoop's tool-dispatch block) uses key
+		// "tool_name" -- this previously read "tool", a wire-format
+		// mismatch AF's own unit tests never caught because they
+		// hand-constructed fixtures with the wrong key instead of
+		// exercising the real KA emission path.
+		toolName := extractJSONField(evt.Data, "tool_name")
 		if toolName != "" {
 			return "Calling " + toolName + "..."
 		}

--- a/pkg/apifrontend/tools/ka_investigate_mcp_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp_test.go
@@ -266,7 +266,11 @@ var _ = Describe("formatEventForUser — #1326 BR-MCP-008 event filtering", func
 		It("should format tool name with 'Calling ...' prefix", func() {
 			evt := ka.InvestigationEvent{
 				Type: ka.EventTypeToolCallStart,
-				Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+				// #2090 (main port of #2089): "tool_name" is KA's real wire
+				// key (investigator's emitToSink calls) -- this fixture
+				// previously hand-constructed the wrong key ("tool"),
+				// matching the pre-fix code and never catching the mismatch.
+				Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
 			}
 			result := tools.FormatEventForUser(evt)
 			Expect(result).To(Equal("Calling kubectl_get..."))
@@ -409,7 +413,7 @@ var _ = Describe("A2A status channel routing — event type aware emission", fun
 			eventCh := make(chan ka.InvestigationEvent, 5)
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeToolCallStart,
-				Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+				Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
 			}
 			eventCh <- ka.InvestigationEvent{Type: ka.EventTypeComplete}
 			close(eventCh)
@@ -554,7 +558,7 @@ var _ = Describe("A2A status channel routing — event type aware emission", fun
 			eventCh := make(chan ka.InvestigationEvent, 10)
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeToolCallStart,
-				Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+				Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
 			}
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeReasoningDelta,
@@ -566,7 +570,7 @@ var _ = Describe("A2A status channel routing — event type aware emission", fun
 			}
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeToolCallStart,
-				Data: json.RawMessage(`{"tool":"kubectl_describe"}`),
+				Data: json.RawMessage(`{"tool_name":"kubectl_describe"}`),
 			}
 			eventCh <- ka.InvestigationEvent{Type: ka.EventTypeComplete}
 			close(eventCh)
@@ -1085,7 +1089,7 @@ var _ = Describe("HandleInvestigationMCPWithRegistry — blocking mode (A2A path
 					go func() {
 						eventCh <- ka.InvestigationEvent{
 							Type: ka.EventTypeToolCallStart,
-							Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+							Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
 						}
 						eventCh <- ka.InvestigationEvent{
 							Type: ka.EventTypeReasoningDelta,
@@ -1483,13 +1487,13 @@ var _ = Describe("HandleInvestigationMCPWithRegistry — fleet cluster_id wiring
 			ctx, &tools.InvestigateConfig{
 				MCPClient: closedEventsMCP(),
 				Client:    tc,
-			Namespace: "kubernaut-system",
-			Triager:   defaultTestTriager("prod", "Deployment", "web-1409-003"),
-		}, tools.InvestigateMCPArgs{
-			APIVersion: "apps/v1",
-			Namespace:  "prod",
-			Kind:       "Deployment",
-			Name:       "web-1409-003",
+				Namespace: "kubernaut-system",
+				Triager:   defaultTestTriager("prod", "Deployment", "web-1409-003"),
+			}, tools.InvestigateMCPArgs{
+				APIVersion: "apps/v1",
+				Namespace:  "prod",
+				Kind:       "Deployment",
+				Name:       "web-1409-003",
 				ClusterID:  "cluster-fleet-it-003",
 			},
 			true, "alice",

--- a/test/integration/apifrontend/investigation_event_bridge_test.go
+++ b/test/integration/apifrontend/investigation_event_bridge_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Investigation Event Bridge Wiring (IT-AF-1326)", func() {
 			}
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeToolCallStart,
-				Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+				Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
 			}
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeComplete,
@@ -302,7 +302,7 @@ var _ = Describe("Investigation Event Bridge Wiring (IT-AF-1326)", func() {
 					expected: "Analyzing...",
 				},
 				{
-					evt:      ka.InvestigationEvent{Type: ka.EventTypeToolCallStart, Data: json.RawMessage(`{"tool":"kubectl_get"}`)},
+					evt:      ka.InvestigationEvent{Type: ka.EventTypeToolCallStart, Data: json.RawMessage(`{"tool_name":"kubectl_get"}`)},
 					expected: "Calling kubectl_get...",
 				},
 				{


### PR DESCRIPTION
## Summary

Completes the v1.6 remaining-work triage plan's "batch-port Bucket B" step. Of the 11 issues originally flagged as needing a port from `release/v1.5`, re-triage after fast-forwarding `main` showed 9 were already fixed independently. This PR ports the final 2 (both from `release/v1.5` PR #2091, itself fixing #2086/#2089):

- **#2088** (origin #2086): silent gate-retry LLM calls, benign retry-race log level, session-timeout-without-result misclassification
- **#2090** (origin #2089): `FormatEventForUser` tool_call_start wire-format key mismatch

Each ported fix was adapted to `main`'s refactored structure (`LLMInvocationContext`-based investigator call sites, `investigate_start.go`'s split-out `handleStart`, `ka_investigate_bridge.go`'s exit-reason-based bridge).

One notable scope reduction found during preflight: the original release/v1.5 commit `88b3b18fb` bundled a second, unrelated fix (`bridgeEventsCollectSummary` truthful-status-on-inactivity-timeout + `BridgeInactivityTimeout` 60s→90s bump) alongside the `tool_name` wire-format fix. That truthful-status concern is already superseded on `main` by issue #1451's exit-reason mechanism (`ExitReasonInactivityTimeout` → `"timed_out"`, not `"completed"`, with an even more generous 180s timeout) — confirmed via #1451's closed GitHub issue and its existing `bridge_exit_reason_1451_test.go` coverage. Only the still-missing `tool_name` key fix was ported.

## Commits

1. `fix(kubernautagent,aianalysis): emit gate-retry keepalives, downgrade benign retry-race log, classify session-timeout-without-result` — Fixes #2088
2. `fix(apifrontend): FormatEventForUser reads tool_name, not tool, for tool_call_start events` — Fixes #2090

## Test plan

- New/ported unit tests: `UT-KA-2088-001..003`, `UT-KA-2088-006`, `UT-KA-2088-006b`, `IT-AA-2088-020`, `IT-AF-2090-030`
- `go build ./...` passes
- `go test ./internal/kubernautagent/... ./pkg/apifrontend/... ./pkg/aianalysis/...` all green
- `golangci-lint run ./...` — 0 new issues (19 pre-existing issues remain, all in unrelated `docs/spikes/`, `scripts/`, `hack/` paths)

## Checklist

- [x] Preflight: pinned exact `release/v1.5` fix commits per issue, diffed against `main`'s current file structure
- [x] TDD: ported/adapted RED-phase tests alongside each fix
- [x] Wiring verified via existing production call sites (investigator loop, MCP tool handlers, AA reconcile handler)
- [x] Build, lint, and targeted test suites green