### PR TITLE
fix(apifrontend): harden EmitArtifact against gob-unsafe artifact data (#2111 follow-up)

### DIFF
--- a/docs/testing/2111/TEST_PLAN.md
+++ b/docs/testing/2111/TEST_PLAN.md
@@ -1,0 +1,122 @@
+# Test Plan: #2111 — `EmitArtifact` gob-safety Boundary Hardening (follow-up to #2110's fix)
+
+## 1. Purpose
+
+[#2110](https://github.com/jordigilh/kubernaut/issues/2110) (main clone
+[#2111](https://github.com/jordigilh/kubernaut/issues/2111)) was a
+release-blocking regression: every `kubernaut_present_decision` call with
+grounded RCA content crashed the a2a task with `gob: type not registered for
+interface: tools.RCAData`, because `canonicalGroundedRCA` returned a raw
+`*tools.RCAData` struct pointer that reached `a2a-go@v0.3.15`'s gob-encoded
+task-manager deep-copy pipeline unregistered.
+
+[#2112](https://github.com/jordigilh/kubernaut/pull/2112)/[#2113](https://github.com/jordigilh/kubernaut/pull/2113)
+fixed that specific call site (changed `canonicalGroundedRCA`'s return type
+to `map[string]any`, added `gob.Register(&RCAData{})` as defense-in-depth).
+That fix was correct but not sufficient: it left the underlying structural
+gap open. `EventBridge.EmitArtifact`
+(`pkg/apifrontend/launcher/event_bridge.go`) is the single choke point all
+three current artifact producers share --
+`part_converter.go`'s `emitDecisionEvent` (`present_decision`),
+`crd_tools.go`'s progress snapshot, and `ka_investigate_mcp.go`'s RCA
+artifact -- before their `data` reaches that same gob pipeline, and
+`EmitArtifact` performed zero validation of `data`'s gob-safety. Nothing
+stopped (and, on `release/v1.5`, still doesn't stop) a future contributor
+from reintroducing the identical crash class by assigning any other struct
+into any nested field of an artifact's `data` map. `gob.Register(&RCAData{})`
+is a manually-maintained per-type whitelist, not a structural guarantee --
+the #2112 PR's own comments say as much.
+
+This follow-up (`main` only; `release/v1.5` keeps the already-shipped #2112
+fix as-is since it's mid-release) hardens `EmitArtifact` itself so the
+guarantee holds for all current and future callers, not just the one that
+broke.
+
+### Root Cause Detail (recap, see #2110's own `docs/testing/2110/TEST_PLAN.md` for the original incident)
+
+`encoding/gob` requires any concrete type stored behind an `interface{}` to
+be `gob.Register`'d before it can be encoded, UNLESS it's one of a small set
+of types Go's own `encoding/gob` package pre-registers for itself at
+`init()` (`type.go`): the basic numeric/string/bool types and a handful of
+their unnamed slice forms (`[]string`, `[]int`, `[]byte`, etc.). Named
+struct types, `map[string]any`, and `[]any` are never in that built-in set --
+`a2a-go@v0.3.15`'s own `internal/taskstore/store.go` registers
+`map[string]any` and `[]any` itself at `init()` for exactly this reason.
+
+### Design Consideration: Why Not Unconditional JSON Normalization
+
+An earlier iteration of this fix unconditionally JSON-marshaled/unmarshaled
+every call's `data`, which trivially guarantees gob-safety but silently
+coerces already-compliant values into different Go types on the way through
+-- `[]string` becomes `[]any`, `int` becomes `float64`. This broke existing
+callers that type-assert on the original shape
+(`pkg/apifrontend/tools/ka_investigate_wiring_test.go`'s
+UT-AF-1922-001/002 and UT-AF-WIRE-SESSION-003 all asserted
+`rcaData["causal_chain"].([]string)` and an `int`-typed
+`tool_calls_count`), i.e. it introduced new, avoidable breakage in the name
+of hardening.
+
+**Chosen fix**: probe `data` with the real `encoding/gob` encoder first
+(`gobProbe`, writing to `io.Discard`) rather than reimplementing gob's own
+type-safety rules as a hand-maintained list. Data that already gob-encodes
+successfully -- true for every existing caller in this package -- is
+returned completely unchanged, type-for-type. Only when the probe fails
+(an actually gob-unsafe value, e.g. a bare struct pointer -- exactly #2110's
+mistake) does `sanitizeArtifactData` fall back to a JSON marshal/unmarshal
+round-trip, which normalizes the offending value into the same
+`map[string]any`/`[]any`/primitive shape every compliant caller already
+produces by convention, then re-probes the result before returning it.
+
+Also added: an explicit `gob.Register(map[string]any{})` /
+`gob.Register([]any{})` in `event_bridge.go`'s own `init()`. This duplicates
+what `a2a-go`'s `internal/taskstore/store.go` already does, but removes this
+package's gob-safety guarantee from depending on that package happening to
+be transitively imported by *something else* in the binary -- an implicit
+coupling to an unrelated import-graph decision, not a guarantee this
+codebase controls. `gob.Register` is idempotent, so the duplicate
+registration is harmless.
+
+## 2. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **SI-10** | Information Input/Output Validation | The core control, same as #2110: the SSE artifact pipeline must be able to actually deliver the structured artifact it constructs, for every current and future producer, not just the one already known to be compliant. |
+| **AU-3** | Content of Audit Records | `kubernaut_present_decision`'s SSE artifact is the audit-visible decision record (#1408); a boundary-level guard prevents any future artifact producer from silently dropping that record the way #2110 did. |
+| **SI-11** | Error Handling | When data is genuinely unsanitizable (fails even after JSON normalization, or isn't JSON-marshalable at all), `EmitArtifact` degrades to a text-only artifact and logs + increments a failure metric, rather than propagating an error that kills the whole a2a task the way the original bug did. |
+
+## 3. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-AF-2111-001 (regression) | Unit | A struct pointer nested anywhere in `EmitArtifact`'s `data` must not reach a2a-go's real gob deep-copy pipeline unsanitized -- reproduces the actual gob round-trip, not just a call to `EmitArtifact` | SI-10 | `pkg/apifrontend/launcher/event_bridge_gob_boundary_2111_test.go` |
+| UT-AF-2111-002 | Unit | Legitimate JSON-shaped values (strings, floats, bools, nested maps/slices, nil) are preserved byte-for-byte, type-for-type through `EmitArtifact` -- no new normalization for already-compliant callers | SI-10 | same file |
+| UT-AF-2111-003 (defense-in-depth) | Unit | Even without `phase_guard.go`'s `canonicalGroundedRCA` fix, an `EmitArtifact` call carrying a `*tools.RCAData`-shaped struct pointer in `rca` is still made gob-safe by the boundary guard alone -- proves the fix is independent of any one caller staying correct | SI-10, AU-3 | same file |
+| UT-AF-2111-004 | Unit | Data that cannot be made JSON-safe at all (e.g. a channel value) degrades to a text-only artifact instead of failing `EmitArtifact` -- observable via the existing `IncBridgeWriteFailures` counter | SI-11 | same file |
+
+### Tier Coverage Rationale
+
+- **UT** covers this fix completely, for the same reason #2110's did: the
+  actual failure mode is a pure `encoding/gob` property of the data these
+  functions produce, fully reproducible without any of `a2a-go`'s
+  unexported internals -- these tests gob-encode/decode the exact
+  `DataPart.Data` shape `EmitArtifact` hands to `a2a.DataPart`, the literal
+  operation that crashed in production.
+- **IT/E2E**: not added net-new. `EmitArtifact`'s wiring into all three
+  production callers (`emitDecisionEvent`, `crd_tools.go`'s progress
+  snapshot, `ka_investigate_mcp.go`'s RCA artifact) already exists and is
+  already exercised by each of those callers' own IT/E2E coverage; this
+  change modifies `EmitArtifact`'s internal behavior without touching any
+  wiring point, so no new Wiring Manifest row applies (per
+  `.cursor/rules/10-wiring-verification.mdc`, this is hardening existing
+  code, not introducing a new component).
+
+## 4. Validation Results
+
+- `go test ./pkg/apifrontend/launcher/...` -- pass (including the 4 new
+  specs above).
+- `go test ./pkg/apifrontend/...` (full package, all 22 sub-packages) --
+  pass, including the pre-existing `pkg/apifrontend/tools` UT-AF-1922-001/
+  002 and UT-AF-WIRE-SESSION-003 specs that caught the unconditional-JSON-
+  normalization regression during development of this fix.
+- `golangci-lint run pkg/apifrontend/launcher/...` -- 0 issues.
+- `gofmt -l` -- clean.

--- a/pkg/apifrontend/launcher/event_bridge.go
+++ b/pkg/apifrontend/launcher/event_bridge.go
@@ -17,6 +17,10 @@ package launcher
 
 import (
 	"context"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -28,6 +32,19 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/security"
 )
+
+// #2110/#2111: a2a-go@v0.3.15's own internal/taskstore/store.go registers
+// map[string]any and []any at init() too, but relying solely on that
+// package being transitively imported by *something else* in this binary
+// is fragile -- it depends on unrelated import-graph decisions elsewhere in
+// this repo that have nothing to do with EmitArtifact's own correctness.
+// Registering them here as well makes sanitizeArtifactData's gob-safety
+// guarantee self-contained. gob.Register is idempotent, so duplicate
+// registration (here and in a2a-go) is harmless.
+func init() {
+	gob.Register(map[string]any{})
+	gob.Register([]any{})
+}
 
 type contextKey struct{}
 
@@ -563,6 +580,20 @@ func stripEmoji(s string) string {
 // EmitArtifact writes a TaskArtifactUpdateEvent with multi-part content:
 // Part[0] = DataPart (structured JSON), Part[1] = TextPart (human-readable fallback).
 // This is the A2A v1.0-compliant way to deliver structured results to clients.
+//
+// EmitArtifact is the single choke point every artifact producer in this
+// package (present_decision's emitDecisionEvent, crd_tools.go's progress
+// snapshot, ka_investigate_mcp.go's RCA artifact) shares before data
+// reaches a2a-go@v0.3.15's task manager, which gob-encodes every artifact
+// for its internal deep-copy fan-out (#2110/#2111: a *tools.RCAData struct
+// pointer reaching that pipeline unregistered crashed every grounded
+// present_decision call in v1.5.6-rc4 with "gob: type not registered for
+// interface: tools.RCAData"). #2112/#2113 fixed that one call site by
+// changing its return type, but nothing stopped a *future* caller from
+// reintroducing the identical crash by assigning any other struct into any
+// nested field of an artifact's data map. sanitizeArtifactData below closes
+// that gap here, at the boundary every caller shares, instead of relying on
+// each caller to remember the map[string]any convention.
 func (b *EventBridge) EmitArtifact(ctx context.Context, data map[string]any, textFallback string, meta map[string]any) error {
 	if b == nil || b.queue == nil {
 		return nil
@@ -570,10 +601,19 @@ func (b *EventBridge) EmitArtifact(ctx context.Context, data map[string]any, tex
 
 	parts := make(a2a.ContentParts, 0, 2)
 	if data != nil {
-		parts = append(parts, a2a.DataPart{
-			Data:     data,
-			Metadata: map[string]any{"mediaType": "application/json"},
-		})
+		safe, err := sanitizeArtifactData(data)
+		if err != nil {
+			logr.FromContextOrDiscard(ctx).Error(err, "artifact data is not gob-safe for a2a-go's deep-copy pipeline -- "+
+				"dropping structured DataPart and falling back to text-only artifact (#2110/#2111 boundary guard)")
+			if b.metrics != nil {
+				b.metrics.IncBridgeWriteFailures()
+			}
+		} else {
+			parts = append(parts, a2a.DataPart{
+				Data:     safe,
+				Metadata: map[string]any{"mediaType": "application/json"},
+			})
+		}
 	}
 	parts = append(parts, a2a.TextPart{Text: textFallback})
 
@@ -624,6 +664,60 @@ var emojiRanges = []emojiRange{
 	{0x20E3, 0x20E3},   // Combining Enclosing Keycap
 	{0x2300, 0x23FF},   // Misc Technical (includes hourglass, keyboard, etc.)
 	{0x2B50, 0x2B55},   // Stars and circles
+}
+
+// sanitizeArtifactData guarantees data can survive a2a-go@v0.3.15's task
+// manager's gob-encoded deep-copy fan-out (#2110/#2111 -- see EmitArtifact's
+// doc comment for full context), regardless of what any current or future
+// artifact producer puts into an interface{}-typed field.
+//
+// The fast path probes data with the REAL encoding/gob encoder (gobProbe)
+// rather than a hand-maintained list of "safe" types, so it stays correct
+// if Go's or a2a-go's own registered type set ever changes. Data that is
+// already gob-safe -- which is every existing caller in this package,
+// since map[string]any/[]any/string/bool/nil/float64 and Go's own
+// gob-builtin slice types ([]string, []int, etc., see encoding/gob's own
+// type.go init()) all pass -- is returned completely unchanged, byte-for-
+// byte and type-for-type. This matters: an earlier version of this fix
+// naively JSON-round-tripped every call unconditionally, which silently
+// coerced already-compliant []string/int values into []any/float64 and
+// broke existing callers asserting on the original Go types (regression
+// caught by UT-AF-1922-001/002 and UT-AF-WIRE-SESSION-003 in
+// pkg/apifrontend/tools) -- exactly the kind of new, avoidable breakage a
+// boundary hardening fix must not introduce.
+//
+// Only when gobProbe finds something actually unsafe (e.g. a bare struct
+// value/pointer, exactly #2110's mistake) does this fall back to a JSON
+// marshal/unmarshal round-trip, which normalizes the offending value into
+// the same map[string]any/[]any/primitive shape every compliant caller in
+// this package already produces by convention -- turning that convention
+// into a structural guarantee instead of something merely documented.
+func sanitizeArtifactData(data map[string]any) (map[string]any, error) {
+	if gobProbe(data) == nil {
+		return data, nil
+	}
+
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("artifact data is not JSON-marshalable: %w", err)
+	}
+	var safe map[string]any
+	if err := json.Unmarshal(raw, &safe); err != nil {
+		return nil, fmt.Errorf("artifact data failed JSON round-trip: %w", err)
+	}
+	if err := gobProbe(safe); err != nil {
+		return nil, fmt.Errorf("artifact data remains gob-unsafe after JSON normalization: %w", err)
+	}
+	return safe, nil
+}
+
+// gobProbe reports whether v can be gob-encoded through an interface{}
+// value, using a scratch encoder discarded after one use so probing never
+// has observable side effects (gob.Encoder accumulates per-instance type
+// definitions across calls, purely as a wire-size optimization, but that
+// state never escapes this function).
+func gobProbe(v any) error {
+	return gob.NewEncoder(io.Discard).Encode(v)
 }
 
 // isEmoji returns true if the rune is a Unicode emoji codepoint.

--- a/pkg/apifrontend/launcher/event_bridge_gob_boundary_2111_test.go
+++ b/pkg/apifrontend/launcher/event_bridge_gob_boundary_2111_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launcher_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+)
+
+// #2110/#2111 root cause: a2a-go@v0.3.15's task manager gob-encodes every
+// TaskArtifactUpdateEvent's artifact for its internal deep-copy fan-out
+// (internal/utils.DeepCopy). encoding/gob requires any concrete type stored
+// behind an interface{} to be gob.Register'd first -- a2a-go's own
+// internal/taskstore/store.go registers map[string]any and []any at init(),
+// but nothing in THIS repo ever validates that data handed to
+// EventBridge.EmitArtifact only ever contains those (or other gob-safe
+// primitive) types.
+//
+// The #2112/#2113 fix closed the ONE call site that broke
+// (canonicalGroundedRCA) by changing its return type. That fix was correct
+// but not sufficient: EmitArtifact is the single choke point all THREE
+// current artifact producers (present_decision's emitDecisionEvent,
+// crd_tools.go's progress snapshot, ka_investigate_mcp.go's RCA artifact)
+// share, and nothing there stops a *future* caller from reintroducing the
+// exact same crash class by assigning a struct pointer into any nested
+// field of the data map. These tests exercise EmitArtifact itself --
+// the shared boundary -- rather than any one caller's data shape, and
+// reproduce a2a-go's actual gob round-trip (not just the call to
+// EmitArtifact) so a regression here fails for the same reason production
+// did: a live gob decode error, not just a type assertion.
+var _ = Describe("EmitArtifact gob-safety boundary (#2110/#2111 hardening)", func() {
+	// registerA2AGobTypes mirrors a2a-go@v0.3.15's internal/taskstore/
+	// store.go init(). gob.Register is idempotent, so calling this
+	// alongside that real init() (triggered transitively elsewhere in the
+	// test binary) is safe.
+	registerA2AGobTypes := func() {
+		gob.Register(map[string]any{})
+		gob.Register([]any{})
+	}
+
+	// simulateA2AGoDeepCopy reproduces a2a-go's internal/utils.DeepCopy: a
+	// gob encode/decode round-trip of the artifact DataPart's Data field,
+	// which is the literal operation that crashed in production.
+	simulateA2AGoDeepCopy := func(data map[string]any) error {
+		registerA2AGobTypes()
+		var buf bytes.Buffer
+		if err := gob.NewEncoder(&buf).Encode(data); err != nil {
+			return err
+		}
+		var out map[string]any
+		return gob.NewDecoder(&buf).Decode(&out)
+	}
+
+	// unregisteredStruct is deliberately never gob.Register'd anywhere,
+	// standing in for any future struct type a contributor might
+	// accidentally assign into an artifact's data map (the exact mistake
+	// #2110/#2111 made with *tools.RCAData).
+	type unregisteredStruct struct {
+		Foo string
+		Bar int
+	}
+
+	It("UT-AF-2111-001 (regression): a struct pointer nested anywhere in EmitArtifact's data must not reach a2a-go's gob pipeline unsanitized", func() {
+		queue := &fakeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2111-001", "ctx-2111-001", nil)
+
+		data := map[string]any{
+			"type":    "test_artifact",
+			"summary": "some artifact",
+			"payload": &unregisteredStruct{Foo: "leaked", Bar: 7},
+		}
+		err := launcher.EmitArtifactForTest(ctx, data, "fallback text", nil)
+		Expect(err).NotTo(HaveOccurred(), "EmitArtifact itself must not error on unsafe input -- it must sanitize, not propagate the crash")
+
+		Expect(queue.events).To(HaveLen(1))
+		Expect(launcher.LastArtifactDataForTest(queue.events[0])).To(
+			WithTransform(simulateA2AGoDeepCopy, Succeed()),
+			"the emitted artifact's DataPart.Data must survive a2a-go's real gob deep-copy round-trip -- "+
+				"a raw struct pointer here is exactly what crashed every grounded present_decision call in v1.5.6-rc4",
+		)
+	})
+
+	It("UT-AF-2111-002: legitimate JSON-shaped values (strings, floats, bools, nested maps/slices, nil) are preserved through EmitArtifact", func() {
+		queue := &fakeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2111-002", "ctx-2111-002", nil)
+
+		data := map[string]any{
+			"type":         "investigation_summary",
+			"summary":      "OOMKill detected",
+			"confidence":   0.92,
+			"critical":     true,
+			"missing":      nil,
+			"causal_chain": []any{"MemoryPressure", "Evicted"},
+			"rca": map[string]any{
+				"severity": "critical",
+				"target":   "pod/checkout-service",
+			},
+		}
+		err := launcher.EmitArtifactForTest(ctx, data, "fallback", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		got := launcher.LastArtifactDataForTest(queue.events[0])
+		Expect(got["type"]).To(Equal("investigation_summary"))
+		Expect(got["summary"]).To(Equal("OOMKill detected"))
+		Expect(got["confidence"]).To(Equal(0.92))
+		Expect(got["critical"]).To(Equal(true))
+		Expect(got["missing"]).To(BeNil())
+		Expect(got["causal_chain"]).To(Equal([]any{"MemoryPressure", "Evicted"}))
+		rca, ok := got["rca"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(rca["severity"]).To(Equal("critical"))
+		Expect(rca["target"]).To(Equal("pod/checkout-service"))
+
+		Expect(simulateA2AGoDeepCopy(got)).To(Succeed())
+	})
+
+	It("UT-AF-2111-003 (defense-in-depth, independent of phase_guard.go): even if a future regression reintroduces the exact #2110 *tools.RCAData-shaped struct pointer into present_decision's rca argument, EmitArtifact's own boundary must still make it gob-safe", func() {
+		queue := &fakeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2111-003", "ctx-2111-003", nil)
+
+		type rcaShapedStruct struct {
+			Severity       string
+			Confidence     float64
+			ToolCallsCount int
+			LLMTurns       int
+		}
+		data := map[string]any{
+			"type":       "decision",
+			"session_id": "sess-2110",
+			"rca":        &rcaShapedStruct{Severity: "critical", Confidence: 0.9, ToolCallsCount: 7, LLMTurns: 3},
+		}
+		err := launcher.EmitArtifactForTest(ctx, data, "fallback", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		got := launcher.LastArtifactDataForTest(queue.events[0])
+		Expect(simulateA2AGoDeepCopy(got)).To(Succeed(),
+			"this must pass even without phase_guard.go's canonicalGroundedRCA fix -- the boundary guard is the "+
+				"backstop that closes the bug class regardless of which upstream caller regresses")
+	})
+
+	It("UT-AF-2111-004: data that cannot be made JSON-safe degrades gracefully to a text-only artifact instead of failing the whole task", func() {
+		queue := &fakeQueue{}
+		m := &spyBridgeMetrics{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2111-004", "ctx-2111-004", m)
+
+		data := map[string]any{
+			"type":    "test_artifact",
+			"channel": make(chan int), // unmarshalable by encoding/json
+		}
+		err := launcher.EmitArtifactForTest(ctx, data, "fallback text", nil)
+		Expect(err).NotTo(HaveOccurred(), "unsanitizable data must not fail EmitArtifact -- the task must survive")
+
+		Expect(queue.events).To(HaveLen(1))
+		evt := queue.events[0]
+		Expect(launcher.ArtifactHasDataPartForTest(evt)).To(BeFalse(),
+			"the unsafe DataPart must be dropped entirely rather than emitted half-sanitized")
+		Expect(launcher.ArtifactTextFallbackForTest(evt)).To(Equal("fallback text"),
+			"the human-readable fallback must still reach the client even when structured data is dropped")
+		Expect(m.failuresInc).To(Equal(1),
+			"dropping unsafe artifact data must be observable via the existing write-failure counter (SI-4)")
+	})
+})

--- a/pkg/apifrontend/launcher/export_test.go
+++ b/pkg/apifrontend/launcher/export_test.go
@@ -99,6 +99,53 @@ func EmitArtifactForTest(ctx context.Context, data map[string]any, textFallback 
 	return bridge.EmitArtifact(ctx, data, textFallback, meta)
 }
 
+// LastArtifactDataForTest extracts the DataPart.Data map from a
+// TaskArtifactUpdateEvent, or nil if the event carries no DataPart
+// (#2110/#2111 EmitArtifact gob-safety boundary tests).
+func LastArtifactDataForTest(evt a2a.Event) map[string]any {
+	artEvt, ok := evt.(*a2a.TaskArtifactUpdateEvent)
+	if !ok || artEvt.Artifact == nil {
+		return nil
+	}
+	for _, part := range artEvt.Artifact.Parts {
+		if dp, ok := part.(a2a.DataPart); ok {
+			return dp.Data
+		}
+	}
+	return nil
+}
+
+// ArtifactHasDataPartForTest reports whether the event's artifact carries a
+// DataPart at all, distinct from LastArtifactDataForTest returning nil for
+// an empty-but-present map (#2110/#2111 degraded-artifact assertions).
+func ArtifactHasDataPartForTest(evt a2a.Event) bool {
+	artEvt, ok := evt.(*a2a.TaskArtifactUpdateEvent)
+	if !ok || artEvt.Artifact == nil {
+		return false
+	}
+	for _, part := range artEvt.Artifact.Parts {
+		if _, ok := part.(a2a.DataPart); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ArtifactTextFallbackForTest extracts the TextPart.Text from a
+// TaskArtifactUpdateEvent (#2110/#2111 degraded-artifact assertions).
+func ArtifactTextFallbackForTest(evt a2a.Event) string {
+	artEvt, ok := evt.(*a2a.TaskArtifactUpdateEvent)
+	if !ok || artEvt.Artifact == nil {
+		return ""
+	}
+	for _, part := range artEvt.Artifact.Parts {
+		if tp, ok := part.(a2a.TextPart); ok {
+			return tp.Text
+		}
+	}
+	return ""
+}
+
 // ValidatePayloadForTest exports ValidatePayload for testing.
 func ValidatePayloadForTest(schemaName string, data map[string]any) error {
 	return ValidatePayload(schemaName, data)


### PR DESCRIPTION
## Summary

Triage follow-up to #2110/#2111. #2112/#2113 fixed the one call site that crashed every grounded `kubernaut_present_decision` call in `v1.5.6-rc4` (`canonicalGroundedRCA` returning `*tools.RCAData` instead of `map[string]any`), but that left the underlying structural gap open.

`EventBridge.EmitArtifact` (`pkg/apifrontend/launcher/event_bridge.go`) is the single choke point all three current artifact producers share -- `part_converter.go`'s `emitDecisionEvent` (`present_decision`), `crd_tools.go`'s progress snapshot, and `ka_investigate_mcp.go`'s RCA artifact -- before their data reaches `a2a-go@v0.3.15`'s gob-encoded task-manager deep-copy pipeline. `EmitArtifact` performed **zero validation** of that data's gob-safety. Nothing stopped (and, on `release/v1.5`, still doesn't stop) a future contributor from reintroducing the identical crash class by assigning any other struct into any nested field of an artifact's `data` map. `gob.Register(&RCAData{})` (added by #2112 as defense-in-depth) is a manually-maintained per-type whitelist, not a structural guarantee -- that PR's own comments say as much.

Scoped to `main` only per triage decision; `release/v1.5` keeps #2112's already-shipped fix as-is since it's mid-release.

## Fix

- `EmitArtifact` now calls `sanitizeArtifactData`, which probes `data` with the **real** `encoding/gob` encoder first (not a hand-maintained list of "safe" types). Data that's already gob-safe -- true for every existing caller -- passes through completely unchanged, type-for-type. Only when the probe finds something actually unsafe (a bare struct, exactly #2110's mistake) does it fall back to a JSON marshal/unmarshal normalization pass, then re-probes the result.
- If data still can't be made safe (e.g. a channel value), `EmitArtifact` degrades gracefully to a text-only artifact (drops the `DataPart`, logs, increments the existing `IncBridgeWriteFailures` counter) instead of propagating an error that kills the whole a2a task.
- Registers `map[string]any`/`[]any` in this package's own `init()` rather than relying on `a2a-go`'s `internal/taskstore` package happening to be transitively imported by something else in the binary (fragile, implicit coupling).

**Design note**: an earlier iteration of this fix unconditionally JSON-round-tripped every call, which is simpler but silently coerces already-compliant `[]string`/`int` values into `[]any`/`float64`. That regressed `pkg/apifrontend/tools`' `UT-AF-1922-001`/`002` and `UT-AF-WIRE-SESSION-003` (which assert on the original Go types) -- caught by the full suite before merge, see `docs/testing/2111/TEST_PLAN.md` for the full writeup of why the probe-first approach was chosen instead.

## Testing

- 4 new specs in `event_bridge_gob_boundary_2111_test.go`, reproducing a2a-go's actual gob round-trip (not just a call to `EmitArtifact`) so a regression here fails for the literal reason production did.
- Full `pkg/apifrontend/...` suite passes (all 22 sub-packages), including the pre-existing #1922/WIRE-SESSION specs that caught the unconditional-normalization regression during development.
- `golangci-lint run pkg/apifrontend/launcher/...`: 0 issues.

## Test plan

- [x] RED: new specs fail against pre-fix `EmitArtifact` (unsafe data reaches a2a-go's real gob pipeline uncaught)
- [x] GREEN: all new + existing specs pass post-fix, zero regressions across `pkg/apifrontend/...`
- [x] `golangci-lint` clean, `gofmt` clean

Fixes #2111.