### PR TITLE
fix(release): exclude pre-release tags from GA release-notes previous-tag lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -896,11 +896,31 @@ jobs:
             # list to commits actually reachable from this release's own
             # commit, so it always resolves to the true previous release in
             # the same lineage (e.g. v1.5.3 for v1.5.4).
+            #
+            # #2130 follow-up: for a GA release, the candidate list must ALSO
+            # exclude pre-release tags (-rc*, -alpha*, -beta*, etc.).
+            # Promoting an RC straight to GA (e.g. v1.5.6-rc6 -> v1.5.6) means
+            # every rc tag for this release is an ancestor of the GA tag and
+            # was created more recently than the last true GA release, so an
+            # unfiltered --sort=-creatordate picked v1.5.6-rc6 as "previous"
+            # for v1.5.6, producing a "Full Changelog: v1.5.6-rc6...v1.5.6"
+            # link that only covered the final RC->GA diff instead of the
+            # full v1.5.5...v1.5.6 release contents. GA tags are strict
+            # semver (vX.Y.Z, no pre-release suffix); pre-release tags always
+            # have a trailing "-something". When creating a pre-release
+            # ourselves, no such filtering is needed -- rc-to-rc comparisons
+            # are the correct, expected behavior.
+            if [ "$IS_PRERELEASE" = "true" ]; then
+              PREV_TAG_CANDIDATES="$(git tag --sort=-creatordate --merged "${TAG}" | grep '^v' | grep -v "^${TAG}$")"
+            else
+              PREV_TAG_CANDIDATES="$(git tag --sort=-creatordate --merged "${TAG}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TAG}$")"
+            fi
+
             gh release create "${TAG}" \
               --title "Kubernaut ${TAG}" \
               --generate-notes \
               ${PRERELEASE_FLAG} \
-              --notes-start-tag "$(git tag --sort=-creatordate --merged "${TAG}" | grep '^v' | grep -v "^${TAG}$" | head -1)" || \
+              --notes-start-tag "$(echo "${PREV_TAG_CANDIDATES}" | head -1)" || \
             gh release create "${TAG}" \
               --title "Kubernaut ${TAG}" \
               --generate-notes \


### PR DESCRIPTION
## Summary

Fixes #2130.

`https://github.com/jordigilh/kubernaut/releases/tag/v1.5.6`'s "Full Changelog" link compared `v1.5.6-rc6...v1.5.6` instead of `v1.5.5...v1.5.6` — it only showed the single "release: prepare v1.5.6 GA" PR instead of everything since the last real release.

**Root cause**: the previous-tag lookup added for #1721/#1730 (`git tag --sort=-creatordate --merged "${TAG}"`) filters by ancestry and recency, but never checks whether a candidate is itself a real (semver, no pre-release suffix) release. Promoting an RC straight to GA means every `-rc*` tag for that release is an ancestor of the GA tag and was created more recently than the last true GA tag, so it always wins the `head -1`.

## Fix

For a GA release (`IS_PRERELEASE=false`), restrict the candidate list to strict semver tags (`vX.Y.Z`, no trailing `-rc`/`-alpha`/`-beta` etc.) so it always resolves to the previous true GA release. Pre-release tags we create ourselves are unaffected — rc-to-rc comparisons remain correct there.

Verified locally against this repo's actual tags:
```
TAG=v1.5.6      IS_PRERELEASE=false -> previous=v1.5.5   (was: v1.5.6-rc6)
TAG=v1.5.6-rc6  IS_PRERELEASE=true  -> previous=v1.5.6-rc5 (unchanged, correct)
TAG=v1.5.5      IS_PRERELEASE=false -> previous=v1.5.4    (unchanged, correct)
```

v1.5.6's already-published release notes were corrected manually via `gh api repos/.../releases/generate-notes` as a follow-up; this PR prevents the same bug on future GA promotions.

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Shell logic simulated locally against real tag history for a GA tag, an RC tag, and a prior GA tag — all three resolve to the expected previous tag
- [ ] This workflow only runs on tag push, so it can't be exercised by this PR's own CI — the actual behavior will next be exercised at the next release promotion (v1.5.7/v1.6.0)