### PR TITLE
fix(v1.5.6): port #2111 gob-safety boundary hardening + fix #2118 confidence drop + fix #2120 gate undeclared-tool retry

### DIFF
--- a/docs/testing/2111/TEST_PLAN.md
+++ b/docs/testing/2111/TEST_PLAN.md
@@ -1,0 +1,120 @@
+# Test Plan: #2111 — `EmitArtifact` gob-safety Boundary Hardening (backport to `release/v1.5`, milestone v1.5.6)
+
+## 1. Purpose
+
+[#2110](https://github.com/jordigilh/kubernaut/issues/2110) was a
+release-blocking regression on this branch: every `kubernaut_present_decision`
+call with grounded RCA content crashed the a2a task with `gob: type not
+registered for interface: tools.RCAData`, because `canonicalGroundedRCA`
+returned a raw `*tools.RCAData` struct pointer that reached
+`a2a-go@v0.3.15`'s gob-encoded task-manager deep-copy pipeline unregistered.
+
+`release/v1.5` already carries #2110's own fix (`canonicalGroundedRCA`
+returns `map[string]any`, not `*tools.RCAData`), which closed the one call
+site that broke in v1.5.6-rc4. That fix was correct but not sufficient: it
+left the underlying structural gap open. `EventBridge.EmitArtifact`
+(`pkg/apifrontend/launcher/event_bridge.go`) is the single choke point all
+three current artifact producers share -- `part_converter.go`'s
+`emitDecisionEvent` (`present_decision`), `crd_tools.go`'s progress
+snapshot, and `ka_investigate_mcp.go`'s RCA artifact -- before their `data`
+reaches that same gob pipeline, and `EmitArtifact` performed zero
+validation of `data`'s gob-safety. Nothing stopped a future contributor from
+reintroducing the identical crash class by assigning any other struct into
+any nested field of an artifact's `data` map.
+
+This is a straight backport of the equivalent hardening merged to `main` as
+[#2111](https://github.com/jordigilh/kubernaut/issues/2111) (PR
+[#2117](https://github.com/jordigilh/kubernaut/pull/2117)). `main`'s
+`event_bridge.go` had diverged structurally from this branch's (added
+`ClusterID`, `EmitReasoningContent`, context-aware `sanitizeTextWithLimit`,
+etc.), so the hardening logic below was re-applied to `release/v1.5`'s
+current file rather than cherry-picked.
+
+### Root Cause Detail (recap, see #2110's own `docs/testing/2110/TEST_PLAN.md` for the original incident)
+
+`encoding/gob` requires any concrete type stored behind an `interface{}` to
+be `gob.Register`'d before it can be encoded, UNLESS it's one of a small set
+of types Go's own `encoding/gob` package pre-registers for itself at
+`init()` (`type.go`): the basic numeric/string/bool types and a handful of
+their unnamed slice forms (`[]string`, `[]int`, `[]byte`, etc.). Named
+struct types, `map[string]any`, and `[]any` are never in that built-in set --
+`a2a-go@v0.3.15`'s own `internal/taskstore/store.go` registers
+`map[string]any` and `[]any` itself at `init()` for exactly this reason.
+
+### Design Consideration: Why Not Unconditional JSON Normalization
+
+An earlier iteration of the `main` fix unconditionally JSON-marshaled/
+unmarshaled every call's `data`, which trivially guarantees gob-safety but
+silently coerces already-compliant values into different Go types on the
+way through -- `[]string` becomes `[]any`, `int` becomes `float64`. This
+broke existing callers that type-assert on the original shape
+(`pkg/apifrontend/tools/ka_investigate_wiring_test.go`'s UT-AF-1922-001/002
+and UT-AF-WIRE-SESSION-003 all asserted `rcaData["causal_chain"].([]string)`
+and an `int`-typed `tool_calls_count`), i.e. it introduced new, avoidable
+breakage in the name of hardening. This backport carries the same design
+decision forward and re-validates against this branch's copy of those same
+regression specs (see Validation Results below).
+
+**Chosen fix**: probe `data` with the real `encoding/gob` encoder first
+(`gobProbe`, writing to `io.Discard`) rather than reimplementing gob's own
+type-safety rules as a hand-maintained list. Data that already gob-encodes
+successfully -- true for every existing caller in this package -- is
+returned completely unchanged, type-for-type. Only when the probe fails
+(an actually gob-unsafe value, e.g. a bare struct pointer -- exactly #2110's
+mistake) does `sanitizeArtifactData` fall back to a JSON marshal/unmarshal
+round-trip, which normalizes the offending value into the same
+`map[string]any`/`[]any`/primitive shape every compliant caller already
+produces by convention, then re-probes the result before returning it.
+
+Also added: an explicit `gob.Register(map[string]any{})` /
+`gob.Register([]any{})` in `event_bridge.go`'s own `init()`. This duplicates
+what `a2a-go`'s `internal/taskstore/store.go` already does, but removes this
+package's gob-safety guarantee from depending on that package happening to
+be transitively imported by *something else* in the binary -- an implicit
+coupling to an unrelated import-graph decision, not a guarantee this
+codebase controls. `gob.Register` is idempotent, so the duplicate
+registration is harmless.
+
+## 2. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **SI-10** | Information Input/Output Validation | The core control, same as #2110: the SSE artifact pipeline must be able to actually deliver the structured artifact it constructs, for every current and future producer, not just the one already known to be compliant. |
+| **AU-3** | Content of Audit Records | `kubernaut_present_decision`'s SSE artifact is the audit-visible decision record (#1408); a boundary-level guard prevents any future artifact producer from silently dropping that record the way #2110 did. |
+| **SI-11** | Error Handling | When data is genuinely unsanitizable (fails even after JSON normalization, or isn't JSON-marshalable at all), `EmitArtifact` degrades to a text-only artifact and logs + increments a failure metric, rather than propagating an error that kills the whole a2a task the way the original bug did. |
+
+## 3. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-AF-2111-001 (regression) | Unit | A struct pointer nested anywhere in `EmitArtifact`'s `data` must not reach a2a-go's real gob deep-copy pipeline unsanitized -- reproduces the actual gob round-trip, not just a call to `EmitArtifact` | SI-10 | `pkg/apifrontend/launcher/event_bridge_gob_boundary_2111_test.go` |
+| UT-AF-2111-002 | Unit | Legitimate JSON-shaped values (strings, floats, bools, nested maps/slices, nil) are preserved byte-for-byte, type-for-type through `EmitArtifact` -- no new normalization for already-compliant callers | SI-10 | same file |
+| UT-AF-2111-003 (defense-in-depth) | Unit | Even without `phase_guard.go`'s `canonicalGroundedRCA` fix, an `EmitArtifact` call carrying a `*tools.RCAData`-shaped struct pointer in `rca` is still made gob-safe by the boundary guard alone -- proves the fix is independent of any one caller staying correct | SI-10, AU-3 | same file |
+| UT-AF-2111-004 | Unit | Data that cannot be made JSON-safe at all (e.g. a channel value) degrades to a text-only artifact instead of failing `EmitArtifact` -- observable via the existing `IncBridgeWriteFailures` counter | SI-11 | same file |
+
+### Tier Coverage Rationale
+
+- **UT** covers this fix completely, for the same reason #2110's did: the
+  actual failure mode is a pure `encoding/gob` property of the data these
+  functions produce, fully reproducible without any of `a2a-go`'s
+  unexported internals -- these tests gob-encode/decode the exact
+  `DataPart.Data` shape `EmitArtifact` hands to `a2a.DataPart`, the literal
+  operation that crashed in production.
+- **IT/E2E**: not added net-new. `EmitArtifact`'s wiring into all three
+  production callers (`emitDecisionEvent`, `crd_tools.go`'s progress
+  snapshot, `ka_investigate_mcp.go`'s RCA artifact) already exists and is
+  already exercised by each of those callers' own IT/E2E coverage; this
+  change modifies `EmitArtifact`'s internal behavior without touching any
+  wiring point, so no new Wiring Manifest row applies.
+
+## 4. Validation Results
+
+- `go test ./pkg/apifrontend/launcher/...` -- pass (including the 4 new
+  specs above).
+- `go test ./pkg/apifrontend/...` (full package) -- pass, confirming this
+  branch's own equivalents of the `pkg/apifrontend/tools` UT-AF-1922-001/002
+  and UT-AF-WIRE-SESSION-003 specs (which caught the unconditional-JSON-
+  normalization regression during the original `main` fix's development)
+  still pass unchanged.
+- `golangci-lint run pkg/apifrontend/launcher/...` -- 0 issues.
+- `gofmt -l` -- clean.

--- a/docs/testing/2118/TEST_PLAN.md
+++ b/docs/testing/2118/TEST_PLAN.md
@@ -1,0 +1,137 @@
+# Test Plan: #2118 — Same-Kind Validation Gate Retry Silently Drops RCA Confidence
+
+## 1. Purpose
+
+`sameKindValidationGate` (`internal/kubernautagent/investigator/investigator_gates.go`)
+fires when the LLM's initial RCA `remediation_target.kind` equals the input
+signal's own resource kind (a signal often propagating upward from a child
+resource, e.g. a Pod OOM manifesting as Node `DiskPressure`). It sends a
+correction prompt asking the LLM to re-evaluate whether a child resource is
+the true root cause, then retries the LLM call with only `submit_result`
+declared as a tool.
+
+The gate already had a "lost field, keep original" guard for
+`RemediationTarget.Kind` (added for a prior issue): if the retry response
+drops the target entirely, the original result is kept rather than
+discarded. It had **no equivalent guard for `Confidence`**. Because the
+correction prompt reads as a narrow yes/no question ("is the target
+correct?"), the LLM frequently responds with a minimal tool call that
+answers only that question and omits (or zeroes) the separately-required
+`confidence` field. Since `sameKindValidationGate` accepted
+`retryResult.Confidence` unconditionally whenever `RemediationTarget.Kind`
+was non-empty, this silently overwrote a real, previously-validated
+confidence score with `0.0` -- corrupting the audit-visible RCA record and,
+by extension, `investigator_phases.go`'s `MergePhase1Fallbacks`, which only
+backfills Phase 3's confidence from Phase 1's (`p1.Confidence`) when Phase 3
+itself is `0` -- it has no way to know Phase 1's own value was already
+corrupted by the gate before it ever reached that merge step.
+
+### Live-LLM Spike (completed prior to implementation)
+
+Before implementing, a throwaway Go program (`cmd/spike2118main/`, deleted
+after the run) probed the real `claude-sonnet-5` model on Vertex AI (the
+same auth path production uses) with the actual `sameKindCorrectionMessage`
+wording, a realistic multi-turn synthetic investigation history, and only
+`submitOnlyRCATools()` declared -- matching production's exact request
+shape -- across 8 trials per wording variant (current vs. a strengthened
+candidate).
+
+**Finding 1 (confirms the bug is real, not theoretical):** one old-wording
+trial reproduced the exact #2118 symptom live: the model's `submit_result`
+tool call omitted `confidence` entirely while `due_diligence.target_accuracy`
+was fully and coherently populated -- i.e. the model treated the retry as
+"just confirm the target," exactly as the root-cause theory predicted.
+
+**Finding 2 (limits how much weight prompt wording alone can carry):** in
+both variants, the model frequently (4/8 old, 7/8 new trials) called a tool
+name that was not in the declared `Tools` list at all, instead of
+`submit_result`. This is a separate, pre-existing reliability gap (filed
+separately, see Scope below), but it also means the clean, comparable
+sample for the wording A/B was too small to validate the wording change on
+its own. **Conclusion**: ship the strengthened wording as a best-effort,
+defense-in-depth improvement, but treat the deterministic code-level
+backfill guard as the actual, load-bearing fix -- mirroring the project's
+dual-layer approach to #2110/#2111 (fix the source, then guard the
+boundary).
+
+### Scope
+
+A secondary finding from the spike -- the same-kind (and API-version) gate
+retry sometimes calls an undeclared tool instead of `submit_result`, so the
+correction is silently skipped entirely -- is out of scope for this fix and
+tracked separately: [#2120](https://github.com/jordigilh/kubernaut/issues/2120)
+(v1.5.6) / [#2121](https://github.com/jordigilh/kubernaut/issues/2121) (v1.6
+clone).
+
+## 2. Chosen Fix (defense-in-depth)
+
+1. **Strengthened prompt** (`sameKindValidationGate`'s `correctionMsg`):
+   added a second paragraph instructing the LLM to resubmit a *complete*
+   RCA result -- confidence genuinely recomputed (not a placeholder or
+   default), severity, and causal_chain at the same rigor as the original
+   submission -- regardless of which target it concludes is correct.
+2. **Confidence-backfill guard** (the deterministic fix, applied
+   immediately after the existing `RemediationTarget.Kind` guard):
+
+```go
+if retryResult.Confidence <= 0 && result.Confidence > 0 {
+    inv.logger.Info("same-kind validation gate: retry lost confidence, keeping original",
+        "original_confidence", result.Confidence, "correlation_id", correlationID)
+    retryResult.Confidence = result.Confidence
+}
+```
+
+   Unlike the `RemediationTarget.Kind` guard (which discards the entire
+   retry on loss), this backfills only the regressed field -- other
+   genuinely new retry content (e.g. an updated
+   `due_diligence.target_accuracy` narrative) is preserved rather than
+   discarded.
+
+No Wiring Manifest row: this modifies existing, already-wired gate logic
+(`Investigate()` -> `sameKindValidationGate`); no new production entry point.
+
+## 3. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **SI-10** | Information Input/Output Validation | A retry's `confidence` value must be validated against regression, not blindly trusted just because it satisfies schema bounds (`[0,1]`, `parser/schema.go`). |
+| **AU-3** | Content of Audit Records | Confidence surfaced to operators/Console and persisted in the audit-visible RCA record must reflect genuine RCA certainty, not a silently-dropped placeholder. |
+
+## 4. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-KA-2118-001 (regression) | Unit (exercised through the real `Investigate()` production path) | Same-kind gate retry confirms the same target but the tool call arguments omit confidence entirely; the pre-retry confidence (0.88) must be backfilled through to the final merged result, not silently dropped to 0 | SI-10, AU-3 | `internal/kubernautagent/investigator/samekind_confidence_2118_test.go` |
+| UT-KA-2118-002 | Unit | Retry genuinely recomputes a different, non-zero confidence (0.55); the gate must preserve it unchanged, not overwrite it with the pre-retry value | SI-10 | same file |
+| UT-KA-2118-003 (edge case) | Unit | The pre-retry confidence was itself never set (0) and the retry also omits it; the guard must not fabricate a non-zero confidence out of another zero value | SI-10 | same file |
+| UT-KA-2118-004 | Unit | The correction message sent to the LLM must explicitly instruct it to restate confidence as part of a full RCA restatement, not just confirm/deny the target | AU-3 | same file |
+
+### Tier Coverage Rationale
+
+- **UT** (via the real `Investigate()` entry point, following this
+  package's established pattern in `apiversion_gate_test.go` and
+  `gate_history_propagation_1935_test.go`) covers this fix completely: the
+  bug is a pure business-logic property of `sameKindValidationGate`'s own
+  retry-acceptance branch, fully reproducible with a mock `llm.Client` and
+  no external dependencies. UT-KA-2118-001/003 specifically route the
+  synthetic workflow-selection response's own confidence to `0` (via
+  `gateWfToolResp` omitting `confidence`) so the assertion exercises
+  `investigator_phases.go`'s `MergePhase1Fallbacks` backfill from Phase 1's
+  post-gate `p1.Confidence` -- isolating whether the gate itself preserved
+  or corrupted that value, independent of Phase 3's own confidence.
+- **IT/E2E**: not added net-new. The gate's wiring into the production
+  `Investigate()` path already exists and is already exercised by the
+  existing `apiversion_gate_test.go`/`gate_history_propagation_1935_test.go`
+  suites plus this fix's own UT specs (which call through that same real
+  entry point); this change modifies the gate's internal retry-acceptance
+  behavior without adding a new wiring point.
+
+## 5. Validation Results
+
+- `go test ./internal/kubernautagent/investigator/...` -- pass (including
+  the 4 new UT-KA-2118-XXX specs above; UT-KA-2118-001/004 failed against
+  the unmodified gate, confirming RED before the fix was applied).
+- `go test ./internal/kubernautagent/...` (full package) -- pass, no
+  regressions.
+- `golangci-lint run internal/kubernautagent/investigator/...` -- 0 issues.
+- `gofmt -l` -- clean.

--- a/docs/testing/2120/TEST_PLAN.md
+++ b/docs/testing/2120/TEST_PLAN.md
@@ -1,0 +1,169 @@
+# Test Plan: #2120 — Gate Retry Silently Skips Correction on Undeclared Tool Call
+
+## 1. Purpose
+
+`sameKindValidationGate` and `apiVersionValidationGate`
+(`internal/kubernautagent/investigator/investigator_gates.go`) both send
+their gate-retry LLM call with only a single declared tool
+(`submitResultOnlyTools()`, i.e. just `submit_result`). Discovered during the
+#2118 live-LLM spike: the model does not always respect this constraint --
+it frequently returns a `tool_use` block naming a tool that was never
+declared in the request's `tools` array (e.g. `kubectl_describe`,
+`get_namespaced_resource_context`) instead of calling `submit_result`.
+
+Pre-#2120, this did not corrupt data or crash: the gate's tool-call scan
+found no `submit_result` call, fell back to `resp.Message.Content` (empty,
+since the model's turn was pure tool-use), and correctly treated the empty
+content as an error path -- logging "no content in retry response, keeping
+original" and returning the pre-retry result unchanged.
+
+The problem was **silent correction loss, indistinguishable from a
+genuinely empty response**: the gate believed it attempted a correction, but
+the LLM never engaged with the correction prompt at all. Neither gate's
+audit event distinguished "LLM re-evaluated and confirmed/changed the
+target" from "LLM never got the chance to re-evaluate because it wanted a
+different tool" -- both fell into the same opaque bucket (no `retry_outcome`
+at all for `sameKindValidationGate`; a hardcoded `"exhausted"` for
+`apiVersionValidationGate`, indistinguishable from every other failure mode).
+
+### Live-LLM Spike (completed prior to implementation)
+
+A throwaway Go program (`cmd/spike2120main/`, deleted after the run) reused
+the production `vertexanthropic` client construction path (`claude-sonnet-5`
+on Vertex AI, real project/credentials pulled from the cluster's
+`kubernaut-agent-llm-runtime` ConfigMap / `llm-credentials` Secret) to
+reproduce the same-kind gate retry with a realistic multi-turn synthetic
+investigation history, matching production's exact request shape
+(`submitResultOnlyTools()` declared, `JSONMode: true`).
+
+- **10/10 trials**: the first gate-retry attempt called `kubectl_describe`
+  instead of `submit_result` -- confirming the bug is not rare, it is the
+  *dominant* outcome for this prompt/tool-set shape.
+- **10/10 trials**: after replaying that wrong call as a synthetic
+  `tool_result` "not available" error plus one explicit reminder message,
+  the **second** attempt correctly called `submit_result`.
+
+This gave strong empirical confidence that "detect undeclared tool -> retry
+once with reminder" (the issue's suggested fix option 1) is a highly
+effective, low-risk fix. Option 3 from the issue (forcing `tool_choice`) was
+out of scope: `llm.ChatOptions` (`pkg/kubernautagent/llm/types.go`) has no
+`ToolChoice` field today, and production also routes through
+`pkg/kubernautagent/llm/langchaingo/adapter.go` for non-`vertex_ai`
+providers, where equivalent support is unconfirmed -- left as a separate
+future issue if ever needed.
+
+## 2. Chosen Fix
+
+1. **`gateRetrySubmitContent(resp)`** classifies a gate-retry response:
+   returns `submit_result`'s tool-call arguments if present (falling back to
+   raw message content, mirroring pre-#2120 behavior for bare-JSON-text
+   responses), plus the names of any other tool(s) called instead.
+2. **`retryGateOnUnexpectedTool(...)`** re-issues the gate-retry call once
+   more when an undeclared tool was called: replays that call as a
+   synthetic `tool_result` "not available" error, plus an explicit reminder
+   that only `submit_result` is available, then re-sends with the same
+   single-tool declaration.
+3. Both gates now route through these two helpers. On recovery, the outcome
+   is tagged `resolved_after_other_tool_retry`, distinct from a first-try
+   `resolved`. On persistence of the undeclared-tool behavior across both
+   attempts, the outcome is tagged `llm_requested_other_tool`, distinct from
+   `empty_response`/`parse_error`/generic `exhausted` -- so production
+   frequency of each specific failure mode becomes observable.
+4. `apiVersionGateExhaustion` now takes the outcome as a parameter instead
+   of hardcoding `"exhausted"`, since it is called for more distinct reasons
+   post-#2120. Confirmed via Serena's `find_referencing_symbols` that it has
+   exactly 4 call sites, all within `apiVersionValidationGate` in the same
+   file -- the signature change is fully self-contained.
+5. `submitResultOnlyTools()` extracted as a shared helper, deduplicating the
+   identical `[]llm.ToolDefinition{...}` literal previously repeated in both
+   gates (REFACTOR phase).
+
+### Secondary finding fixed in the same change: dead `retry_outcome`/`EventOutcome`
+
+While restructuring both gates' audit-event lifecycle to add the new
+`retry_outcome` values, a **pre-existing** bug was found and fixed --
+tracked separately for traceability as
+[#2124](https://github.com/jordigilh/kubernaut/issues/2124):
+`apiVersionValidationGate` called `audit.StoreBestEffort(gateEvent, ...)`
+*before* the gate-retry LLM call, then mutated `gateEvent.Data["retry_outcome"]`
+*afterward*. Real production audit stores
+(`internal/kubernautagent/audit/ds_store.go`'s `DSAuditStore`/
+`BufferedDSAuditStore`) synchronously serialize `event.Data` into the
+outbound request **at call time**, so that mutation was never actually
+persisted. The existing unit-test double (`gateRecordingAuditStore`) masked
+this by storing the raw `*audit.AuditEvent` **pointer**, so an in-memory
+read after `Investigate()` returned always reflected the final state
+regardless of when `StoreAudit` was actually called.
+
+Fix: both gates now `defer audit.StoreBestEffort(...)` immediately after
+building `gateEvent`, so the store call fires once, after every `Data`/
+`EventOutcome` mutation on every exit path has already happened. The shared
+`gateRecordingAuditStore.StoreAudit` (`apiversion_gate_test.go`, used by 11
+test files) now snapshots `event.Data` (map copy) at call time, matching
+real production semantics -- verified via Serena's `search_for_pattern`
+that no other `StoreBestEffort` call site in this package mutates `Data`
+after storing, so this test-fidelity fix carries zero regression risk for
+the other 10 files sharing the fixture. A related smaller defect fixed
+alongside: both gates previously hardcoded `gateEvent.EventOutcome =
+audit.OutcomeSuccess` unconditionally at construction; both now set it per
+exit path (`Success` only on genuine resolution, `Failure` on every
+failure/exhaustion branch), matching the sibling `CheckWorkflowTargetAlignment`
+gate's existing convention.
+
+No Wiring Manifest row: both gates already wire into the production
+`Investigate()` path; this change modifies their internal retry-handling
+and audit-emission logic without adding a new production entry point.
+
+## 3. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **AU-3** | Content of Audit Records | The audit trail must distinguish "the LLM re-evaluated and answered" from "the LLM never engaged with the correction at all," and must actually persist that distinction (fixing the dead-mutation defect) rather than silently dropping it before it reaches the real audit store. |
+| **SI-10** | Information Input/Output Validation | A gate correction must be actually delivered and answered before its result is trusted; an undeclared-tool response must not be silently conflated with a validated confirmation. |
+
+## 4. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-KA-2120-001 (regression) | Unit (via real `Investigate()`) | Same-kind gate's retry calls an undeclared tool on attempt 1, `submit_result` on attempt 2 (reminder recovery) -> final result reflects attempt 2's data; `retry_outcome == "resolved_after_other_tool_retry"`, `EventOutcome == success` | AU-3, SI-10 | `internal/kubernautagent/investigator/gate_undeclared_tool_2120_test.go` |
+| UT-KA-2120-002 | Unit | Same-kind gate's retry calls an undeclared tool on both attempts -> original result kept (pre-#2120 fallback behavior preserved); `retry_outcome == "llm_requested_other_tool"`, `EventOutcome == failure` | AU-3 | same file |
+| UT-KA-2120-003 | Unit | API-version gate mirrors 001: undeclared tool then correct `api_version` on reminder -> recovered, no human review, `retry_outcome == "resolved_after_other_tool_retry"` | AU-3, SI-10 | same file |
+| UT-KA-2120-004 | Unit | API-version gate mirrors 002: undeclared tool on both attempts -> human review still triggered (`rca_incomplete`) to prevent incorrect RBAC grants, `retry_outcome == "llm_requested_other_tool"`, `EventOutcome == failure` | SI-10 | same file |
+| UT-KA-2120-005 (regression for #2124) | Unit | With the fixed, honest `gateRecordingAuditStore` (snapshotting at call time), a plain successful same-kind retry shows `retry_outcome == "resolved"`/`EventOutcome == success`, and a plain exhausted api-version retry shows `retry_outcome == "exhausted"`/`EventOutcome == failure` -- proving both are captured by `StoreAudit` at call time, not just recoverable from a later in-memory pointer read | AU-3 | same file |
+
+### Tier Coverage Rationale
+
+- **UT** (via the real `Investigate()` entry point, following this
+  package's established convention in `apiversion_gate_test.go` and
+  `samekind_confidence_2118_test.go`) covers this fix completely: the
+  undeclared-tool-retry behavior and the audit-timing fix are both pure
+  business-logic properties of the two gates' retry-handling and
+  audit-emission code, fully reproducible with a mock `llm.Client` and no
+  external dependencies.
+- **IT/E2E**: not added net-new. Both gates' wiring into the production
+  `Investigate()` path already exists and is already exercised by the
+  existing `apiversion_gate_test.go`/`gate_history_propagation_1935_test.go`/
+  `gate_keepalive_2086_test.go` suites plus this fix's own UT specs (which
+  call through that same real entry point); this change modifies internal
+  retry-handling and audit-emission behavior without adding a new wiring
+  point. `test/integration/kubernautagent/investigator/...` was re-run to
+  confirm no regression (its `recordingAuditStore` test double has the same
+  by-pointer capture pattern as the pre-fix unit double, but no IT asserts
+  on `retry_outcome`/`EventOutcome` values or store-call ordering, so it is
+  unaffected either way).
+
+## 5. Validation Results
+
+- `go test ./internal/kubernautagent/investigator/...` -- pass, 286/286
+  specs (including the 6 new UT-KA-2120-XXX specs above; all 6 failed
+  against the unmodified gates, confirming RED before the fix was applied).
+- `go test ./internal/kubernautagent/...` (full package) -- pass, no
+  regressions.
+- `go test ./test/integration/kubernautagent/investigator/...` -- pass,
+  117/117 specs, no regressions.
+- `go test ./test/integration/kubernautagent/...` (full package) -- pass
+  except two pre-existing, unrelated envtest infrastructure failures
+  (`enrichment`, `tools/custom`: missing local `/usr/local/kubebuilder/bin/etcd`
+  binary in this environment) -- unaffected by this change.
+- `golangci-lint run internal/kubernautagent/investigator/...` -- 0 issues.
+- `go build ./...` -- clean.

--- a/internal/kubernautagent/investigator/apiversion_gate_test.go
+++ b/internal/kubernautagent/investigator/apiversion_gate_test.go
@@ -81,7 +81,21 @@ type gateRecordingAuditStore struct {
 func (s *gateRecordingAuditStore) StoreAudit(_ context.Context, event *audit.AuditEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.events = append(s.events, event)
+	// #2120: snapshot event.Data (and EventOutcome) at call time, matching
+	// real production audit stores (internal/kubernautagent/audit/ds_store.go's
+	// DSAuditStore/BufferedDSAuditStore), which serialize the event into an
+	// outbound request synchronously here and never see later mutations.
+	// Storing the raw *audit.AuditEvent pointer previously masked a
+	// pre-existing bug (#1044) where callers mutated event.Data AFTER this
+	// call returned -- a real store would have missed that mutation, but a
+	// live pointer read by the test after Investigate() returned would not.
+	snapshot := *event
+	dataCopy := make(map[string]interface{}, len(event.Data))
+	for k, v := range event.Data {
+		dataCopy[k] = v
+	}
+	snapshot.Data = dataCopy
+	s.events = append(s.events, &snapshot)
 	return nil
 }
 

--- a/internal/kubernautagent/investigator/gate_undeclared_tool_2120_test.go
+++ b/internal/kubernautagent/investigator/gate_undeclared_tool_2120_test.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// #2120 (BR-AI-2120, FedRAMP AU-3): sameKindValidationGate and
+// apiVersionValidationGate build their gate-retry LLM call with a
+// submit-result-only tool declaration, but the model frequently ignores that
+// constraint and calls an undeclared tool anyway (e.g. kubectl_describe) — a
+// live-LLM spike against the real production Claude/Vertex client measured
+// this in 10/10 trials for the same-kind gate's correction prompt. Because
+// both gates only recognized a `submit_result` tool call or non-empty
+// message text as "the retry answered", an undeclared-tool response fell
+// through to the same fallback path as a genuinely empty response: the
+// correction is silently dropped and the pre-retry (possibly wrong) result
+// is kept, with no record in the audit trail of *why* the retry failed.
+//
+// The same spike showed a second attempt — replaying the wrong call as a
+// synthetic tool_result error plus an explicit reminder — recovered the
+// correct submit_result call in 10/10 trials. These specs exercise both
+// gates through the real Investigate() production path (mirroring this
+// package's established convention).
+var _ = Describe("#2120: gate retries must recover from (or account for) an undeclared tool call", func() {
+
+	var (
+		logger     logr.Logger
+		auditStore *gateRecordingAuditStore
+		mockClient *gateMockLLMClient
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+	)
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+		auditStore = &gateRecordingAuditStore{}
+		mockClient = &gateMockLLMClient{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		enricher = enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, auditStore, logger)
+		phaseTools = investigator.DefaultPhaseToolMap()
+	})
+
+	sameKindSignal := katypes.SignalContext{
+		ResourceKind: "Pod",
+		ResourceName: "api-server-xyz",
+		Name:         "api-server-xyz",
+		Namespace:    "production",
+		Severity:     "critical",
+		Message:      "Pod OOMKilled repeatedly",
+	}
+
+	apiVersionSignal := katypes.SignalContext{
+		ResourceKind: "Deployment",
+		ResourceName: "etcd-operator-xyz",
+		Name:         "etcd-operator-xyz",
+		Namespace:    "demo-operator",
+		Severity:     "critical",
+		Message:      "RBAC denial on wrong API group",
+	}
+
+	// undeclaredToolResp simulates the model calling a tool other than
+	// submit_result during a gate retry — the #2120 failure mode. Real
+	// responses carry no message text on a pure tool-calling turn.
+	undeclaredToolResp := func(toolName string) llm.ChatResponse {
+		return llm.ChatResponse{
+			Message: llm.Message{Role: "assistant", Content: ""},
+			ToolCalls: []llm.ToolCall{
+				{ID: "tc_undeclared", Name: toolName, Arguments: `{"name":"api-server","namespace":"production"}`},
+			},
+		}
+	}
+
+	Describe("UT-KA-2120-001 (regression): sameKindValidationGate recovers after one undeclared-tool retry", func() {
+		It("must accept the reminder-retry's result and record retry_outcome=resolved_after_other_tool_retry (BR-AI-2120 AC1)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				// Turn 1: RCA submit — same-kind gate fires (target.Kind == signal.ResourceKind == "Pod").
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Pod OOMKilled",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Pod","name":"api-server-xyz","namespace":"production"}
+				}`}},
+				// Gate retry attempt 1: LLM calls an undeclared tool instead of submit_result (#2120).
+				undeclaredToolResp("kubectl_describe"),
+				// Gate retry attempt 2 (after reminder): LLM correctly re-targets the parent Deployment.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Deployment memory limit too low",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production","api_version":"apps/v1"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"increase-memory-limit","confidence":0.9}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), sameKindSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.RemediationTarget.Kind).To(Equal("Deployment"),
+				"UT-KA-2120-001: final result must reflect the reminder retry's data, not the original Pod target")
+			Expect(mockClient.calls).To(HaveLen(4),
+				"UT-KA-2120-001: expected RCA + first gate retry + reminder retry + workflow-selection LLM calls")
+
+			gateEvents := auditStore.eventsByAction(audit.ActionSameKindGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-001: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("resolved_after_other_tool_retry"),
+				"UT-KA-2120-001: audit trail must distinguish a reminder-assisted recovery from a first-try resolution")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeSuccess),
+				"UT-KA-2120-001: a recovered retry is a successful gate outcome")
+		})
+	})
+
+	Describe("UT-KA-2120-002: sameKindValidationGate keeps the original result when the undeclared tool call persists", func() {
+		It("must keep the pre-retry result and record retry_outcome=llm_requested_other_tool (BR-AI-2120 AC2)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Pod OOMKilled",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Pod","name":"api-server-xyz","namespace":"production"}
+				}`}},
+				// Both the initial retry and the reminder retry call an undeclared tool.
+				undeclaredToolResp("kubectl_describe"),
+				undeclaredToolResp("kubectl_describe"),
+				gateWfToolResp(`{"workflow_id":"restart-pod","confidence":0.8}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), sameKindSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.RemediationTarget.Kind).To(Equal("Pod"),
+				"UT-KA-2120-002: original (pre-retry) result must be kept when the reminder retry also fails")
+			Expect(mockClient.calls).To(HaveLen(4),
+				"UT-KA-2120-002: expected RCA + first gate retry + reminder retry + workflow-selection LLM calls")
+
+			gateEvents := auditStore.eventsByAction(audit.ActionSameKindGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-002: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("llm_requested_other_tool"),
+				"UT-KA-2120-002: audit trail must record that the LLM never answered with submit_result")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeFailure),
+				"UT-KA-2120-002: an unresolved retry must be a failed gate outcome, not the hardcoded success of pre-#2120 code")
+		})
+	})
+
+	Describe("UT-KA-2120-003: apiVersionValidationGate recovers after one undeclared-tool retry", func() {
+		It("must accept the reminder-retry's api_version and record retry_outcome=resolved_after_other_tool_retry (BR-AI-2120 AC1)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+				// Gate retry attempt 1: LLM calls an undeclared tool instead of submit_result (#2120).
+				undeclaredToolResp("kubectl_describe"),
+				// Gate retry attempt 2 (after reminder): LLM correctly provides api_version.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator","api_version":"operators.coreos.com/v1alpha1"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"restart-sub","confidence":0.9}`),
+			}
+
+			resolver := investigator.NewMapperScopeResolver(newAmbiguousSubscriptionMapper())
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, ScopeResolver: resolver,
+			})
+
+			result, err := inv.Investigate(context.Background(), apiVersionSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.RemediationTarget.APIVersion).To(Equal("operators.coreos.com/v1alpha1"),
+				"UT-KA-2120-003: final result must reflect the reminder retry's api_version")
+			Expect(result.HumanReviewNeeded).To(BeFalse(),
+				"UT-KA-2120-003: a recovered retry must not trigger human review")
+			Expect(mockClient.calls).To(HaveLen(4),
+				"UT-KA-2120-003: expected RCA + first gate retry + reminder retry + workflow-selection LLM calls")
+
+			gateEvents := auditStore.eventsByAction(audit.ActionAPIVersionGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-003: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("resolved_after_other_tool_retry"),
+				"UT-KA-2120-003: audit trail must distinguish a reminder-assisted recovery from a first-try resolution")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeSuccess),
+				"UT-KA-2120-003: a recovered retry is a successful gate outcome")
+		})
+	})
+
+	Describe("UT-KA-2120-004: apiVersionValidationGate triggers human review when the undeclared tool call persists", func() {
+		It("must trigger human review and record retry_outcome=llm_requested_other_tool (BR-AI-2120 AC2 Security)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+				undeclaredToolResp("kubectl_describe"),
+				undeclaredToolResp("kubectl_describe"),
+			}
+
+			resolver := investigator.NewMapperScopeResolver(newAmbiguousSubscriptionMapper())
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, ScopeResolver: resolver,
+			})
+
+			result, err := inv.Investigate(context.Background(), apiVersionSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.HumanReviewNeeded).To(BeTrue(),
+				"UT-KA-2120-004: an unresolved ambiguous-kind retry must still trigger human review "+
+					"to prevent incorrect RBAC grants, exactly as a plain empty/unparseable retry would")
+			Expect(result.HumanReviewReason).To(Equal("rca_incomplete"),
+				"UT-KA-2120-004: reason must be rca_incomplete, matching the existing exhaustion convention")
+
+			gateEvents := auditStore.eventsByAction(audit.ActionAPIVersionGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-004: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("llm_requested_other_tool"),
+				"UT-KA-2120-004: audit trail must record that the LLM never answered with submit_result")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeFailure),
+				"UT-KA-2120-004: gate exhaustion must be a failed outcome, not the hardcoded success of pre-#2120 code")
+		})
+	})
+
+	// UT-KA-2120-005 is the regression test for the secondary finding: both
+	// gates previously called audit.StoreBestEffort(gateEvent) BEFORE setting
+	// gateEvent.Data["retry_outcome"]/EventOutcome, so a production audit
+	// store — which serializes Data into an outbound request synchronously
+	// at call time (internal/kubernautagent/audit/ds_store.go's
+	// DSAuditStore/BufferedDSAuditStore) — never actually persisted those
+	// fields. gateRecordingAuditStore previously masked this by capturing
+	// the raw *audit.AuditEvent pointer, so a later in-memory read always
+	// reflected the mutation regardless of when StoreAudit was called. Once
+	// fixed to snapshot event.Data at call time (matching real production
+	// stores), this test would fail against the pre-#2120 store-then-mutate
+	// code and passes once the store call is deferred until every Data
+	// mutation has happened (BR-AI-2120 AC3, FedRAMP AU-3).
+	Describe("UT-KA-2120-005 (regression): retry_outcome/EventOutcome are captured at StoreAudit call time, not just in a later in-memory read", func() {
+		It("must have set retry_outcome=resolved and EventOutcome=success on sameKindValidationGate's audit event before storing it", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Pod OOMKilled",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Pod","name":"api-server-xyz","namespace":"production"}
+				}`}},
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Deployment memory limit too low",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production","api_version":"apps/v1"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"increase-memory-limit","confidence":0.9}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), sameKindSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			gateEvents := auditStore.eventsByAction(audit.ActionSameKindGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-005: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("resolved"),
+				"UT-KA-2120-005: retry_outcome must be captured by StoreAudit at call time, not mutated afterward")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeSuccess),
+				"UT-KA-2120-005: EventOutcome must be captured by StoreAudit at call time, not the pre-#2120 "+
+					"unconditional hardcoded success")
+		})
+
+		It("must have set retry_outcome=exhausted and EventOutcome=failure on apiVersionValidationGate's audit event before storing it", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+				// Gate retry still omits api_version -> exhaustion.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+			}
+
+			resolver := investigator.NewMapperScopeResolver(newAmbiguousSubscriptionMapper())
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, ScopeResolver: resolver,
+			})
+
+			result, err := inv.Investigate(context.Background(), apiVersionSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			gateEvents := auditStore.eventsByAction(audit.ActionAPIVersionGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-005: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("exhausted"),
+				"UT-KA-2120-005: retry_outcome must be captured by StoreAudit at call time — this is the "+
+					"pre-existing dead-mutation bug (#1044 lines 336/354) this PR fixes alongside #2120")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeFailure),
+				"UT-KA-2120-005: EventOutcome must reflect the actual (failed) outcome, not the pre-#2120 "+
+					"unconditional hardcoded success")
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/investigator_gates.go
+++ b/internal/kubernautagent/investigator/investigator_gates.go
@@ -53,6 +53,17 @@ func (inv *Investigator) sameKindValidationGate(
 		"signal_resource_kind", signal.ResourceKind,
 		"correlation_id", correlationID)
 
+	// #2118: the original wording below only asked the LLM to confirm or
+	// change remediation_target.kind. Because that reads as a narrow
+	// yes/no question, the LLM often responds with a minimal tool call
+	// that answers only the target question and omits (or zeroes) the
+	// separately-required confidence field -- silently overwriting a
+	// real, previously-validated confidence with a placeholder. The
+	// second paragraph makes the full-restatement requirement explicit.
+	// This is a best-effort, defense-in-depth improvement: a live-LLM
+	// spike (see docs/testing/2118/TEST_PLAN.md) confirmed prompt wording
+	// alone is not reliably sufficient, which is why the guard below is
+	// the actual, deterministic fix.
 	correctionMsg := fmt.Sprintf(
 		`Your remediation_target.kind is "%s", which is the same resource kind as the input signal. `+
 			`Signals often propagate upward: workload-level issues manifest as conditions on parent resources `+
@@ -60,7 +71,12 @@ func (inv *Investigator) sameKindValidationGate(
 			`Please re-evaluate: is a child resource (Deployment, StatefulSet, DaemonSet, Pod) the actual root cause `+
 			`whose configuration should be modified? If after re-evaluation you are confident the %s itself is the `+
 			`correct remediation target, confirm by resubmitting with the same target and explain why in your `+
-			`due_diligence.target_accuracy field.`,
+			`due_diligence.target_accuracy field. `+
+			`Whichever target you conclude is correct, you MUST resubmit a COMPLETE root cause analysis result: `+
+			`restate confidence (genuinely recomputed from the evidence, not a placeholder or default value), `+
+			`severity, and causal_chain at the same rigor as your original submission. Do not omit or zero out `+
+			`confidence just because this is a confirmation -- an incomplete resubmission will be treated as a `+
+			`loss of your prior analysis.`,
 		result.RemediationTarget.Kind,
 		result.RemediationTarget.Kind,
 	)
@@ -145,6 +161,18 @@ func (inv *Investigator) sameKindValidationGate(
 			"original_target", result.RemediationTarget.Kind+"/"+result.RemediationTarget.Name,
 			"correlation_id", correlationID)
 		return result
+	}
+
+	// #2118: unlike the RemediationTarget.Kind guard above, a lost
+	// confidence does not warrant discarding the whole retry -- the
+	// retry's other content (e.g. an updated due_diligence.target_accuracy
+	// narrative) is genuinely new and worth keeping. Only the regressed
+	// field itself is backfilled from the pre-retry result.
+	if retryResult.Confidence <= 0 && result.Confidence > 0 {
+		inv.logger.Info("same-kind validation gate: retry lost confidence, keeping original",
+			"original_confidence", result.Confidence,
+			"correlation_id", correlationID)
+		retryResult.Confidence = result.Confidence
 	}
 
 	inv.logger.Info("same-kind validation gate: accepted retry result",

--- a/internal/kubernautagent/investigator/investigator_gates.go
+++ b/internal/kubernautagent/investigator/investigator_gates.go
@@ -30,6 +30,130 @@ import (
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
 
+// gateRetryOutcome enumerates why a validation-gate retry ended the way it
+// did, recorded in the gate's audit event Data["retry_outcome"] (#2120,
+// BR-AI-2120, FedRAMP AU-3). Prior to #2120 only "resolved"/"exhausted"
+// existed (apiVersionValidationGate only); the additional values give
+// auditors finer-grained visibility into *why* a retry failed instead of a
+// single opaque "exhausted" bucket.
+type gateRetryOutcome string
+
+const (
+	// gateRetryResolved: the retry's first attempt returned a usable
+	// submit_result content.
+	gateRetryResolved gateRetryOutcome = "resolved"
+	// gateRetryResolvedAfterReminder: the retry's first attempt called an
+	// undeclared tool instead of submit_result; a second attempt (replaying
+	// that call as a tool_result error plus an explicit reminder) recovered
+	// a usable submit_result content (#2120).
+	gateRetryResolvedAfterReminder gateRetryOutcome = "resolved_after_other_tool_retry"
+	// gateRetryOtherToolExhausted: the LLM called an undeclared tool on both
+	// the initial retry and the reminder retry (or the reminder retry itself
+	// errored) — the correction was never answered with submit_result (#2120).
+	gateRetryOtherToolExhausted gateRetryOutcome = "llm_requested_other_tool"
+	// gateRetryEmptyResponse: the retry returned no tool calls and no message
+	// content at all.
+	gateRetryEmptyResponse gateRetryOutcome = "empty_response"
+	// gateRetryParseError: the retry's content could not be parsed as an RCA result.
+	gateRetryParseError gateRetryOutcome = "parse_error"
+	// gateRetryExhausted: a generic/infrastructure failure (LLM call error, or
+	// the parsed retry result still failed the gate's own check) with no more
+	// specific outcome above applying.
+	gateRetryExhausted gateRetryOutcome = "exhausted"
+)
+
+// gateRetrySubmitContent classifies a gate-retry LLM response: returns the
+// submit_result tool-call arguments if the model called that tool, else
+// falls back to the raw message content (mirroring the pre-#2120 behavior
+// for models that respond with bare JSON text instead of a tool call).
+// Any tool call to a name other than submit_result is reported in
+// otherTools -- calling an undeclared tool instead of resubmitting the RCA
+// result is the #2120 failure mode this enables detecting.
+func gateRetrySubmitContent(resp llm.ChatResponse) (content string, otherTools []string) {
+	for _, tc := range resp.ToolCalls {
+		if tc.Name == SubmitResultToolName {
+			return tc.Arguments, nil
+		}
+		otherTools = append(otherTools, tc.Name)
+	}
+	if resp.Message.Content != "" {
+		return resp.Message.Content, otherTools
+	}
+	return "", otherTools
+}
+
+// retryGateOnUnexpectedTool re-issues a gate-retry call once more after the
+// model called a tool other than submit_result instead of resubmitting the
+// RCA result. It replays the wrong call(s) as synthetic tool_result "not
+// available" errors, plus an explicit reminder to call submit_result --
+// mirroring the real tool-execution message pattern used elsewhere in this
+// package (see the tool-call loop in Investigate). A live-LLM spike against
+// the production Claude/Vertex client (10/10 trials, see
+// docs/testing/2120/TEST_PLAN.md) confirmed this recovers the correct
+// submit_result call on the very next turn.
+func (inv *Investigator) retryGateOnUnexpectedTool(
+	ctx context.Context,
+	client llm.Client,
+	retryMessages []llm.Message,
+	firstResp llm.ChatResponse,
+	tools []llm.ToolDefinition,
+	tokens *TokenAccumulator,
+	runtimeParams llm.RuntimeParams,
+	correlationID string,
+) (content string, otherTools []string, err error) {
+	assistantMsg := firstResp.Message
+	assistantMsg.ToolCalls = firstResp.ToolCalls
+	retryMessages = append(retryMessages, assistantMsg)
+
+	var calledTools []string
+	for _, tc := range firstResp.ToolCalls {
+		calledTools = append(calledTools, tc.Name)
+		retryMessages = append(retryMessages, llm.Message{
+			Role:       "tool",
+			Content:    fmt.Sprintf("Tool %q is not available for this correction step.", tc.Name),
+			ToolCallID: tc.ID,
+			ToolName:   tc.Name,
+		})
+	}
+	retryMessages = append(retryMessages, llm.Message{
+		Role: "user",
+		Content: "You must call submit_result to resubmit your root cause analysis result. " +
+			"No other tool is available for this correction step.",
+	})
+
+	inv.logger.Info("gate retry: LLM called an undeclared tool, retrying once with reminder",
+		"tools_called", calledTools,
+		"correlation_id", correlationID)
+
+	resp, chatErr := llm.ChatWithParams(ctx, client, llm.ChatRequest{
+		Messages: retryMessages,
+		Tools:    tools,
+		Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
+	}, runtimeParams)
+	if chatErr != nil {
+		return "", nil, chatErr
+	}
+	if tokens != nil {
+		tokens.Add(resp.Usage)
+	}
+
+	content, otherTools = gateRetrySubmitContent(resp)
+	return content, otherTools, nil
+}
+
+// submitResultOnlyTools returns the single-tool declaration shared by both
+// validation gates' retry calls: submit_result is the only tool the LLM is
+// allowed to call when resubmitting its RCA result during a gate correction.
+func submitResultOnlyTools() []llm.ToolDefinition {
+	return []llm.ToolDefinition{
+		{
+			Name:        SubmitResultToolName,
+			Description: "Submit root cause analysis result.",
+			Parameters:  parser.RCAResultSchema(),
+		},
+	}
+}
+
 func (inv *Investigator) sameKindValidationGate(
 	ctx context.Context,
 	result *katypes.InvestigationResult,
@@ -81,13 +205,7 @@ func (inv *Investigator) sameKindValidationGate(
 		result.RemediationTarget.Kind,
 	)
 
-	submitOnlyTools := []llm.ToolDefinition{
-		{
-			Name:        SubmitResultToolName,
-			Description: "Submit root cause analysis result.",
-			Parameters:  parser.RCAResultSchema(),
-		},
-	}
+	submitOnlyTools := submitResultOnlyTools()
 
 	retryMessages := make([]llm.Message, len(history))
 	copy(retryMessages, history)
@@ -101,14 +219,21 @@ func (inv *Investigator) sameKindValidationGate(
 	// misrepresented every gate retry as an empty request.
 	gateEvent := audit.NewEvent(audit.EventTypeLLMRequest, correlationID)
 	gateEvent.EventAction = audit.ActionSameKindGate
-	gateEvent.EventOutcome = audit.OutcomeSuccess
 	gateEvent.Data["model"] = modelName
 	gateEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
 	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages, 500)
 	gateEvent.Data["signal_resource_kind"] = signal.ResourceKind
 	gateEvent.Data["target_kind"] = result.RemediationTarget.Kind
 	gateEvent.Data["target_name"] = result.RemediationTarget.Name
-	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
+	// #2120 (BR-AI-2120, FedRAMP AU-3): fire once, after the final outcome is
+	// known, via defer -- StoreBestEffort reads gateEvent.Data/EventOutcome at
+	// the time this deferred call actually executes (function return), not
+	// at the time the defer statement runs. Storing immediately here (as the
+	// pre-#2120 code did) meant retry_outcome/EventOutcome mutations made
+	// below were set on the event in memory but never actually captured by a
+	// production audit store, which serializes Data into an outbound request
+	// synchronously at call time.
+	defer audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
 	// #2086: this gate-retry LLM call is non-streamed (llm.ChatWithParams),
 	// so it emits zero sink events for the duration of the round-trip. A
@@ -127,25 +252,54 @@ func (inv *Investigator) sameKindValidationGate(
 	if err != nil {
 		inv.logger.Error(err, "same-kind validation gate retry failed, keeping original result",
 			"correlation_id", correlationID)
+		gateEvent.EventOutcome = audit.OutcomeFailure
+		gateEvent.Data["retry_outcome"] = string(gateRetryExhausted)
 		return result
 	}
 	if tokens != nil {
 		tokens.Add(resp.Usage)
 	}
 
-	var retryContent string
-	for _, tc := range resp.ToolCalls {
-		if tc.Name == SubmitResultToolName {
-			retryContent = tc.Arguments
-			break
-		}
+	var usedReminder bool
+	retryContent, otherTools := gateRetrySubmitContent(resp)
+	if len(otherTools) > 0 {
+		gateEvent.Data["other_tools_called"] = otherTools
 	}
-	if retryContent == "" && resp.Message.Content != "" {
-		retryContent = resp.Message.Content
+	if retryContent == "" && len(otherTools) > 0 {
+		// #2120: the model called an undeclared tool instead of resubmitting
+		// the RCA result. Retry once with a synthetic tool-error + reminder
+		// (live-LLM spike: 10/10 recovery) before falling back to keeping
+		// the original result.
+		inv.logger.Info("same-kind validation gate: LLM called an undeclared tool instead of submit_result, retrying once with reminder",
+			"tools_called", otherTools,
+			"correlation_id", correlationID)
+		usedReminder = true
+		var reminderErr error
+		retryContent, otherTools, reminderErr = inv.retryGateOnUnexpectedTool(ctx, client, retryMessages, resp, submitOnlyTools, tokens, runtimeParams, correlationID)
+		if len(otherTools) > 0 {
+			gateEvent.Data["other_tools_called"] = otherTools
+		}
+		if reminderErr != nil {
+			inv.logger.Error(reminderErr, "same-kind validation gate: retry-on-unexpected-tool call failed, keeping original",
+				"correlation_id", correlationID)
+			gateEvent.EventOutcome = audit.OutcomeFailure
+			gateEvent.Data["retry_outcome"] = string(gateRetryOtherToolExhausted)
+			return result
+		}
+		if retryContent == "" {
+			inv.logger.Info("same-kind validation gate: LLM called an undeclared tool on both attempts, keeping original",
+				"tools_called", otherTools,
+				"correlation_id", correlationID)
+			gateEvent.EventOutcome = audit.OutcomeFailure
+			gateEvent.Data["retry_outcome"] = string(gateRetryOtherToolExhausted)
+			return result
+		}
 	}
 	if retryContent == "" {
 		inv.logger.Info("same-kind validation gate: no content in retry response, keeping original",
 			"correlation_id", correlationID)
+		gateEvent.EventOutcome = audit.OutcomeFailure
+		gateEvent.Data["retry_outcome"] = string(gateRetryEmptyResponse)
 		return result
 	}
 
@@ -153,6 +307,8 @@ func (inv *Investigator) sameKindValidationGate(
 	if parseErr != nil {
 		inv.logger.Error(parseErr, "same-kind validation gate: retry parse failed, keeping original",
 			"correlation_id", correlationID)
+		gateEvent.EventOutcome = audit.OutcomeFailure
+		gateEvent.Data["retry_outcome"] = string(gateRetryParseError)
 		return result
 	}
 
@@ -160,6 +316,8 @@ func (inv *Investigator) sameKindValidationGate(
 		inv.logger.Info("same-kind validation gate: retry lost remediation_target, keeping original",
 			"original_target", result.RemediationTarget.Kind+"/"+result.RemediationTarget.Name,
 			"correlation_id", correlationID)
+		gateEvent.EventOutcome = audit.OutcomeFailure
+		gateEvent.Data["retry_outcome"] = string(gateRetryEmptyResponse)
 		return result
 	}
 
@@ -175,6 +333,12 @@ func (inv *Investigator) sameKindValidationGate(
 		retryResult.Confidence = result.Confidence
 	}
 
+	gateEvent.EventOutcome = audit.OutcomeSuccess
+	if usedReminder {
+		gateEvent.Data["retry_outcome"] = string(gateRetryResolvedAfterReminder)
+	} else {
+		gateEvent.Data["retry_outcome"] = string(gateRetryResolved)
+	}
 	inv.logger.Info("same-kind validation gate: accepted retry result",
 		"original_target", result.RemediationTarget.Kind+"/"+result.RemediationTarget.Name,
 		"retry_target", retryResult.RemediationTarget.Kind+"/"+retryResult.RemediationTarget.Name,
@@ -257,13 +421,7 @@ func (inv *Investigator) apiVersionValidationGate(
 		kind, groupList, kind, result.RemediationTarget.Name,
 	)
 
-	submitOnlyTools := []llm.ToolDefinition{
-		{
-			Name:        SubmitResultToolName,
-			Description: "Submit root cause analysis result.",
-			Parameters:  parser.RCAResultSchema(),
-		},
-	}
+	submitOnlyTools := submitResultOnlyTools()
 
 	retryMessages := make([]llm.Message, len(history))
 	copy(retryMessages, history)
@@ -277,13 +435,18 @@ func (inv *Investigator) apiVersionValidationGate(
 	// misrepresented every gate retry as an empty request.
 	gateEvent := audit.NewEvent(audit.EventTypeLLMRequest, correlationID)
 	gateEvent.EventAction = audit.ActionAPIVersionGate
-	gateEvent.EventOutcome = audit.OutcomeSuccess
 	gateEvent.Data["model"] = modelName
 	gateEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
 	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages, 500)
 	gateEvent.Data["ambiguous_kind"] = kind
 	gateEvent.Data["conflicting_groups"] = groupList
-	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
+	// #2120 (BR-AI-2120, FedRAMP AU-3): fire once, after the final outcome is
+	// known, via defer -- this also fixes a pre-existing bug (#1044) where
+	// gateEvent.Data["retry_outcome"] was mutated below AFTER this store call
+	// fired, so a production audit store (which serializes Data into an
+	// outbound request synchronously at call time) never actually persisted
+	// retry_outcome.
+	defer audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
 	// #2086: same silent-gap risk as sameKindValidationGate above — this
 	// retry LLM call is non-streamed and emits no sink events during the
@@ -298,42 +461,65 @@ func (inv *Investigator) apiVersionValidationGate(
 	if retryErr != nil {
 		inv.logger.Error(retryErr, "apiVersionValidationGate: retry failed, triggering human review",
 			"kind", kind, "correlation_id", correlationID)
-		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent)
+		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, gateRetryExhausted)
 	}
 	if tokens != nil {
 		tokens.Add(resp.Usage)
 	}
 
-	var retryContent string
-	for _, tc := range resp.ToolCalls {
-		if tc.Name == SubmitResultToolName {
-			retryContent = tc.Arguments
-			break
-		}
+	var usedReminder bool
+	retryContent, otherTools := gateRetrySubmitContent(resp)
+	if len(otherTools) > 0 {
+		gateEvent.Data["other_tools_called"] = otherTools
 	}
-	if retryContent == "" && resp.Message.Content != "" {
-		retryContent = resp.Message.Content
+	if retryContent == "" && len(otherTools) > 0 {
+		// #2120: the model called an undeclared tool instead of resubmitting
+		// the RCA result. Retry once with a synthetic tool-error + reminder
+		// (live-LLM spike: 10/10 recovery) before triggering human review.
+		inv.logger.Info("apiVersionValidationGate: LLM called an undeclared tool instead of submit_result, retrying once with reminder",
+			"kind", kind, "tools_called", otherTools, "correlation_id", correlationID)
+		usedReminder = true
+		var reminderErr error
+		retryContent, otherTools, reminderErr = inv.retryGateOnUnexpectedTool(ctx, client, retryMessages, resp, submitOnlyTools, tokens, runtimeParams, correlationID)
+		if len(otherTools) > 0 {
+			gateEvent.Data["other_tools_called"] = otherTools
+		}
+		if reminderErr != nil {
+			inv.logger.Error(reminderErr, "apiVersionValidationGate: retry-on-unexpected-tool call failed, triggering human review",
+				"kind", kind, "correlation_id", correlationID)
+			return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, gateRetryOtherToolExhausted)
+		}
+		if retryContent == "" {
+			inv.logger.Info("apiVersionValidationGate: LLM called an undeclared tool on both attempts, triggering human review",
+				"kind", kind, "tools_called", otherTools, "correlation_id", correlationID)
+			return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, gateRetryOtherToolExhausted)
+		}
 	}
 	if retryContent == "" {
 		inv.logger.Info("apiVersionValidationGate: empty retry response, triggering human review",
 			"correlation_id", correlationID)
-		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent)
+		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, gateRetryEmptyResponse)
 	}
 
 	retryResult, parseErr := inv.resultParser.Parse(retryContent)
 	if parseErr != nil {
 		inv.logger.Error(parseErr, "apiVersionValidationGate: retry parse failed, triggering human review",
 			"correlation_id", correlationID)
-		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent)
+		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, gateRetryParseError)
 	}
 
 	if retryResult.RemediationTarget.APIVersion == "" {
 		inv.logger.Info("apiVersionValidationGate: retry still missing api_version, triggering human review",
 			"kind", kind, "correlation_id", correlationID)
-		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent)
+		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, gateRetryExhausted)
 	}
 
-	gateEvent.Data["retry_outcome"] = "resolved"
+	gateEvent.EventOutcome = audit.OutcomeSuccess
+	if usedReminder {
+		gateEvent.Data["retry_outcome"] = string(gateRetryResolvedAfterReminder)
+	} else {
+		gateEvent.Data["retry_outcome"] = string(gateRetryResolved)
+	}
 	// Clear parser-set HumanReviewNeeded from the retry result. The gate's
 	// decision is authoritative: if the retry provided api_version, the
 	// pipeline should continue to workflow selection, not abort.
@@ -350,8 +536,10 @@ func (inv *Investigator) apiVersionGateExhaustion(
 	result *katypes.InvestigationResult,
 	groupList, kind, correlationID string,
 	gateEvent *audit.AuditEvent,
+	outcome gateRetryOutcome,
 ) *katypes.InvestigationResult {
-	gateEvent.Data["retry_outcome"] = "exhausted"
+	gateEvent.Data["retry_outcome"] = string(outcome)
+	gateEvent.EventOutcome = audit.OutcomeFailure
 	result.HumanReviewNeeded = true
 	result.HumanReviewReason = "rca_incomplete"
 
@@ -373,7 +561,7 @@ func (inv *Investigator) apiVersionGateExhaustion(
 			"but LLM did not provide api_version after retry — human review required to prevent "+
 			"incorrect RBAC grants", kind, groupList))
 	inv.logger.Info("apiVersionValidationGate: exhausted, human review required",
-		"kind", kind, "conflicting_groups", groupList, "correlation_id", correlationID)
+		"kind", kind, "conflicting_groups", groupList, "retry_outcome", outcome, "correlation_id", correlationID)
 	return result
 }
 

--- a/internal/kubernautagent/investigator/samekind_confidence_2118_test.go
+++ b/internal/kubernautagent/investigator/samekind_confidence_2118_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// #2118 (BR-AI-2118, FedRAMP SI-11/AU-3): sameKindValidationGate's retry
+// confirms the LLM's original remediation target is correct, but the LLM's
+// tool call arguments for that confirmation frequently omit `confidence`
+// entirely (the model treats the correction turn as a yes/no confirmation,
+// not a full RCA restatement). Because the gate accepts retryResult.Confidence
+// as-is whenever RemediationTarget.Kind is non-empty, this silently drops a
+// previously-computed, real confidence score down to 0.0 -- corrupting the
+// audit-visible RCA record (AU-3) and, downstream, any confidence-gated
+// automation (BR-AI-2118) that trusts InvestigationResult.Confidence.
+//
+// These specs exercise the gate through the real Investigate() production
+// path (mirroring apiversion_gate_test.go's/gate_history_propagation_1935_
+// test.go's established pattern in this package) rather than calling the
+// unexported gate function directly.
+var _ = Describe("#2118: sameKindValidationGate must not silently drop RCA confidence on retry", func() {
+
+	var (
+		logger     logr.Logger
+		auditStore *gateRecordingAuditStore
+		mockClient *gateMockLLMClient
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+	)
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+		auditStore = &gateRecordingAuditStore{}
+		mockClient = &gateMockLLMClient{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		enricher = enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, auditStore, logger)
+		phaseTools = investigator.DefaultPhaseToolMap()
+	})
+
+	signal := katypes.SignalContext{
+		ResourceKind: "Node",
+		ResourceName: "ip-10-0-1-23",
+		Name:         "ip-10-0-1-23",
+		Namespace:    "",
+		Severity:     "critical",
+		Message:      "Node DiskPressure",
+	}
+
+	Describe("UT-KA-2118-001 (regression): retry confirms the same target but omits confidence", func() {
+		It("must backfill the pre-retry confidence instead of silently zeroing it out (BR-AI-2118 AC1)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				// Turn 1: RCA submit — same-kind gate fires (target.Kind == signal.ResourceKind == "Node").
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Node under DiskPressure due to accumulated container logs",
+					"confidence":0.88,
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				// Turn 2: gate retry — LLM re-confirms the same target but the tool
+				// call arguments omit confidence entirely (the observed #2118 failure mode).
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Confirmed: Node itself is the correct target, log accumulation is host-level",
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"},
+					"due_diligence":{"target_accuracy":"host-level log rotation misconfiguration confirmed via kubectl describe node"}
+				}`}},
+				// Phase 3 (workflow selection) also omits confidence here -- a
+				// realistic case, since the LLM often treats workflow selection
+				// as a separate concern from the RCA confidence score. This
+				// isolates whether Phase 1's own post-gate confidence (what
+				// BuildPhase1Context/MergePhase1Fallbacks propagate as p1) was
+				// corrupted by the gate retry, independent of Phase 3's own
+				// (unrelated) confidence value.
+				gateWfToolResp(`{"workflow_id":"rotate-node-logs"}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.RemediationTarget.Kind).To(Equal("Node"),
+				"UT-KA-2118-001: retry confirming the same target must be accepted")
+			Expect(result.Confidence).To(BeNumerically("==", 0.88),
+				"UT-KA-2118-001: the pre-retry confidence (0.88) must be backfilled when the retry response omits "+
+					"confidence, not silently dropped to 0 (#2118)")
+		})
+	})
+
+	Describe("UT-KA-2118-002: retry provides its own genuine, non-zero confidence", func() {
+		It("must preserve the retry's own confidence unchanged, not overwrite it with the pre-retry value (BR-AI-2118 AC2)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Node under DiskPressure",
+					"confidence":0.88,
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				// Gate retry: LLM re-evaluates and returns a deliberately lower,
+				// genuinely-recomputed confidence for the same target.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Re-confirmed Node as target, but evidence is less conclusive than initially assessed",
+					"confidence":0.55,
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"rotate-node-logs"}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Confidence).To(BeNumerically("==", 0.55),
+				"UT-KA-2118-002: a genuine, non-zero retry confidence must be preserved as-is -- "+
+					"the backfill guard must not clobber a real re-assessment")
+		})
+	})
+
+	Describe("UT-KA-2118-003: original pre-retry confidence was itself never set (0)", func() {
+		It("must leave confidence at 0 rather than backfilling from a meaningless zero value (BR-AI-2118 edge case)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Node under DiskPressure",
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				// Gate retry also omits confidence.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Confirmed Node as target",
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"rotate-node-logs"}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Confidence).To(BeNumerically("==", 0),
+				"UT-KA-2118-003: backfill must only trigger when the pre-retry confidence was a real (>0) value -- "+
+					"it must not fabricate a non-zero confidence out of another zero value")
+		})
+	})
+
+	Describe("UT-KA-2118-004: correction message must instruct a full RCA restatement, not a bare confirmation", func() {
+		It("must ask the LLM to restate confidence alongside the target (BR-AI-2118 AC3, defense-in-depth)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Node under DiskPressure",
+					"confidence":0.88,
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Confirmed Node as target",
+					"confidence":0.88,
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"rotate-node-logs","confidence":0.9}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockClient.calls).To(HaveLen(3),
+				"UT-KA-2118-004: expected RCA submit + gate retry + workflow-selection LLM calls")
+			gateCall := mockClient.calls[1]
+			lastMsg := gateCall.Messages[len(gateCall.Messages)-1]
+			Expect(lastMsg.Content).To(ContainSubstring("confidence"),
+				"UT-KA-2118-004: correction message must explicitly instruct the LLM to restate its confidence, "+
+					"not just confirm/deny the target (#2118)")
+			Expect(lastMsg.Content).To(SatisfyAny(
+				ContainSubstring("full"),
+				ContainSubstring("restate"),
+				ContainSubstring("entire"),
+			), "UT-KA-2118-004: correction message must instruct a full RCA restatement, not a bare yes/no confirmation")
+		})
+	})
+})

--- a/pkg/apifrontend/launcher/event_bridge.go
+++ b/pkg/apifrontend/launcher/event_bridge.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,6 +17,10 @@ package launcher
 
 import (
 	"context"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -28,6 +32,19 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/security"
 )
+
+// #2110/#2111: a2a-go@v0.3.15's own internal/taskstore/store.go registers
+// map[string]any and []any at init() too, but relying solely on that
+// package being transitively imported by *something else* in this binary
+// is fragile -- it depends on unrelated import-graph decisions elsewhere in
+// this repo that have nothing to do with EmitArtifact's own correctness.
+// Registering them here as well makes sanitizeArtifactData's gob-safety
+// guarantee self-contained. gob.Register is idempotent, so duplicate
+// registration (here and in a2a-go) is harmless.
+func init() {
+	gob.Register(map[string]any{})
+	gob.Register([]any{})
+}
 
 type contextKey struct{}
 
@@ -486,6 +503,21 @@ func stripEmoji(s string) string {
 // EmitArtifact writes a TaskArtifactUpdateEvent with multi-part content:
 // Part[0] = DataPart (structured JSON), Part[1] = TextPart (human-readable fallback).
 // This is the A2A v1.0-compliant way to deliver structured results to clients.
+//
+// EmitArtifact is the single choke point every artifact producer in this
+// package (present_decision's emitDecisionEvent, crd_tools.go's progress
+// snapshot, ka_investigate_mcp.go's RCA artifact) shares before data
+// reaches a2a-go@v0.3.15's task manager, which gob-encodes every artifact
+// for its internal deep-copy fan-out (#2110/#2111: a *tools.RCAData struct
+// pointer reaching that pipeline unregistered crashed every grounded
+// present_decision call in v1.5.6-rc4 with "gob: type not registered for
+// interface: tools.RCAData"). #2112's fix on this branch closed that one
+// call site by changing its return type, but nothing stopped a *future*
+// caller from reintroducing the identical crash by assigning any other
+// struct into any nested field of an artifact's data map.
+// sanitizeArtifactData below closes that gap here, at the boundary every
+// caller shares, instead of relying on each caller to remember the
+// map[string]any convention.
 func (b *EventBridge) EmitArtifact(ctx context.Context, data map[string]any, textFallback string, meta map[string]any) error {
 	if b == nil || b.queue == nil {
 		return nil
@@ -493,10 +525,19 @@ func (b *EventBridge) EmitArtifact(ctx context.Context, data map[string]any, tex
 
 	parts := make(a2a.ContentParts, 0, 2)
 	if data != nil {
-		parts = append(parts, a2a.DataPart{
-			Data:     data,
-			Metadata: map[string]any{"mediaType": "application/json"},
-		})
+		safe, err := sanitizeArtifactData(data)
+		if err != nil {
+			logr.FromContextOrDiscard(ctx).Error(err, "artifact data is not gob-safe for a2a-go's deep-copy pipeline -- "+
+				"dropping structured DataPart and falling back to text-only artifact (#2110/#2111 boundary guard)")
+			if b.metrics != nil {
+				b.metrics.IncBridgeWriteFailures()
+			}
+		} else {
+			parts = append(parts, a2a.DataPart{
+				Data:     safe,
+				Metadata: map[string]any{"mediaType": "application/json"},
+			})
+		}
 	}
 	parts = append(parts, a2a.TextPart{Text: textFallback})
 
@@ -523,6 +564,60 @@ func (b *EventBridge) EmitArtifact(ctx context.Context, data map[string]any, tex
 		}
 	}
 	return err
+}
+
+// sanitizeArtifactData guarantees data can survive a2a-go@v0.3.15's task
+// manager's gob-encoded deep-copy fan-out (#2110/#2111 -- see EmitArtifact's
+// doc comment for full context), regardless of what any current or future
+// artifact producer puts into an interface{}-typed field.
+//
+// The fast path probes data with the REAL encoding/gob encoder (gobProbe)
+// rather than a hand-maintained list of "safe" types, so it stays correct
+// if Go's or a2a-go's own registered type set ever changes. Data that is
+// already gob-safe -- which is every existing caller in this package,
+// since map[string]any/[]any/string/bool/nil/float64 and Go's own
+// gob-builtin slice types ([]string, []int, etc., see encoding/gob's own
+// type.go init()) all pass -- is returned completely unchanged, byte-for-
+// byte and type-for-type. This matters: an earlier version of this fix
+// naively JSON-round-tripped every call unconditionally, which silently
+// coerced already-compliant []string/int values into []any/float64 and
+// broke existing callers asserting on the original Go types (regression
+// caught by UT-AF-1922-001/002 and UT-AF-WIRE-SESSION-003 in
+// pkg/apifrontend/tools) -- exactly the kind of new, avoidable breakage a
+// boundary hardening fix must not introduce.
+//
+// Only when gobProbe finds something actually unsafe (e.g. a bare struct
+// value/pointer, exactly #2110's mistake) does this fall back to a JSON
+// marshal/unmarshal round-trip, which normalizes the offending value into
+// the same map[string]any/[]any/primitive shape every compliant caller in
+// this package already produces by convention -- turning that convention
+// into a structural guarantee instead of something merely documented.
+func sanitizeArtifactData(data map[string]any) (map[string]any, error) {
+	if gobProbe(data) == nil {
+		return data, nil
+	}
+
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("artifact data is not JSON-marshalable: %w", err)
+	}
+	var safe map[string]any
+	if err := json.Unmarshal(raw, &safe); err != nil {
+		return nil, fmt.Errorf("artifact data failed JSON round-trip: %w", err)
+	}
+	if err := gobProbe(safe); err != nil {
+		return nil, fmt.Errorf("artifact data remains gob-unsafe after JSON normalization: %w", err)
+	}
+	return safe, nil
+}
+
+// gobProbe reports whether v can be gob-encoded through an interface{}
+// value, using a scratch encoder discarded after one use so probing never
+// has observable side effects (gob.Encoder accumulates per-instance type
+// definitions across calls, purely as a wire-size optimization, but that
+// state never escapes this function).
+func gobProbe(v any) error {
+	return gob.NewEncoder(io.Discard).Encode(v)
 }
 
 // isEmoji returns true if the rune is a Unicode emoji codepoint.

--- a/pkg/apifrontend/launcher/event_bridge_gob_boundary_2111_test.go
+++ b/pkg/apifrontend/launcher/event_bridge_gob_boundary_2111_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launcher_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+)
+
+// #2110/#2111 root cause: a2a-go@v0.3.15's task manager gob-encodes every
+// TaskArtifactUpdateEvent's artifact for its internal deep-copy fan-out
+// (internal/utils.DeepCopy). encoding/gob requires any concrete type stored
+// behind an interface{} to be gob.Register'd first -- a2a-go's own
+// internal/taskstore/store.go registers map[string]any and []any at init(),
+// but nothing in THIS repo ever validates that data handed to
+// EventBridge.EmitArtifact only ever contains those (or other gob-safe
+// primitive) types.
+//
+// The #2112/#2113 fix closed the ONE call site that broke
+// (canonicalGroundedRCA) by changing its return type. That fix was correct
+// but not sufficient: EmitArtifact is the single choke point all THREE
+// current artifact producers (present_decision's emitDecisionEvent,
+// crd_tools.go's progress snapshot, ka_investigate_mcp.go's RCA artifact)
+// share, and nothing there stops a *future* caller from reintroducing the
+// exact same crash class by assigning a struct pointer into any nested
+// field of the data map. These tests exercise EmitArtifact itself --
+// the shared boundary -- rather than any one caller's data shape, and
+// reproduce a2a-go's actual gob round-trip (not just the call to
+// EmitArtifact) so a regression here fails for the same reason production
+// did: a live gob decode error, not just a type assertion.
+var _ = Describe("EmitArtifact gob-safety boundary (#2110/#2111 hardening)", func() {
+	// registerA2AGobTypes mirrors a2a-go@v0.3.15's internal/taskstore/
+	// store.go init(). gob.Register is idempotent, so calling this
+	// alongside that real init() (triggered transitively elsewhere in the
+	// test binary) is safe.
+	registerA2AGobTypes := func() {
+		gob.Register(map[string]any{})
+		gob.Register([]any{})
+	}
+
+	// simulateA2AGoDeepCopy reproduces a2a-go's internal/utils.DeepCopy: a
+	// gob encode/decode round-trip of the artifact DataPart's Data field,
+	// which is the literal operation that crashed in production.
+	simulateA2AGoDeepCopy := func(data map[string]any) error {
+		registerA2AGobTypes()
+		var buf bytes.Buffer
+		if err := gob.NewEncoder(&buf).Encode(data); err != nil {
+			return err
+		}
+		var out map[string]any
+		return gob.NewDecoder(&buf).Decode(&out)
+	}
+
+	// unregisteredStruct is deliberately never gob.Register'd anywhere,
+	// standing in for any future struct type a contributor might
+	// accidentally assign into an artifact's data map (the exact mistake
+	// #2110/#2111 made with *tools.RCAData).
+	type unregisteredStruct struct {
+		Foo string
+		Bar int
+	}
+
+	It("UT-AF-2111-001 (regression): a struct pointer nested anywhere in EmitArtifact's data must not reach a2a-go's gob pipeline unsanitized", func() {
+		queue := &fakeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2111-001", "ctx-2111-001", nil)
+
+		data := map[string]any{
+			"type":    "test_artifact",
+			"summary": "some artifact",
+			"payload": &unregisteredStruct{Foo: "leaked", Bar: 7},
+		}
+		err := launcher.EmitArtifactForTest(ctx, data, "fallback text", nil)
+		Expect(err).NotTo(HaveOccurred(), "EmitArtifact itself must not error on unsafe input -- it must sanitize, not propagate the crash")
+
+		Expect(queue.events).To(HaveLen(1))
+		Expect(launcher.LastArtifactDataForTest(queue.events[0])).To(
+			WithTransform(simulateA2AGoDeepCopy, Succeed()),
+			"the emitted artifact's DataPart.Data must survive a2a-go's real gob deep-copy round-trip -- "+
+				"a raw struct pointer here is exactly what crashed every grounded present_decision call in v1.5.6-rc4",
+		)
+	})
+
+	It("UT-AF-2111-002: legitimate JSON-shaped values (strings, floats, bools, nested maps/slices, nil) are preserved through EmitArtifact", func() {
+		queue := &fakeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2111-002", "ctx-2111-002", nil)
+
+		data := map[string]any{
+			"type":         "investigation_summary",
+			"summary":      "OOMKill detected",
+			"confidence":   0.92,
+			"critical":     true,
+			"missing":      nil,
+			"causal_chain": []any{"MemoryPressure", "Evicted"},
+			"rca": map[string]any{
+				"severity": "critical",
+				"target":   "pod/checkout-service",
+			},
+		}
+		err := launcher.EmitArtifactForTest(ctx, data, "fallback", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		got := launcher.LastArtifactDataForTest(queue.events[0])
+		Expect(got["type"]).To(Equal("investigation_summary"))
+		Expect(got["summary"]).To(Equal("OOMKill detected"))
+		Expect(got["confidence"]).To(Equal(0.92))
+		Expect(got["critical"]).To(Equal(true))
+		Expect(got["missing"]).To(BeNil())
+		Expect(got["causal_chain"]).To(Equal([]any{"MemoryPressure", "Evicted"}))
+		rca, ok := got["rca"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(rca["severity"]).To(Equal("critical"))
+		Expect(rca["target"]).To(Equal("pod/checkout-service"))
+
+		Expect(simulateA2AGoDeepCopy(got)).To(Succeed())
+	})
+
+	It("UT-AF-2111-003 (defense-in-depth, independent of phase_guard.go): even if a future regression reintroduces the exact #2110 *tools.RCAData-shaped struct pointer into present_decision's rca argument, EmitArtifact's own boundary must still make it gob-safe", func() {
+		queue := &fakeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2111-003", "ctx-2111-003", nil)
+
+		type rcaShapedStruct struct {
+			Severity       string
+			Confidence     float64
+			ToolCallsCount int
+			LLMTurns       int
+		}
+		data := map[string]any{
+			"type":       "decision",
+			"session_id": "sess-2110",
+			"rca":        &rcaShapedStruct{Severity: "critical", Confidence: 0.9, ToolCallsCount: 7, LLMTurns: 3},
+		}
+		err := launcher.EmitArtifactForTest(ctx, data, "fallback", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		got := launcher.LastArtifactDataForTest(queue.events[0])
+		Expect(simulateA2AGoDeepCopy(got)).To(Succeed(),
+			"this must pass even without phase_guard.go's canonicalGroundedRCA fix -- the boundary guard is the "+
+				"backstop that closes the bug class regardless of which upstream caller regresses")
+	})
+
+	It("UT-AF-2111-004: data that cannot be made JSON-safe degrades gracefully to a text-only artifact instead of failing the whole task", func() {
+		queue := &fakeQueue{}
+		m := &spyBridgeMetrics{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-2111-004", "ctx-2111-004", m)
+
+		data := map[string]any{
+			"type":    "test_artifact",
+			"channel": make(chan int), // unmarshalable by encoding/json
+		}
+		err := launcher.EmitArtifactForTest(ctx, data, "fallback text", nil)
+		Expect(err).NotTo(HaveOccurred(), "unsanitizable data must not fail EmitArtifact -- the task must survive")
+
+		Expect(queue.events).To(HaveLen(1))
+		evt := queue.events[0]
+		Expect(launcher.ArtifactHasDataPartForTest(evt)).To(BeFalse(),
+			"the unsafe DataPart must be dropped entirely rather than emitted half-sanitized")
+		Expect(launcher.ArtifactTextFallbackForTest(evt)).To(Equal("fallback text"),
+			"the human-readable fallback must still reach the client even when structured data is dropped")
+		Expect(m.failuresInc).To(Equal(1),
+			"dropping unsafe artifact data must be observable via the existing write-failure counter (SI-4)")
+	})
+})

--- a/pkg/apifrontend/launcher/export_test.go
+++ b/pkg/apifrontend/launcher/export_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/go-logr/logr"
 	"google.golang.org/adk/model"
 	"google.golang.org/adk/server/adka2a"
 	"google.golang.org/adk/session"
@@ -102,6 +102,53 @@ func EmitArtifactForTest(ctx context.Context, data map[string]any, textFallback 
 		return nil
 	}
 	return bridge.EmitArtifact(ctx, data, textFallback, meta)
+}
+
+// LastArtifactDataForTest extracts the DataPart.Data map from a
+// TaskArtifactUpdateEvent, or nil if the event carries no DataPart
+// (#2110/#2111 EmitArtifact gob-safety boundary tests).
+func LastArtifactDataForTest(evt a2a.Event) map[string]any {
+	artEvt, ok := evt.(*a2a.TaskArtifactUpdateEvent)
+	if !ok || artEvt.Artifact == nil {
+		return nil
+	}
+	for _, part := range artEvt.Artifact.Parts {
+		if dp, ok := part.(a2a.DataPart); ok {
+			return dp.Data
+		}
+	}
+	return nil
+}
+
+// ArtifactHasDataPartForTest reports whether the event's artifact carries a
+// DataPart at all, distinct from LastArtifactDataForTest returning nil for
+// an empty-but-present map (#2110/#2111 degraded-artifact assertions).
+func ArtifactHasDataPartForTest(evt a2a.Event) bool {
+	artEvt, ok := evt.(*a2a.TaskArtifactUpdateEvent)
+	if !ok || artEvt.Artifact == nil {
+		return false
+	}
+	for _, part := range artEvt.Artifact.Parts {
+		if _, ok := part.(a2a.DataPart); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ArtifactTextFallbackForTest extracts the TextPart.Text from a
+// TaskArtifactUpdateEvent (#2110/#2111 degraded-artifact assertions).
+func ArtifactTextFallbackForTest(evt a2a.Event) string {
+	artEvt, ok := evt.(*a2a.TaskArtifactUpdateEvent)
+	if !ok || artEvt.Artifact == nil {
+		return ""
+	}
+	for _, part := range artEvt.Artifact.Parts {
+		if tp, ok := part.(a2a.TextPart); ok {
+			return tp.Text
+		}
+	}
+	return ""
 }
 
 // ValidatePayloadForTest exports ValidatePayload for testing.


### PR DESCRIPTION
## Summary

Consolidates three fixes into a single PR against `release/v1.5` (milestone v1.5.6), per plan.

**Part A -- port #2111's `EmitArtifact` gob-safety boundary hardening** (backport, not a cherry-pick: `release/v1.5`'s `event_bridge.go` has diverged from `main`'s since the branch cut)
- `release/v1.5` already carries #2110/#2112's symptomatic fix (`canonicalGroundedRCA` returns `map[string]any`, not `*tools.RCAData`), but had none of the boundary-level hardening `main` received as #2111 (PR #2117).
- Adds `sanitizeArtifactData`/`gobProbe` to `EventBridge.EmitArtifact` -- the single choke point all three artifact producers (`present_decision`, progress snapshot, RCA artifact) share before data reaches `a2a-go`'s gob-encoded deep-copy pipeline. Probes with the real `encoding/gob` encoder first (preserving already-compliant callers' exact types), falling back to a JSON round-trip only when something is actually gob-unsafe.
- 4 new unit specs (`UT-AF-2111-001..004`) reproduce the real gob round-trip that crashed production, verify type-fidelity preservation, defense-in-depth independent of `canonicalGroundedRCA`, and graceful degradation to text-only artifacts.
- Fixes #2110 (reopened briefly to track this follow-up, per the same pattern used for #2111 on `main`).

**Part B -- fix #2118: same-kind gate retry silently drops RCA confidence**
- `sameKindValidationGate` already had a "lost field, keep original" guard for `RemediationTarget.Kind`, but none for `Confidence`. Its correction prompt reads as a narrow yes/no question, so the LLM frequently responds with a minimal tool call that omits (or zeroes) confidence -- silently overwriting a real, previously-validated confidence with `0.0`.
- A live-LLM spike against the actual `claude-sonnet-5` Vertex AI endpoint confirmed the bug reproduces live. It also surfaced a secondary, out-of-scope finding (the gate retry sometimes calls an undeclared tool instead of `submit_result`, silently skipping the correction) -- filed separately as #2120 (v1.5.6) / #2121 (v1.6 clone), addressed below in Part C.
- Fix ships a strengthened correction prompt as a best-effort defense-in-depth improvement, plus a deterministic confidence-backfill guard (mirrors the existing `RemediationTarget.Kind` guard) as the actual, load-bearing fix.
- 4 new unit specs (`UT-KA-2118-001..004`), exercised through the real `Investigate()` production path.

**Part C -- fix #2120: gate retry silently skips correction on undeclared tool call**
- `sameKindValidationGate` and `apiVersionValidationGate` both send their gate-retry LLM call with only `submit_result` declared, but a live-LLM spike against the real `claude-sonnet-5` Vertex AI endpoint showed the model frequently (10/10 trials) calls an undeclared tool instead (e.g. `kubectl_describe`) -- silently skipping the correction, indistinguishable in the audit trail from a genuinely empty response. A follow-up spike showed replaying that call as a synthetic `tool_result` error plus one reminder recovers the correct `submit_result` call in 10/10 trials.
- Adds `gateRetrySubmitContent`/`retryGateOnUnexpectedTool` helpers implementing that retry-once-with-reminder recovery, wired into both gates, with a new `gateRetryOutcome` taxonomy (`resolved`, `resolved_after_other_tool_retry`, `llm_requested_other_tool`, `empty_response`, `parse_error`, `exhausted`) recorded per attempt in each gate's audit event.
- While restructuring the audit-event lifecycle to add these, found and fixed a **pre-existing** bug (tracked separately as #2124): both gates called `audit.StoreBestEffort` before mutating `gateEvent.Data["retry_outcome"]`, but production audit stores serialize `Data` synchronously at call time, so that mutation was never actually persisted -- masked by the unit-test double storing a live pointer instead of a snapshot. Both gates now `defer` the store call until every exit path's mutations are final, and the shared `gateRecordingAuditStore` test double now snapshots `Data` at call time to match real production semantics (verified safe for all 11 files sharing this fixture via a search over every other `StoreBestEffort` call site in this package).
- 6 new unit specs (`UT-KA-2120-001..005`, exercised through the real `Investigate()` production path).
- Fixes #2120. Filed #2124 for the dead-audit-mutation secondary finding (fixed in this same PR for traceability).

## FedRAMP Control Mapping

| Control | Relevance |
|---|---|
| SI-10 | Part A: artifact data must survive the gob pipeline for every producer. Part B: retry confidence must be validated against regression. Part C: an undeclared-tool response must not be silently conflated with a validated confirmation. |
| AU-3 | Part A: SSE decision artifact is the audit-visible record. Part B: confidence surfaced to operators must reflect genuine RCA certainty. Part C: the audit trail must distinguish (and actually persist) *why* a gate retry succeeded or failed. |
| SI-11 | Part A only: unsanitizable data degrades to text-only + metric increment rather than crashing the task. |

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/apifrontend/... ./internal/kubernautagent/...` -- all pass, including 14 new specs across all three parts
- [x] `go test ./test/integration/kubernautagent/investigator/...` -- 117/117 pass, no regressions from Part C's audit-store test-double fix
- [x] RED confirmed before GREEN for all three parts (UT-AF-2111-001/003/004, UT-KA-2118-001/004, and all 6 UT-KA-2120-XXX failed against unmodified code)
- [x] `golangci-lint run` on all affected trees -- 0 issues
- [x] `gofmt -l` -- clean
- [x] `docs/testing/2111/TEST_PLAN.md`, `docs/testing/2118/TEST_PLAN.md`, `docs/testing/2120/TEST_PLAN.md` written before implementation

Closes #2118. Closes #2120. Fixes #2110. Files #2124 (fixed here). References #2111 (main equivalent, PR #2117).