### PR TITLE
fix(apifrontend): replace time.Sleep()-based idle-timeout tests with an injectable Clock (#1446)

### DIFF
--- a/pkg/apifrontend/agent/phase_guard_test.go
+++ b/pkg/apifrontend/agent/phase_guard_test.go
@@ -1074,11 +1074,12 @@ var _ = Describe("Phase Guard — ActiveContextRegistry Integration (BR-SESS-020
 	})
 
 	It("UT-AF-1496-003: kubernaut_complete_no_action does NOT refresh idle timer (#1496)", func() {
-		shortIdleRegistry := launcher.NewActiveContextRegistry(2*time.Hour, 200*time.Millisecond)
+		clock := launcher.NewMockClock(time.Now())
+		shortIdleRegistry := launcher.NewActiveContextRegistryWithClock(2*time.Hour, 200*time.Millisecond, clock)
 		shortIdleRegistry.Set("alice", "ctx-session-abc")
 		_, afterShort := NewPhaseGuardWithRegistryForTest(shortIdleRegistry)
 
-		time.Sleep(50 * time.Millisecond)
+		clock.Advance(50 * time.Millisecond)
 
 		_, _ = afterShort(toolCtx, fakeTool{name: "kubernaut_complete_no_action"}, nil, map[string]any{
 			"status": "completed_no_action",
@@ -1146,17 +1147,18 @@ var _ = Describe("Phase Guard — ActiveContextRegistry Integration (BR-SESS-020
 			"session_id": "ka-sess-001", "rr_id": "rr-123",
 		}, nil)
 
-		shortIdleRegistry := launcher.NewActiveContextRegistry(2*time.Hour, 200*time.Millisecond)
+		clock := launcher.NewMockClock(time.Now())
+		shortIdleRegistry := launcher.NewActiveContextRegistryWithClock(2*time.Hour, 200*time.Millisecond, clock)
 		shortIdleRegistry.Set("alice", "ctx-session-abc")
 		_, afterShort := NewPhaseGuardWithRegistryForTest(shortIdleRegistry)
 
-		time.Sleep(50 * time.Millisecond)
+		clock.Advance(50 * time.Millisecond)
 
 		_, _ = afterShort(toolCtx, fakeTool{name: "kubectl_get"}, nil, map[string]any{
 			"result": "pod/nginx Running",
 		}, nil)
 
-		time.Sleep(100 * time.Millisecond)
+		clock.Advance(100 * time.Millisecond)
 
 		contextID, ok := shortIdleRegistry.Get("alice")
 		Expect(ok).To(BeTrue(),
@@ -1165,17 +1167,18 @@ var _ = Describe("Phase Guard — ActiveContextRegistry Integration (BR-SESS-020
 	})
 
 	It("UT-AF-1446-008: AU-3 — Refresh NOT called on failed tool call (#1446)", func() {
-		shortIdleRegistry := launcher.NewActiveContextRegistry(2*time.Hour, 200*time.Millisecond)
+		clock := launcher.NewMockClock(time.Now())
+		shortIdleRegistry := launcher.NewActiveContextRegistryWithClock(2*time.Hour, 200*time.Millisecond, clock)
 		shortIdleRegistry.Set("alice", "ctx-session-abc")
 		_, afterShort := NewPhaseGuardWithRegistryForTest(shortIdleRegistry)
 
-		time.Sleep(50 * time.Millisecond)
+		clock.Advance(50 * time.Millisecond)
 
 		_, _ = afterShort(toolCtx, fakeTool{name: "kubectl_get"}, nil, map[string]any{
 			"error": "forbidden",
 		}, nil)
 
-		time.Sleep(250 * time.Millisecond)
+		clock.Advance(250 * time.Millisecond)
 
 		_, ok := shortIdleRegistry.Get("alice")
 		Expect(ok).To(BeFalse(),

--- a/pkg/apifrontend/launcher/active_context_registry.go
+++ b/pkg/apifrontend/launcher/active_context_registry.go
@@ -20,6 +20,55 @@ type contextEntry struct {
 	lastActive time.Time
 }
 
+// Clock abstracts time.Now for deterministic testing of idle-timeout/TTL
+// expiry (#1446). Production code always uses RealClock; tests use MockClock
+// to advance time instantly instead of racing the wall clock with
+// time.Sleep(), which is a common source of CI flakiness for millisecond-scale
+// idle timeouts.
+type Clock interface {
+	Now() time.Time
+}
+
+// RealClock provides actual system time for production use.
+type RealClock struct{}
+
+// Now returns the current system time.
+func (RealClock) Now() time.Time { return time.Now() }
+
+// MockClock provides controllable time for deterministic tests.
+//
+// Usage:
+//
+//	clock := launcher.NewMockClock(time.Now())
+//	registry := launcher.NewActiveContextRegistryWithClock(2*time.Hour, 10*time.Millisecond, clock)
+//	registry.Set("bob", "ctx-active")
+//	clock.Advance(5 * time.Millisecond) // instant, no wall-clock wait
+//	registry.Refresh("bob")
+//	clock.Advance(7 * time.Millisecond)
+type MockClock struct {
+	mu          sync.Mutex
+	currentTime time.Time
+}
+
+// NewMockClock creates a MockClock starting at the given time.
+func NewMockClock(initialTime time.Time) *MockClock {
+	return &MockClock{currentTime: initialTime}
+}
+
+// Now returns the current mock time.
+func (c *MockClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.currentTime
+}
+
+// Advance moves the mock clock forward by the given duration.
+func (c *MockClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.currentTime = c.currentTime.Add(d)
+}
+
 // ActiveContextRegistry maintains a per-user mapping of active A2A context IDs.
 // It enables multi-turn conversation continuity (BR-SESS-020) by allowing the
 // SessionInterceptor to redirect new messages into an existing ADK session.
@@ -33,18 +82,27 @@ type ActiveContextRegistry struct {
 	entries     sync.Map
 	ttl         time.Duration
 	idleTimeout time.Duration
+	clock       Clock
 }
 
 // NewActiveContextRegistry creates a registry with the given max TTL and idle
 // timeout. Entries older than ttl OR idle longer than idleTimeout are treated
-// as expired on access.
+// as expired on access. Uses the real system clock; see
+// NewActiveContextRegistryWithClock for deterministic tests.
 func NewActiveContextRegistry(ttl, idleTimeout time.Duration) *ActiveContextRegistry {
-	return &ActiveContextRegistry{ttl: ttl, idleTimeout: idleTimeout}
+	return NewActiveContextRegistryWithClock(ttl, idleTimeout, RealClock{})
+}
+
+// NewActiveContextRegistryWithClock creates a registry using the given Clock,
+// enabling deterministic idle-timeout/TTL tests via MockClock instead of
+// time.Sleep() (#1446).
+func NewActiveContextRegistryWithClock(ttl, idleTimeout time.Duration, clock Clock) *ActiveContextRegistry {
+	return &ActiveContextRegistry{ttl: ttl, idleTimeout: idleTimeout, clock: clock}
 }
 
 // Set stores or overwrites the active context ID for the given username.
 func (r *ActiveContextRegistry) Set(username, contextID string) {
-	now := time.Now()
+	now := r.clock.Now()
 	r.entries.Store(username, contextEntry{
 		contextID:  contextID,
 		createdAt:  now,
@@ -62,7 +120,7 @@ func (r *ActiveContextRegistry) Refresh(username string) {
 		return
 	}
 	entry := raw.(contextEntry)
-	entry.lastActive = time.Now()
+	entry.lastActive = r.clock.Now()
 	r.entries.Store(username, entry)
 }
 
@@ -75,7 +133,7 @@ func (r *ActiveContextRegistry) Get(username string) (string, bool) {
 		return "", false
 	}
 	entry := raw.(contextEntry)
-	now := time.Now()
+	now := r.clock.Now()
 	if now.Sub(entry.createdAt) > r.ttl || now.Sub(entry.lastActive) > r.idleTimeout {
 		r.entries.Delete(username)
 		return "", false

--- a/pkg/apifrontend/launcher/active_context_registry_test.go
+++ b/pkg/apifrontend/launcher/active_context_registry_test.go
@@ -13,10 +13,11 @@ import (
 var _ = Describe("ActiveContextRegistry — Idle Timeout (#1446, BR-SESS-023)", func() {
 
 	It("UT-AF-1446-001: SC-7 — Get returns false when entry exceeds idle timeout but is within max TTL", func() {
-		registry := launcher.NewActiveContextRegistry(2*time.Hour, 1*time.Millisecond)
+		clock := launcher.NewMockClock(time.Now())
+		registry := launcher.NewActiveContextRegistryWithClock(2*time.Hour, 1*time.Millisecond, clock)
 		registry.Set("alice", "ctx-stale")
 
-		time.Sleep(5 * time.Millisecond)
+		clock.Advance(5 * time.Millisecond)
 
 		contextID, ok := registry.Get("alice")
 		Expect(ok).To(BeFalse(),
@@ -25,12 +26,13 @@ var _ = Describe("ActiveContextRegistry — Idle Timeout (#1446, BR-SESS-023)", 
 	})
 
 	It("UT-AF-1446-002: SC-7 — Refresh resets idle timer, keeping entry alive past idle timeout", func() {
-		registry := launcher.NewActiveContextRegistry(2*time.Hour, 10*time.Millisecond)
+		clock := launcher.NewMockClock(time.Now())
+		registry := launcher.NewActiveContextRegistryWithClock(2*time.Hour, 10*time.Millisecond, clock)
 		registry.Set("bob", "ctx-active")
 
-		time.Sleep(5 * time.Millisecond)
+		clock.Advance(5 * time.Millisecond)
 		registry.Refresh("bob")
-		time.Sleep(7 * time.Millisecond)
+		clock.Advance(7 * time.Millisecond)
 
 		contextID, ok := registry.Get("bob")
 		Expect(ok).To(BeTrue(),
@@ -91,10 +93,11 @@ var _ = Describe("ActiveContextRegistry (BR-SESS-020, BR-SESS-022, BR-SESS-024)"
 	})
 
 	It("UT-AF-SESS-020-005: Get returns false for expired entry (AC-2)", func() {
-		shortTTL := launcher.NewActiveContextRegistry(1*time.Millisecond, 1*time.Millisecond)
+		clock := launcher.NewMockClock(time.Now())
+		shortTTL := launcher.NewActiveContextRegistryWithClock(1*time.Millisecond, 1*time.Millisecond, clock)
 		shortTTL.Set("dave", "ctx-expired")
 
-		time.Sleep(5 * time.Millisecond)
+		clock.Advance(5 * time.Millisecond)
 
 		contextID, ok := shortTTL.Get("dave")
 		Expect(ok).To(BeFalse())

--- a/pkg/apifrontend/launcher/session_interceptor_it_test.go
+++ b/pkg/apifrontend/launcher/session_interceptor_it_test.go
@@ -140,10 +140,11 @@ var _ = Describe("SessionInterceptor Integration (BR-SESS-020)", func() {
 	})
 
 	It("IT-AF-1446-004: SC-7 — Message with empty contextId is NOT redirected when registry entry is idle-expired (#1446)", func() {
-		shortIdleRegistry := launcher.NewActiveContextRegistry(2*time.Hour, 1*time.Millisecond)
+		clock := launcher.NewMockClock(time.Now())
+		shortIdleRegistry := launcher.NewActiveContextRegistryWithClock(2*time.Hour, 1*time.Millisecond, clock)
 		shortIdleRegistry.Set("diana", "ctx-stale-investigation")
 
-		time.Sleep(5 * time.Millisecond)
+		clock.Advance(5 * time.Millisecond)
 
 		interceptor := launcher.NewSessionInterceptor(shortIdleRegistry, logger)
 		h, err := launcher.NewA2AHandler(launcher.A2AConfig{
@@ -169,7 +170,8 @@ var _ = Describe("SessionInterceptor Integration (BR-SESS-020)", func() {
 	})
 
 	It("IT-AF-1446-005: SC-7, AC-2 — Active session stays alive via Refresh through tool call sequence (#1446)", func() {
-		shortIdleRegistry := launcher.NewActiveContextRegistry(2*time.Hour, 50*time.Millisecond)
+		clock := launcher.NewMockClock(time.Now())
+		shortIdleRegistry := launcher.NewActiveContextRegistryWithClock(2*time.Hour, 50*time.Millisecond, clock)
 		shortIdleRegistry.Set("edgar", "ctx-active-investigation")
 
 		interceptor := launcher.NewSessionInterceptor(shortIdleRegistry, logger)
@@ -182,9 +184,9 @@ var _ = Describe("SessionInterceptor Integration (BR-SESS-020)", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		time.Sleep(30 * time.Millisecond)
+		clock.Advance(30 * time.Millisecond)
 		shortIdleRegistry.Refresh("edgar")
-		time.Sleep(30 * time.Millisecond)
+		clock.Advance(30 * time.Millisecond)
 
 		rec := sendMessage(h, "edgar", "", "show me the RCA")
 		Expect(rec.Code).To(Equal(http.StatusOK))

--- a/pkg/apifrontend/launcher/session_interceptor_test.go
+++ b/pkg/apifrontend/launcher/session_interceptor_test.go
@@ -180,7 +180,8 @@ var _ = Describe("SessionInterceptor (BR-SESS-020, BR-SESS-021, BR-SESS-023)", f
 	})
 
 	It("UT-AF-1446-006: SC-7, AC-6 — Does NOT override contextId when session is idle-expired; clears stale entry (#1446)", func() {
-		shortIdle := launcher.NewActiveContextRegistry(2*time.Hour, 1*time.Millisecond)
+		clock := launcher.NewMockClock(time.Now())
+		shortIdle := launcher.NewActiveContextRegistryWithClock(2*time.Hour, 1*time.Millisecond, clock)
 		logBuf.Reset()
 		logger := funcr.New(func(prefix, args string) {
 			logBuf.WriteString(prefix + " " + args + "\n")
@@ -188,7 +189,7 @@ var _ = Describe("SessionInterceptor (BR-SESS-020, BR-SESS-021, BR-SESS-023)", f
 		staleInterceptor := launcher.NewSessionInterceptor(shortIdle, logger)
 
 		shortIdle.Set("hank", "ctx-stale-investigation")
-		time.Sleep(5 * time.Millisecond)
+		clock.Advance(5 * time.Millisecond)
 
 		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 			Username: "hank", Groups: []string{"sre"},


### PR DESCRIPTION
## Summary

Port of #2126 (merged to `release/v1.5`) to `main`.

`ActiveContextRegistry.Set/Refresh/Get` called `time.Now()` directly, so the only way tests could exercise idle-timeout/TTL expiry was to make real wall-clock time pass via `time.Sleep()` against millisecond-scale timeouts. `UT-AF-1446-002` flaked on `release/v1.5`'s CI pipeline (10ms idle timeout, 5ms+7ms sleeps, ~3ms margin) — a classic CI-flake shape, not a business-logic regression.

## Changes

Adds a `Clock` interface (`RealClock`/`MockClock`) to `active_context_registry.go`, following the same pattern already used in `pkg/gateway/processing/clock.go` and `pkg/datastorage/partition/ensure.go`:
- `NewActiveContextRegistry` keeps its existing signature and defaults to `RealClock` — the one production call site (`cmd/apifrontend/main.go`) is unaffected.
- New `NewActiveContextRegistryWithClock(ttl, idleTimeout, clock)` constructor for tests.

Migrates all sleep-based timing assertions to `MockClock.Advance()` across `active_context_registry_test.go`, `session_interceptor_test.go`, `session_interceptor_it_test.go`, and `phase_guard_test.go`, eliminating this flake category — including `UT-AF-1496-003`, a `main`-only test (not present on `release/v1.5`) that used the same anti-pattern.

`phase_guard_test.go` has diverged structurally between `main` and `release/v1.5` (different test ordering/issue numbering), so this isn't a byte-for-byte cherry-pick — the equivalent edits were applied to `main`'s current version of the file.

## Test plan

- [x] `go build ./...`, `go vet`, `golangci-lint run` clean on changed packages
- [x] `make test-unit-apifrontend` — all 25 suites pass
- [x] `pkg/apifrontend/launcher` + `pkg/apifrontend/agent` tests run 10x repeated with `-race` — zero flakes