### PR TITLE
fix(kubernautagent): port v1.5.6 gate-retry fixes (#2119, #2121) + close audit schema gap (#2141)

### DIFF
--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -4873,6 +4873,26 @@ components:
           items:
             type: string
           description: List of MCP servers
+        retry_outcome:
+          type: string
+          description: >-
+            Present only on sameKindValidationGate/apiVersionValidationGate
+            retry audit events (#2119/#2120/#2121, BR-AI-2120, FedRAMP AU-3):
+            why the gate retry ended the way it did, e.g. "resolved",
+            "resolved_after_other_tool_retry", "llm_requested_other_tool",
+            "empty_response", "parse_error", "exhausted".
+        ambiguous_kind:
+          type: string
+          description: >-
+            Present only on apiVersionValidationGate audit events (#1044,
+            BR-AI-1044): the Kind that resolved to multiple API groups,
+            triggering the gate.
+        conflicting_groups:
+          type: string
+          description: >-
+            Present only on apiVersionValidationGate audit events (#1044,
+            BR-AI-1044): comma-joined list of the conflicting API groups
+            for ambiguous_kind.
 
     LLMResponsePayload:
       type: object

--- a/docs/testing/2119/TEST_PLAN.md
+++ b/docs/testing/2119/TEST_PLAN.md
@@ -1,0 +1,117 @@
+# Test Plan: #2119 — Same-Kind Validation Gate Retry Silently Drops RCA Confidence (v1.6 port of #2118)
+
+## 1. Purpose
+
+`sameKindValidationGate` (`internal/kubernautagent/investigator/investigator_gates.go`)
+fires when the LLM's initial RCA `remediation_target.kind` equals the input
+signal's own resource kind (a signal often propagating upward from a child
+resource, e.g. a Pod OOM manifesting as Node `DiskPressure`). It sends a
+correction prompt asking the LLM to re-evaluate whether a child resource is
+the true root cause, then retries the LLM call with only `submit_result`
+declared as a tool.
+
+The gate already had a "lost field, keep original" guard for
+`RemediationTarget.Kind`: if the retry response drops the target entirely,
+the original result is kept rather than discarded. It had **no equivalent
+guard for `Confidence`**. Because the correction prompt reads as a narrow
+yes/no question ("is the target correct?"), the LLM frequently responds with
+a minimal tool call that answers only that question and omits (or zeroes)
+the separately-required `confidence` field. Since `sameKindValidationGate`
+accepted `retryResult.Confidence` unconditionally whenever
+`RemediationTarget.Kind` was non-empty, this silently overwrote a real,
+previously-validated confidence score with `0.0` -- corrupting the
+audit-visible RCA record.
+
+This is the v1.6 port of the fix originally shipped for
+[#2118](https://github.com/jordigilh/kubernaut/issues/2118) on
+`release/v1.5` (v1.5.6, PR #2122). Root-cause analysis, the live-LLM spike,
+and the chosen fix are identical; see #2118's own test plan for the spike
+details. This document tracks the v1.6 port and its adapted test
+scenarios (main's gate structure at port time differs from v1.5.6's:
+`LLMInvocationContext` plumbing, a split `sameKindValidationGate`/
+`retryForSameKind`, and post-#1578 Reasoning-block capture that #2118/#2120
+predate).
+
+### Scope
+
+The same-kind (and API-version) gate retry occasionally calling an
+undeclared tool instead of `submit_result` is a separate, related defect,
+tracked and ported together with this fix as
+[#2121](https://github.com/jordigilh/kubernaut/issues/2121) (v1.6 clone of
+[#2120](https://github.com/jordigilh/kubernaut/issues/2120)).
+
+## 2. Chosen Fix (defense-in-depth)
+
+1. **Strengthened prompt** (`sameKindValidationGate`'s `correctionMsg`,
+   built by `sameKindCorrectionMessage`): added a second paragraph
+   instructing the LLM to resubmit a *complete* RCA result -- confidence
+   genuinely recomputed (not a placeholder or default), severity, and
+   causal_chain at the same rigor as the original submission -- regardless
+   of which target it concludes is correct.
+2. **Confidence-backfill guard** (the deterministic fix, applied in
+   `finalizeSameKindRetry` immediately after the existing
+   `RemediationTarget.Kind` guard):
+
+```go
+if retryResult.Confidence <= 0 && result.Confidence > 0 {
+    inv.logger.Info("same-kind validation gate: retry lost confidence, keeping original",
+        "original_confidence", result.Confidence, "correlation_id", correlationID)
+    retryResult.Confidence = result.Confidence
+}
+```
+
+   Unlike the `RemediationTarget.Kind` guard (which discards the entire
+   retry on loss), this backfills only the regressed field -- other
+   genuinely new retry content (e.g. an updated
+   `due_diligence.target_accuracy` narrative) is preserved rather than
+   discarded.
+
+No Wiring Manifest row: this modifies existing, already-wired gate logic
+(`Investigate()` -> `sameKindValidationGate` -> `retryForSameKind`); no new
+production entry point.
+
+## 3. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **SI-10** | Information Input/Output Validation | A retry's `confidence` value must be validated against regression, not blindly trusted just because it satisfies schema bounds (`[0,1]`, `parser/schema.go`). |
+| **AU-3** | Content of Audit Records | Confidence surfaced to operators/Console and persisted in the audit-visible RCA record must reflect genuine RCA certainty, not a silently-dropped placeholder. |
+
+## 4. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-KA-2118-001 (regression) | Unit (exercised through the real `Investigate()` production path) | Same-kind gate retry confirms the same target but the tool call arguments omit confidence entirely; the pre-retry confidence (0.88) must be backfilled through to the final merged result, not silently dropped to 0 | SI-10, AU-3 | `internal/kubernautagent/investigator/samekind_confidence_2118_test.go` |
+| UT-KA-2118-002 | Unit | Retry genuinely recomputes a different, non-zero confidence (0.55); the gate must preserve it unchanged, not overwrite it with the pre-retry value | SI-10 | same file |
+| UT-KA-2118-003 (edge case) | Unit | The pre-retry confidence was itself never set (0) and the retry also omits it; the guard must not fabricate a non-zero confidence out of another zero value | SI-10 | same file |
+| UT-KA-2118-004 | Unit | The correction message sent to the LLM must explicitly instruct it to restate confidence as part of a full RCA restatement, not just confirm/deny the target | AU-3 | same file |
+
+(Test/scenario IDs retain the original `UT-KA-2118-*` numbering from the
+upstream fix rather than being renumbered to `2119`, per this package's
+convention of keeping scenario IDs stable across backports/ports so the same
+spec can be cross-referenced from either issue.)
+
+### Tier Coverage Rationale
+
+- **UT** (via the real `Investigate()` entry point, following this
+  package's established pattern in `apiversion_gate_test.go`) covers this
+  fix completely: the bug is a pure business-logic property of
+  `sameKindValidationGate`/`retryForSameKind`'s own retry-acceptance branch,
+  fully reproducible with a mock `llm.Client` and no external dependencies.
+- **IT/E2E**: not added net-new. The gate's wiring into the production
+  `Investigate()` path already exists and is already exercised by the
+  existing `apiversion_gate_test.go` suite plus this fix's own UT specs
+  (which call through that same real entry point); this change modifies
+  the gate's internal retry-acceptance behavior without adding a new wiring
+  point.
+
+## 5. Validation Results
+
+- `go test ./internal/kubernautagent/investigator/...` -- pass, 366/366
+  specs (including the 4 new UT-KA-2118-XXX specs above plus 6
+  UT-KA-2120-XXX specs from the co-ported #2121 fix).
+- `go test ./internal/kubernautagent/...` (full package) -- pass, no
+  regressions.
+- `golangci-lint run ./internal/kubernautagent/investigator/...` -- 0
+  issues.
+- `go build ./...` -- clean.

--- a/docs/testing/2121/TEST_PLAN.md
+++ b/docs/testing/2121/TEST_PLAN.md
@@ -1,0 +1,144 @@
+# Test Plan: #2121 — Gate Retry Silently Skips Correction on Undeclared Tool Call (v1.6 port of #2120)
+
+## 1. Purpose
+
+`sameKindValidationGate` and `apiVersionValidationGate`
+(`internal/kubernautagent/investigator/investigator_gates.go`) both send
+their gate-retry LLM call with only a single declared tool
+(`submitOnlyRCATools()`, i.e. just `submit_result`). Discovered during the
+#2118 live-LLM spike: the model does not always respect this constraint --
+it frequently returns a `tool_use` block naming a tool that was never
+declared in the request's `tools` array (e.g. `kubectl_describe`,
+`get_namespaced_resource_context`) instead of calling `submit_result`.
+
+Pre-fix, this did not corrupt data or crash: the gate's tool-call scan found
+no `submit_result` call, fell back to `resp.Message.Content` (empty, since
+the model's turn was pure tool-use), and correctly treated the empty
+content as an error path -- logging "no content in retry response, keeping
+original" and returning the pre-retry result unchanged.
+
+The problem was **silent correction loss, indistinguishable from a
+genuinely empty response**: the gate believed it attempted a correction, but
+the LLM never engaged with the correction prompt at all. Neither gate's
+audit event distinguished "LLM re-evaluated and confirmed/changed the
+target" from "LLM never got the chance to re-evaluate because it wanted a
+different tool."
+
+This is the v1.6 port of the fix originally shipped for
+[#2120](https://github.com/jordigilh/kubernaut/issues/2120) on
+`release/v1.5` (v1.5.6, PR #2122). The live-LLM spike (10/10 undeclared-tool
+reproduction, 10/10 recovery after a reminder retry) and the chosen fix are
+identical; see #2120's own test plan for the spike details. This document
+tracks the v1.6 port and its adapted implementation (main's gate structure
+at port time differs from v1.5.6's: `LLMInvocationContext` plumbing, split
+`sameKindValidationGate`/`retryForSameKind` and
+`apiVersionValidationGate`/`retryForAPIVersion` functions, and post-#1578
+Reasoning-block capture on the accepted retry result that #2118/#2120
+predate -- `retryGateOnUnexpectedTool` was extended to also return the
+reminder response's `Reasoning` block so that capture is preserved on the
+reminder-recovery path, not just the first-attempt path).
+
+## 2. Chosen Fix
+
+1. **`gateRetrySubmitContent(resp)`** classifies a gate-retry response:
+   returns `submit_result`'s tool-call arguments if present (falling back to
+   raw message content, mirroring pre-fix behavior for bare-JSON-text
+   responses), plus the names of any other tool(s) called instead.
+2. **`retryGateOnUnexpectedTool(...)`** re-issues the gate-retry call once
+   more when an undeclared tool was called: replays that call as a
+   synthetic `tool_result` "not available" error, plus an explicit reminder
+   that only `submit_result` is available, then re-sends with the same
+   single-tool declaration. Also returns the reminder turn's `Reasoning`
+   block (main-only addition vs. upstream, for BR-AI-086 AC6 parity).
+3. **`resolveGateContent(...)`** (main-only extraction, added during the
+   port to keep `retryForSameKind`/`retryForAPIVersion` under the
+   `funlen`/`gocyclo` budget): shared helper wrapping steps 1-2, used by
+   both gates so the undeclared-tool-recovery logic is not duplicated.
+4. Both gates now route through these helpers. On recovery, the outcome is
+   tagged `resolved_after_other_tool_retry`, distinct from a first-try
+   `resolved`. On persistence of the undeclared-tool behavior across both
+   attempts, the outcome is tagged `llm_requested_other_tool`, distinct
+   from `empty_response`/`parse_error`/generic `exhausted`.
+5. `apiVersionGateExhaustion` now takes the outcome as a parameter instead
+   of hardcoding `"exhausted"`.
+
+### Secondary finding fixed in the same change: dead `retry_outcome`/`EventOutcome`
+
+While restructuring both gates' audit-event lifecycle to add the new
+`retry_outcome` values, a pre-existing bug was found and fixed (also fixed
+upstream, tracked there as #2124): `apiVersionValidationGate` called
+`audit.StoreBestEffort(gateEvent, ...)` *before* the gate-retry LLM call,
+then mutated `gateEvent.Data["retry_outcome"]` *afterward*. `sameKindValidationGate`
+had the same shape (call before the retry). Real production audit stores
+(`internal/kubernautagent/audit/ds_store.go`'s `DSAuditStore`/
+`BufferedDSAuditStore`) synchronously serialize `event.Data` into the
+outbound request **at call time**, so that mutation was never actually
+persisted. The existing unit-test double (`gateRecordingAuditStore` in
+`apiversion_gate_test.go`) masked this by storing the raw
+`*audit.AuditEvent` **pointer**, so an in-memory read after `Investigate()`
+returned always reflected the final state regardless of when `StoreAudit`
+was actually called.
+
+Fix: both gates now `defer audit.StoreBestEffort(...)` immediately after
+building `gateEvent`, so the store call fires once, after every `Data`/
+`EventOutcome` mutation on every exit path has already happened. The
+shared `gateRecordingAuditStore.StoreAudit` now snapshots `event.Data`
+(map copy) at call time, matching real production semantics.
+
+No Wiring Manifest row: both gates already wire into the production
+`Investigate()` path; this change modifies their internal retry-handling
+and audit-emission logic without adding a new production entry point.
+
+## 3. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **AU-3** | Content of Audit Records | The audit trail must distinguish "the LLM re-evaluated and answered" from "the LLM never engaged with the correction at all," and must actually persist that distinction (fixing the dead-mutation defect) rather than silently dropping it before it reaches the real audit store. |
+| **SI-10** | Information Input/Output Validation | A gate correction must be actually delivered and answered before its result is trusted; an undeclared-tool response must not be silently conflated with a validated confirmation. |
+
+## 4. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-KA-2120-001 (regression) | Unit (via real `Investigate()`) | Same-kind gate's retry calls an undeclared tool on attempt 1, `submit_result` on attempt 2 (reminder recovery) -> final result reflects attempt 2's data; `retry_outcome == "resolved_after_other_tool_retry"`, `EventOutcome == success` | AU-3, SI-10 | `internal/kubernautagent/investigator/gate_undeclared_tool_2120_test.go` |
+| UT-KA-2120-002 | Unit | Same-kind gate's retry calls an undeclared tool on both attempts -> original result kept (pre-fix fallback behavior preserved); `retry_outcome == "llm_requested_other_tool"`, `EventOutcome == failure` | AU-3 | same file |
+| UT-KA-2120-003 | Unit | API-version gate mirrors 001: undeclared tool then correct `api_version` on reminder -> recovered, no human review, `retry_outcome == "resolved_after_other_tool_retry"` | AU-3, SI-10 | same file |
+| UT-KA-2120-004 | Unit | API-version gate mirrors 002: undeclared tool on both attempts -> human review still triggered (`rca_incomplete`) to prevent incorrect RBAC grants, `retry_outcome == "llm_requested_other_tool"`, `EventOutcome == failure` | SI-10 | same file |
+| UT-KA-2120-005 (regression for the dead-mutation defect) | Unit | With the fixed, honest `gateRecordingAuditStore` (snapshotting at call time), a plain successful same-kind retry shows `retry_outcome == "resolved"`/`EventOutcome == success`, and a plain exhausted api-version retry shows `retry_outcome == "exhausted"`/`EventOutcome == failure` -- proving both are captured by `StoreAudit` at call time, not just recoverable from a later in-memory pointer read | AU-3 | same file |
+
+(Test/scenario IDs retain the original `UT-KA-2120-*` numbering from the
+upstream fix, per this package's convention.)
+
+### Tier Coverage Rationale
+
+- **UT** (via the real `Investigate()` entry point, following this
+  package's established convention in `apiversion_gate_test.go` and
+  `samekind_confidence_2118_test.go`) covers this fix completely: the
+  undeclared-tool-retry behavior and the audit-timing fix are both pure
+  business-logic properties of the two gates' retry-handling and
+  audit-emission code, fully reproducible with a mock `llm.Client` and no
+  external dependencies.
+- **IT/E2E**: not added net-new. Both gates' wiring into the production
+  `Investigate()` path already exists and is already exercised by the
+  existing `apiversion_gate_test.go` suite plus this fix's own UT specs
+  (which call through that same real entry point); this change modifies
+  internal retry-handling and audit-emission behavior without adding a new
+  wiring point.
+
+## 5. Validation Results
+
+- `go test ./internal/kubernautagent/investigator/...` -- pass, 366/366
+  specs (including the 6 new UT-KA-2120-XXX specs above plus 4
+  UT-KA-2118-XXX specs from the co-ported #2119 fix; UT-KA-2120-003 required
+  switching to the package's `newTestInvestigator` helper -- unlike upstream
+  v1.5.6, main's post-#1677 hardening fails workflow selection closed to
+  human review when no `CatalogFetcher` is configured, which is orthogonal
+  to the behavior under test).
+- `go test ./internal/kubernautagent/...` (full package) -- pass, no
+  regressions.
+- `golangci-lint run ./internal/kubernautagent/investigator/...` -- 0
+  issues (required extracting `gateContentResult`/`resolveGateContent` and
+  `finalizeSameKindRetry`/`finalizeAPIVersionRetry` helpers to stay under
+  the `funlen`/`gocyclo`/`revive` argument-limit budgets -- main's gates
+  carry more logic per function than v1.5.6's pre-port versions).
+- `go build ./...` -- clean.

--- a/docs/testing/2121/TEST_PLAN.md
+++ b/docs/testing/2121/TEST_PLAN.md
@@ -206,24 +206,34 @@ matching the tracked issue number.)
   for ordinary events). Confirmed RED before GREEN (test failed against
   the pre-#2141 schema, as expected).
 - `IT-KA-2141-001`
-  (`test/integration/kubernautagent/investigator/apiversion_gate_integration_test.go`)
-  and the `E2E-KA-1044-001` extension
-  (`test/e2e/kubernautagent/apiversion_gate_e2e_test.go`): compile clean
-  (`go vet`). Could not be executed in this environment (no local Docker
-  daemon, no `envtest`/kubebuilder binaries, no live Kind cluster) --
-  will be validated by CI on push, same constraint as the
-  `capturingAuditStore` fixture fix below.
+  (`test/integration/kubernautagent/investigator/apiversion_gate_integration_test.go`):
+  **executed locally against real envtest + Podman-backed Data
+  Storage/Postgres** (`KUBEBUILDER_ASSETS=$(setup-envtest use 1.36 -p path)
+  ginkgo ./test/integration/kubernautagent/investigator/...`) -- **142/142
+  specs pass**, including this one: the gate-exhaustion audit event is
+  queried back from the real Postgres-backed Data Storage by
+  `correlation_id` and `retry_outcome`/`ambiguous_kind`/`conflicting_groups`
+  are confirmed present and correct on the decoded `LLMRequestPayload`.
+  This also transitively re-validates the `capturingAuditStore` fixture fix
+  below (same suite run, same process).
+- `E2E-KA-1044-001` extension
+  (`test/e2e/kubernautagent/apiversion_gate_e2e_test.go`): **executed
+  locally against a real Kind cluster** (`ginkgo --focus="BR-AI-1044"
+  ./test/e2e/kubernautagent/...`, full infra bootstrap: Kind + Data
+  Storage + Postgres + Mock LLM + Kubernaut Agent deployment) -- **2/2
+  focused specs pass** (134 total, 132 skipped via focus). The extended
+  assertions confirm the full production journey: real gate exhaustion in
+  the deployed Kubernaut Agent binary -> real `DSAuditStore` -> real Data
+  Storage service -> real Postgres -> queryable by `remediation_id` via
+  `QueryAuditEvents`, with `ambiguous_kind` and `retry_outcome=exhausted`
+  reconstructable end-to-end.
 - `capturingAuditStore` fixture fix
-  (`test/integration/kubernautagent/investigator/suite_test.go`): compiles
-  clean (`go vet ./test/integration/kubernautagent/investigator/...`).
-  Could not be executed in this environment (no local Docker daemon, no
-  `envtest`/kubebuilder binaries) -- will be validated by
-  `ci-pipeline.yml`'s kubernaut-agent integration job on push. This is a
-  narrow, mechanical change (identical to the already-proven unit-level
-  snapshot fix) affecting how ~15 pre-existing `IT-KA-*` specs observe
-  audit events they already assert on; it does not change what those
-  specs assert, only when the observed data is captured relative to
-  `StoreAudit`.
+  (`test/integration/kubernautagent/investigator/suite_test.go`):
+  re-validated by the same 142/142 passing integration run above -- the
+  ~15 pre-existing `IT-KA-*` specs that observe audit events via this
+  fixture all pass unchanged, confirming the snapshot-at-call-time
+  behavior did not alter what those specs assert, only when the observed
+  data is captured relative to `StoreAudit`.
 - `go test ./internal/kubernautagent/investigator/...` -- pass, 366/366
   specs (including the 6 new UT-KA-2120-XXX specs above plus 4
   UT-KA-2118-XXX specs from the co-ported #2119 fix; UT-KA-2120-003 required

--- a/docs/testing/2121/TEST_PLAN.md
+++ b/docs/testing/2121/TEST_PLAN.md
@@ -89,31 +89,37 @@ No Wiring Manifest row: both gates already wire into the production
 `Investigate()` path; this change modifies their internal retry-handling
 and audit-emission logic without adding a new production entry point.
 
-### Follow-up discovery: `retry_outcome` doesn't actually reach Data Storage today (tracked separately, not fixed here)
+### Follow-up discovery, then closed in this same PR: `retry_outcome`/`ambiguous_kind`/`conflicting_groups` didn't actually reach Data Storage (#2141)
 
 Post-implementation review asked whether a DB round-trip test (query
 Data Storage/Postgres by `correlation_id` after a real `Investigate()`
 call, confirming `retry_outcome` is queryable from the persisted audit
 trail per BR-AUDIT-005/SOC2 CC8.1) was needed to fully prove the
-dead-mutation fix above. Investigation found it would fail regardless of
-the ordering fix: both gates' audit events use
+dead-mutation fix above. Investigation found it would have failed
+regardless of the ordering fix: both gates' audit events use
 `EventType: audit.EventTypeLLMRequest`, which serializes through
 `buildLLMRequestPayload` (`internal/kubernautagent/audit/ds_payloads.go`)
 into the OpenAPI-generated `ogenclient.LLMRequestPayload` -- a fixed
 schema (`model`, `prompt_length`, `prompt_preview`, `event_id`,
 `incident_id`, `toolsets_enabled`) with no passthrough for arbitrary
 `Data` keys. `retry_outcome` (and the pre-existing `ambiguous_kind`/
-`conflicting_groups` fields `IT-KA-1044-005` already asserts on) are
-silently dropped before the outbound `AuditEventRequest` is even built.
+`conflicting_groups` fields `IT-KA-1044-005` already asserted on, only
+in-memory) were silently dropped before the outbound `AuditEventRequest`
+was even built.
 
-This is a pre-existing schema gap, not something #2119/#2121 caused or
-can fix in scope -- fixing it is a Data Storage API contract change
-(OpenAPI schema + ogen codegen), not a test-only change. Tracked as
-[#2141](https://github.com/jordigilh/kubernaut/issues/2141) for its own
-preflight/plan. Decision: keep this PR scoped to the in-process ordering
-fix (still correct and necessary once the schema gap is eventually
-closed) and its UT proof; no DB round-trip IT was added here since it
-cannot currently pass for a reason unrelated to this fix's correctness.
+This was a pre-existing schema gap, not something #2119/#2121 caused --
+fixing it is a Data Storage API contract change (OpenAPI schema + ogen
+codegen), not a test-only change, so it was scoped as its own tracked
+issue, [#2141](https://github.com/jordigilh/kubernaut/issues/2141), with
+its own preflight/plan (95% confidence -- server-side write/read paths
+treat `event_data` as opaque JSONB in both directions, so the fix is
+client-side-only: schema + `buildLLMRequestPayload`, zero DS server
+changes). Given CI/Actions resource constraints, #2141 was implemented
+in this same branch/PR rather than a separate one -- see Section 4 for
+the resulting `UT-KA-2141-001`/`IT-KA-2141-001`/`E2E-KA-1044-001`
+(extended) entries, which close the loop: these fields are now
+genuinely reconstructable from the real audit trail, not just from an
+in-memory test double.
 
 ### Independent hardening landed in this same PR: IT-level audit fixture had the identical masking flaw
 
@@ -134,7 +140,7 @@ hardening, not a new business-behavior test -- see Section 5.
 
 | Control | Title | Relevance |
 |---|---|---|
-| **AU-3** | Content of Audit Records | The audit trail must distinguish "the LLM re-evaluated and answered" from "the LLM never engaged with the correction at all," and must actually persist that distinction (fixing the dead-mutation defect) rather than silently dropping it before it reaches the real audit store. **Caveat**: full AU-3 satisfaction (the field actually reconstructable from Data Storage by `correlation_id`) is blocked on the pre-existing schema gap tracked in [#2141](https://github.com/jordigilh/kubernaut/issues/2141) -- this fix corrects in-process ordering so the field is *ready* to persist once that gap closes, and is proven correct at the UT tier via a snapshot-at-call-time double, not yet via a real Data Storage round-trip. |
+| **AU-3** | Content of Audit Records | The audit trail must distinguish "the LLM re-evaluated and answered" from "the LLM never engaged with the correction at all," and must actually persist that distinction (fixing the dead-mutation defect) rather than silently dropping it before it reaches the real audit store. Full AU-3 satisfaction (the field actually reconstructable from Data Storage by `correlation_id`) required closing the schema gap tracked in [#2141](https://github.com/jordigilh/kubernaut/issues/2141) in the same PR -- see `UT-KA-2141-001`/`IT-KA-2141-001`/`E2E-KA-1044-001` below, which prove the field end-to-end rather than only via an in-process snapshot-at-call-time double. |
 | **SI-10** | Information Input/Output Validation | A gate correction must be actually delivered and answered before its result is trusted; an undeclared-tool response must not be silently conflated with a validated confirmation. |
 
 ## 4. Pyramid Invariant — Test Scenario Inventory
@@ -146,9 +152,13 @@ hardening, not a new business-behavior test -- see Section 5.
 | UT-KA-2120-003 | Unit | API-version gate mirrors 001: undeclared tool then correct `api_version` on reminder -> recovered, no human review, `retry_outcome == "resolved_after_other_tool_retry"` | AU-3, SI-10 | same file |
 | UT-KA-2120-004 | Unit | API-version gate mirrors 002: undeclared tool on both attempts -> human review still triggered (`rca_incomplete`) to prevent incorrect RBAC grants, `retry_outcome == "llm_requested_other_tool"`, `EventOutcome == failure` | SI-10 | same file |
 | UT-KA-2120-005 (regression for the dead-mutation defect) | Unit | With the fixed, honest `gateRecordingAuditStore` (snapshotting at call time), a plain successful same-kind retry shows `retry_outcome == "resolved"`/`EventOutcome == success`, and a plain exhausted api-version retry shows `retry_outcome == "exhausted"`/`EventOutcome == failure` -- proving both are captured by `StoreAudit` at call time, not just recoverable from a later in-memory pointer read | AU-3 | same file |
+| UT-KA-2141-001 | Unit | `buildLLMRequestPayload` maps `event.Data["retry_outcome"]`/`["ambiguous_kind"]`/`["conflicting_groups"]` onto the new `LLMRequestPayload` wire-schema fields when present, and leaves them unset (not empty-string) for ordinary non-gate `llm.request` events | AU-3 | `internal/kubernautagent/audit/ds_store_test.go` |
+| IT-KA-2141-001 | Integration (real `DSAuditStore` + Postgres) | A real gate-exhaustion `Investigate()` call, followed by a `QueryAuditEvents` call to the real Data Storage service by `correlation_id`, finds the `api_version_validation_gate` event and decodes `ambiguous_kind`/`conflicting_groups`/`retry_outcome == "exhausted"` from the persisted `LLMRequestPayload` -- the actual DB round-trip proof the #2119/#2121 ordering fix was written for, now possible because #2141 gave these fields a wire carrier | AU-3 | `test/integration/kubernautagent/investigator/apiversion_gate_integration_test.go` |
+| E2E-KA-1044-001 (extended) | E2E (real binary, real K8s, real mock LLM, real Data Storage) | Extends the existing ambiguous-kind gate-exhaustion journey: after asserting `HumanReviewNeeded`/`HumanReviewReason` on the business response, also queries Data Storage by `remediation_id` and asserts `ambiguous_kind`/`retry_outcome == "exhausted"` are present on the persisted audit event -- proves the full production journey, not just the IT-level direct-DB path | AU-3 | `test/e2e/kubernautagent/apiversion_gate_e2e_test.go` |
 
 (Test/scenario IDs retain the original `UT-KA-2120-*` numbering from the
-upstream fix, per this package's convention.)
+upstream fix, per this package's convention; `*-2141-*` IDs are new,
+matching the tracked issue number.)
 
 ### Tier Coverage Rationale
 
@@ -159,15 +169,50 @@ upstream fix, per this package's convention.)
   business-logic properties of the two gates' retry-handling and
   audit-emission code, fully reproducible with a mock `llm.Client` and no
   external dependencies.
-- **IT/E2E**: not added net-new. Both gates' wiring into the production
-  `Investigate()` path already exists and is already exercised by the
-  existing `apiversion_gate_test.go` suite plus this fix's own UT specs
-  (which call through that same real entry point); this change modifies
-  internal retry-handling and audit-emission behavior without adding a new
-  wiring point.
+- **IT/E2E for the #2119/#2121 ordering fix itself**: not added net-new.
+  Both gates' wiring into the production `Investigate()` path already
+  exists and is already exercised by the existing `apiversion_gate_test.go`
+  suite plus this fix's own UT specs (which call through that same real
+  entry point); this change modifies internal retry-handling and
+  audit-emission behavior without adding a new wiring point.
+- **IT/E2E for #2141 (the wire-schema gap)**: added net-new, because this
+  *is* a new wiring point -- data that previously had no path to Data
+  Storage now does. `IT-KA-2141-001` proves the wiring directly (real
+  `DSAuditStore` write, real `QueryAuditEvents` read-back). `E2E-KA-1044-001`
+  proves the full production journey through the real binary reaches the
+  same result, closing the AU-3 control objective with an actual proving
+  journey rather than only a wiring-level proof.
+
+### #2141 Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT Test ID |
+|---|---|---|---|
+| `LLMRequestPayload.RetryOutcome`/`AmbiguousKind`/`ConflictingGroups` | `DSAuditStore.StoreAudit`, invoked via the gates' deferred `audit.StoreBestEffort` | `internal/kubernautagent/audit/ds_payloads.go::buildLLMRequestPayload` | `IT-KA-2141-001` |
 
 ## 5. Validation Results
 
+- **#2141 schema/codegen**: `api/openapi/data-storage-v1.yaml` (`LLMRequestPayload`)
+  extended with 3 optional string fields; `make generate` regenerated
+  `pkg/datastorage/ogen-client` and both embedded spec copies
+  (`pkg/audit/openapi_spec_data.yaml`,
+  `pkg/datastorage/server/middleware/openapi_spec_data.yaml`) with zero
+  unexpected drift (`git status` after `make generate` showed only the
+  files intentionally touched -- confirms the `gen-diff` CI gate will
+  pass). Per preflight, Data Storage's server-side write/read paths treat
+  `event_data` as opaque JSONB in both directions, so no DS server code
+  needed changing.
+- `go test ./internal/kubernautagent/audit/...` -- pass, including new
+  `UT-KA-2141-001` (2 specs: fields populated when present, left unset
+  for ordinary events). Confirmed RED before GREEN (test failed against
+  the pre-#2141 schema, as expected).
+- `IT-KA-2141-001`
+  (`test/integration/kubernautagent/investigator/apiversion_gate_integration_test.go`)
+  and the `E2E-KA-1044-001` extension
+  (`test/e2e/kubernautagent/apiversion_gate_e2e_test.go`): compile clean
+  (`go vet`). Could not be executed in this environment (no local Docker
+  daemon, no `envtest`/kubebuilder binaries, no live Kind cluster) --
+  will be validated by CI on push, same constraint as the
+  `capturingAuditStore` fixture fix below.
 - `capturingAuditStore` fixture fix
   (`test/integration/kubernautagent/investigator/suite_test.go`): compiles
   clean (`go vet ./test/integration/kubernautagent/investigator/...`).

--- a/docs/testing/2121/TEST_PLAN.md
+++ b/docs/testing/2121/TEST_PLAN.md
@@ -89,11 +89,52 @@ No Wiring Manifest row: both gates already wire into the production
 `Investigate()` path; this change modifies their internal retry-handling
 and audit-emission logic without adding a new production entry point.
 
+### Follow-up discovery: `retry_outcome` doesn't actually reach Data Storage today (tracked separately, not fixed here)
+
+Post-implementation review asked whether a DB round-trip test (query
+Data Storage/Postgres by `correlation_id` after a real `Investigate()`
+call, confirming `retry_outcome` is queryable from the persisted audit
+trail per BR-AUDIT-005/SOC2 CC8.1) was needed to fully prove the
+dead-mutation fix above. Investigation found it would fail regardless of
+the ordering fix: both gates' audit events use
+`EventType: audit.EventTypeLLMRequest`, which serializes through
+`buildLLMRequestPayload` (`internal/kubernautagent/audit/ds_payloads.go`)
+into the OpenAPI-generated `ogenclient.LLMRequestPayload` -- a fixed
+schema (`model`, `prompt_length`, `prompt_preview`, `event_id`,
+`incident_id`, `toolsets_enabled`) with no passthrough for arbitrary
+`Data` keys. `retry_outcome` (and the pre-existing `ambiguous_kind`/
+`conflicting_groups` fields `IT-KA-1044-005` already asserts on) are
+silently dropped before the outbound `AuditEventRequest` is even built.
+
+This is a pre-existing schema gap, not something #2119/#2121 caused or
+can fix in scope -- fixing it is a Data Storage API contract change
+(OpenAPI schema + ogen codegen), not a test-only change. Tracked as
+[#2141](https://github.com/jordigilh/kubernaut/issues/2141) for its own
+preflight/plan. Decision: keep this PR scoped to the in-process ordering
+fix (still correct and necessary once the schema gap is eventually
+closed) and its UT proof; no DB round-trip IT was added here since it
+cannot currently pass for a reason unrelated to this fix's correctness.
+
+### Independent hardening landed in this same PR: IT-level audit fixture had the identical masking flaw
+
+While investigating the above, `capturingAuditStore`
+(`test/integration/kubernautagent/investigator/suite_test.go`) -- the
+shared IT-tier fixture behind `IT-KA-1044-*`, `IT-KA-433-AP-*`,
+`IT-KA-851-AP-*`, and `IT-KA-947-*` -- was found to have the exact same
+pointer-aliasing flaw the pre-fix `gateRecordingAuditStore` unit double
+had: `c.events = append(c.events, event)` stores the raw pointer, so any
+of those ~15 existing IT specs reading `auditStore.events` after
+`Investigate()` returns would see final-state data regardless of when
+`StoreAudit` was actually called, masking this same class of bug at the
+IT tier too. Fixed to snapshot `event.Data` at call time, mirroring the
+unit-level fix and real `DSAuditStore` semantics. This is fixture
+hardening, not a new business-behavior test -- see Section 5.
+
 ## 3. FedRAMP Control Mapping
 
 | Control | Title | Relevance |
 |---|---|---|
-| **AU-3** | Content of Audit Records | The audit trail must distinguish "the LLM re-evaluated and answered" from "the LLM never engaged with the correction at all," and must actually persist that distinction (fixing the dead-mutation defect) rather than silently dropping it before it reaches the real audit store. |
+| **AU-3** | Content of Audit Records | The audit trail must distinguish "the LLM re-evaluated and answered" from "the LLM never engaged with the correction at all," and must actually persist that distinction (fixing the dead-mutation defect) rather than silently dropping it before it reaches the real audit store. **Caveat**: full AU-3 satisfaction (the field actually reconstructable from Data Storage by `correlation_id`) is blocked on the pre-existing schema gap tracked in [#2141](https://github.com/jordigilh/kubernaut/issues/2141) -- this fix corrects in-process ordering so the field is *ready* to persist once that gap closes, and is proven correct at the UT tier via a snapshot-at-call-time double, not yet via a real Data Storage round-trip. |
 | **SI-10** | Information Input/Output Validation | A gate correction must be actually delivered and answered before its result is trusted; an undeclared-tool response must not be silently conflated with a validated confirmation. |
 
 ## 4. Pyramid Invariant — Test Scenario Inventory
@@ -127,6 +168,17 @@ upstream fix, per this package's convention.)
 
 ## 5. Validation Results
 
+- `capturingAuditStore` fixture fix
+  (`test/integration/kubernautagent/investigator/suite_test.go`): compiles
+  clean (`go vet ./test/integration/kubernautagent/investigator/...`).
+  Could not be executed in this environment (no local Docker daemon, no
+  `envtest`/kubebuilder binaries) -- will be validated by
+  `ci-pipeline.yml`'s kubernaut-agent integration job on push. This is a
+  narrow, mechanical change (identical to the already-proven unit-level
+  snapshot fix) affecting how ~15 pre-existing `IT-KA-*` specs observe
+  audit events they already assert on; it does not change what those
+  specs assert, only when the observed data is captured relative to
+  `StoreAudit`.
 - `go test ./internal/kubernautagent/investigator/...` -- pass, 366/366
   specs (including the 6 new UT-KA-2120-XXX specs above plus 4
   UT-KA-2118-XXX specs from the co-ported #2119 fix; UT-KA-2120-003 required

--- a/internal/kubernautagent/audit/ds_payloads.go
+++ b/internal/kubernautagent/audit/ds_payloads.go
@@ -65,6 +65,19 @@ func buildLLMRequestPayload(event *AuditEvent) ogenclient.AuditEventRequestEvent
 	if tools := dataStringSlice(event.Data, "toolsets_enabled"); len(tools) > 0 {
 		payload.ToolsetsEnabled = tools
 	}
+	// #2141 (BR-AI-2120/BR-AI-1044, FedRAMP AU-3): only present on
+	// sameKindValidationGate/apiVersionValidationGate retry audit events --
+	// ordinary llm.request events never set these Data keys, so the
+	// optional fields stay unset rather than persisting empty strings.
+	if v := dataString(event.Data, "retry_outcome"); v != "" {
+		payload.RetryOutcome.SetTo(v)
+	}
+	if v := dataString(event.Data, "ambiguous_kind"); v != "" {
+		payload.AmbiguousKind.SetTo(v)
+	}
+	if v := dataString(event.Data, "conflicting_groups"); v != "" {
+		payload.ConflictingGroups.SetTo(v)
+	}
 	return ogenclient.NewLLMRequestPayloadAuditEventRequestEventData(payload)
 }
 

--- a/internal/kubernautagent/audit/ds_store_test.go
+++ b/internal/kubernautagent/audit/ds_store_test.go
@@ -153,6 +153,56 @@ var _ = Describe("Kubernaut Agent DS Audit Store — TP-433-WIR Phase 7", func()
 		})
 	})
 
+	Describe("UT-KA-2141-001: DSAuditStore persists gate-retry diagnostic fields on LLMRequestPayload (BR-AI-2120, FedRAMP AU-3)", func() {
+		It("should populate retry_outcome/ambiguous_kind/conflicting_groups when present on event.Data", func() {
+			recorder := &fakeOgenClient{}
+			store := audit.NewDSAuditStore(recorder)
+
+			event := audit.NewEvent(audit.EventTypeLLMRequest, "corr-gate-retry")
+			event.Data["retry_outcome"] = "resolved_after_other_tool_retry"
+			event.Data["ambiguous_kind"] = "Subscription"
+			event.Data["conflicting_groups"] = "operators.coreos.com,messaging.knative.dev"
+
+			err := store.StoreAudit(context.Background(), event)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recorder.calls).To(HaveLen(1))
+
+			payload, ok := recorder.calls[0].EventData.GetLLMRequestPayload()
+			Expect(ok).To(BeTrue(), "should extract LLMRequestPayload")
+			retryOutcome, hasRetryOutcome := payload.RetryOutcome.Get()
+			Expect(hasRetryOutcome).To(BeTrue(), "retry_outcome must survive into the wire payload")
+			Expect(retryOutcome).To(Equal("resolved_after_other_tool_retry"))
+
+			ambiguousKind, hasAmbiguousKind := payload.AmbiguousKind.Get()
+			Expect(hasAmbiguousKind).To(BeTrue(), "ambiguous_kind must survive into the wire payload")
+			Expect(ambiguousKind).To(Equal("Subscription"))
+
+			conflictingGroups, hasConflictingGroups := payload.ConflictingGroups.Get()
+			Expect(hasConflictingGroups).To(BeTrue(), "conflicting_groups must survive into the wire payload")
+			Expect(conflictingGroups).To(Equal("operators.coreos.com,messaging.knative.dev"))
+		})
+
+		It("should leave retry_outcome/ambiguous_kind/conflicting_groups unset for ordinary (non-gate) LLM request events", func() {
+			recorder := &fakeOgenClient{}
+			store := audit.NewDSAuditStore(recorder)
+
+			event := audit.NewEvent(audit.EventTypeLLMRequest, "corr-ordinary")
+			event.Data["model"] = "claude-sonnet-4-20250514"
+
+			err := store.StoreAudit(context.Background(), event)
+			Expect(err).NotTo(HaveOccurred())
+
+			payload, ok := recorder.calls[0].EventData.GetLLMRequestPayload()
+			Expect(ok).To(BeTrue())
+			_, hasRetryOutcome := payload.RetryOutcome.Get()
+			Expect(hasRetryOutcome).To(BeFalse(), "ordinary llm.request events must not fabricate a retry_outcome")
+			_, hasAmbiguousKind := payload.AmbiguousKind.Get()
+			Expect(hasAmbiguousKind).To(BeFalse())
+			_, hasConflictingGroups := payload.ConflictingGroups.Get()
+			Expect(hasConflictingGroups).To(BeFalse())
+		})
+	})
+
 	Describe("UT-KA-PR9-001: buildEventData coverage for all AllEventTypes (MNT-2)", func() {
 		It("should produce a non-zero EventData type for every event type in AllEventTypes", func() {
 			recorder := &fakeOgenClient{}

--- a/internal/kubernautagent/investigator/apiversion_gate_test.go
+++ b/internal/kubernautagent/investigator/apiversion_gate_test.go
@@ -106,7 +106,21 @@ type gateRecordingAuditStore struct {
 func (s *gateRecordingAuditStore) StoreAudit(_ context.Context, event *audit.AuditEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.events = append(s.events, event)
+	// #2120: snapshot Data at call time rather than storing the raw pointer,
+	// mirroring real production audit stores (internal/kubernautagent/audit/
+	// ds_store.go's DSAuditStore/BufferedDSAuditStore), which serialize the
+	// event into an outbound request synchronously here and never see later
+	// mutations. Storing the raw *audit.AuditEvent pointer previously masked
+	// a bug where callers mutated event.Data AFTER this call returned -- a
+	// real store would have missed that mutation, but a live pointer read by
+	// the test after Investigate() returned would not.
+	snapshot := *event
+	dataCopy := make(map[string]interface{}, len(event.Data))
+	for k, v := range event.Data {
+		dataCopy[k] = v
+	}
+	snapshot.Data = dataCopy
+	s.events = append(s.events, &snapshot)
 	return nil
 }
 

--- a/internal/kubernautagent/investigator/gate_undeclared_tool_2120_test.go
+++ b/internal/kubernautagent/investigator/gate_undeclared_tool_2120_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// #2120/#2121 (BR-AI-2120, FedRAMP AU-3): sameKindValidationGate and
+// apiVersionValidationGate build their gate-retry LLM call with a
+// submit-result-only tool declaration, but the model frequently ignores that
+// constraint and calls an undeclared tool anyway (e.g. kubectl_describe) — a
+// live-LLM spike against the real production Claude/Vertex client measured
+// this in 10/10 trials for the same-kind gate's correction prompt. Because
+// both gates only recognized a `submit_result` tool call or non-empty
+// message text as "the retry answered", an undeclared-tool response fell
+// through to the same fallback path as a genuinely empty response: the
+// correction is silently dropped and the pre-retry (possibly wrong) result
+// is kept, with no record in the audit trail of *why* the retry failed.
+//
+// The same spike showed a second attempt — replaying the wrong call as a
+// synthetic tool_result error plus an explicit reminder — recovered the
+// correct submit_result call in 10/10 trials.
+//
+// v1.6 clone of the release/v1.5.6 fix (#2120 -> #2121 tracking issue).
+// These specs exercise both gates through the real Investigate() production
+// path (mirroring this package's established convention).
+var _ = Describe("#2120/#2121: gate retries must recover from (or account for) an undeclared tool call", func() {
+
+	var (
+		logger     logr.Logger
+		auditStore *gateRecordingAuditStore
+		mockClient *gateMockLLMClient
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+	)
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+		auditStore = &gateRecordingAuditStore{}
+		mockClient = &gateMockLLMClient{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		enricher = enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, auditStore, logger)
+		phaseTools = investigator.DefaultPhaseToolMap()
+	})
+
+	sameKindSignal := katypes.SignalContext{
+		ResourceKind: "Pod",
+		ResourceName: "api-server-xyz",
+		Name:         "api-server-xyz",
+		Namespace:    "production",
+		Severity:     "critical",
+		Message:      "Pod OOMKilled repeatedly",
+	}
+
+	apiVersionSignal := katypes.SignalContext{
+		ResourceKind: "Deployment",
+		ResourceName: "etcd-operator-xyz",
+		Name:         "etcd-operator-xyz",
+		Namespace:    "demo-operator",
+		Severity:     "critical",
+		Message:      "RBAC denial on wrong API group",
+	}
+
+	// undeclaredToolResp simulates the model calling a tool other than
+	// submit_result during a gate retry — the #2120 failure mode. Real
+	// responses carry no message text on a pure tool-calling turn.
+	undeclaredToolResp := func(toolName string) llm.ChatResponse {
+		return llm.ChatResponse{
+			Message: llm.Message{Role: "assistant", Content: ""},
+			ToolCalls: []llm.ToolCall{
+				{ID: "tc_undeclared", Name: toolName, Arguments: `{"name":"api-server","namespace":"production"}`},
+			},
+		}
+	}
+
+	Describe("UT-KA-2120-001 (regression): sameKindValidationGate recovers after one undeclared-tool retry", func() {
+		It("must accept the reminder-retry's result and record retry_outcome=resolved_after_other_tool_retry (BR-AI-2120 AC1)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				// Turn 1: RCA submit — same-kind gate fires (target.Kind == signal.ResourceKind == "Pod").
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Pod OOMKilled",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Pod","name":"api-server-xyz","namespace":"production"}
+				}`}},
+				// Gate retry attempt 1: LLM calls an undeclared tool instead of submit_result (#2120).
+				undeclaredToolResp("kubectl_describe"),
+				// Gate retry attempt 2 (after reminder): LLM correctly re-targets the parent Deployment.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Deployment memory limit too low",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production","api_version":"apps/v1"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"increase-memory-limit","confidence":0.9}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), sameKindSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.RemediationTarget.Kind).To(Equal("Deployment"),
+				"UT-KA-2120-001: final result must reflect the reminder retry's data, not the original Pod target")
+			Expect(mockClient.calls).To(HaveLen(4),
+				"UT-KA-2120-001: expected RCA + first gate retry + reminder retry + workflow-selection LLM calls")
+
+			gateEvents := auditStore.eventsByAction(audit.ActionSameKindGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-001: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("resolved_after_other_tool_retry"),
+				"UT-KA-2120-001: audit trail must distinguish a reminder-assisted recovery from a first-try resolution")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeSuccess),
+				"UT-KA-2120-001: a recovered retry is a successful gate outcome")
+		})
+	})
+
+	Describe("UT-KA-2120-002: sameKindValidationGate keeps the original result when the undeclared tool call persists", func() {
+		It("must keep the pre-retry result and record retry_outcome=llm_requested_other_tool (BR-AI-2120 AC2)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Pod OOMKilled",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Pod","name":"api-server-xyz","namespace":"production"}
+				}`}},
+				// Both the initial retry and the reminder retry call an undeclared tool.
+				undeclaredToolResp("kubectl_describe"),
+				undeclaredToolResp("kubectl_describe"),
+				gateWfToolResp(`{"workflow_id":"restart-pod","confidence":0.8}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), sameKindSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.RemediationTarget.Kind).To(Equal("Pod"),
+				"UT-KA-2120-002: original (pre-retry) result must be kept when the reminder retry also fails")
+			Expect(mockClient.calls).To(HaveLen(4),
+				"UT-KA-2120-002: expected RCA + first gate retry + reminder retry + workflow-selection LLM calls")
+
+			gateEvents := auditStore.eventsByAction(audit.ActionSameKindGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-002: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("llm_requested_other_tool"),
+				"UT-KA-2120-002: audit trail must record that the LLM never answered with submit_result")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeFailure),
+				"UT-KA-2120-002: an unresolved retry must be a failed gate outcome, not the hardcoded success of pre-#2120 code")
+		})
+	})
+
+	Describe("UT-KA-2120-003: apiVersionValidationGate recovers after one undeclared-tool retry", func() {
+		It("must accept the reminder-retry's api_version and record retry_outcome=resolved_after_other_tool_retry (BR-AI-2120 AC1)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+				// Gate retry attempt 1: LLM calls an undeclared tool instead of submit_result (#2120).
+				undeclaredToolResp("kubectl_describe"),
+				// Gate retry attempt 2 (after reminder): LLM correctly provides api_version.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator","api_version":"operators.coreos.com/v1alpha1"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"restart-sub","confidence":0.9}`),
+			}
+
+			resolver := investigator.NewMapperScopeResolver(newAmbiguousSubscriptionMapper())
+			// newTestInvestigator (not investigator.New directly): this
+			// scenario proceeds all the way to workflow selection, which
+			// (#1677 hardening, DD-WORKFLOW-019) fails closed to human
+			// review when no CatalogFetcher is configured -- orthogonal to
+			// the #2120 behavior under test here, so use the package's
+			// permissive stub covering the "restart-sub" fixture ID below.
+			inv := newTestInvestigator(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, ScopeResolver: resolver,
+			})
+
+			result, err := inv.Investigate(context.Background(), apiVersionSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.RemediationTarget.APIVersion).To(Equal("operators.coreos.com/v1alpha1"),
+				"UT-KA-2120-003: final result must reflect the reminder retry's api_version")
+			Expect(result.HumanReviewNeeded).To(BeFalse(),
+				"UT-KA-2120-003: a recovered retry must not trigger human review")
+			Expect(mockClient.calls).To(HaveLen(4),
+				"UT-KA-2120-003: expected RCA + first gate retry + reminder retry + workflow-selection LLM calls")
+
+			gateEvents := auditStore.eventsByAction(audit.ActionAPIVersionGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-003: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("resolved_after_other_tool_retry"),
+				"UT-KA-2120-003: audit trail must distinguish a reminder-assisted recovery from a first-try resolution")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeSuccess),
+				"UT-KA-2120-003: a recovered retry is a successful gate outcome")
+		})
+	})
+
+	Describe("UT-KA-2120-004: apiVersionValidationGate triggers human review when the undeclared tool call persists", func() {
+		It("must trigger human review and record retry_outcome=llm_requested_other_tool (BR-AI-2120 AC2 Security)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+				undeclaredToolResp("kubectl_describe"),
+				undeclaredToolResp("kubectl_describe"),
+			}
+
+			resolver := investigator.NewMapperScopeResolver(newAmbiguousSubscriptionMapper())
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, ScopeResolver: resolver,
+			})
+
+			result, err := inv.Investigate(context.Background(), apiVersionSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.HumanReviewNeeded).To(BeTrue(),
+				"UT-KA-2120-004: an unresolved ambiguous-kind retry must still trigger human review "+
+					"to prevent incorrect RBAC grants, exactly as a plain empty/unparseable retry would")
+			Expect(result.HumanReviewReason).To(Equal(katypes.HumanReviewReasonRCAIncomplete),
+				"UT-KA-2120-004: reason must be rca_incomplete, matching the existing exhaustion convention")
+
+			gateEvents := auditStore.eventsByAction(audit.ActionAPIVersionGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-004: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("llm_requested_other_tool"),
+				"UT-KA-2120-004: audit trail must record that the LLM never answered with submit_result")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeFailure),
+				"UT-KA-2120-004: gate exhaustion must be a failed outcome, not the hardcoded success of pre-#2120 code")
+		})
+	})
+
+	// UT-KA-2120-005 is the regression test for the secondary finding: both
+	// gates previously called audit.StoreBestEffort(gateEvent) BEFORE setting
+	// gateEvent.Data["retry_outcome"]/EventOutcome, so a production audit
+	// store — which serializes Data into an outbound request synchronously
+	// at call time (internal/kubernautagent/audit/ds_store.go's
+	// DSAuditStore/BufferedDSAuditStore) — never actually persisted those
+	// fields. gateRecordingAuditStore previously masked this by capturing
+	// the raw *audit.AuditEvent pointer, so a later in-memory read always
+	// reflected the mutation regardless of when StoreAudit was called. Once
+	// fixed to snapshot event.Data at call time (matching real production
+	// stores), this test would fail against the pre-#2120 store-then-mutate
+	// code and passes once the store call is deferred until every Data
+	// mutation has happened (BR-AI-2120 AC3, FedRAMP AU-3).
+	Describe("UT-KA-2120-005 (regression): retry_outcome/EventOutcome are captured at StoreAudit call time, not just in a later in-memory read", func() {
+		It("must have set retry_outcome=resolved and EventOutcome=success on sameKindValidationGate's audit event before storing it", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Pod OOMKilled",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Pod","name":"api-server-xyz","namespace":"production"}
+				}`}},
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Deployment memory limit too low",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production","api_version":"apps/v1"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"increase-memory-limit","confidence":0.9}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), sameKindSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			gateEvents := auditStore.eventsByAction(audit.ActionSameKindGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-005: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("resolved"),
+				"UT-KA-2120-005: retry_outcome must be captured by StoreAudit at call time, not mutated afterward")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeSuccess),
+				"UT-KA-2120-005: EventOutcome must be captured by StoreAudit at call time, not the pre-#2120 "+
+					"unconditional hardcoded success")
+		})
+
+		It("must have set retry_outcome=exhausted and EventOutcome=failure on apiVersionValidationGate's audit event before storing it", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+				// Gate retry still omits api_version -> exhaustion.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+			}
+
+			resolver := investigator.NewMapperScopeResolver(newAmbiguousSubscriptionMapper())
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, ScopeResolver: resolver,
+			})
+
+			result, err := inv.Investigate(context.Background(), apiVersionSignal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			gateEvents := auditStore.eventsByAction(audit.ActionAPIVersionGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-2120-005: gate must emit an audit event")
+			ev := gateEvents[0]
+			Expect(ev.Data["retry_outcome"]).To(Equal("exhausted"),
+				"UT-KA-2120-005: retry_outcome must be captured by StoreAudit at call time — this is the "+
+					"pre-existing dead-mutation bug (#1044 lines 336/354) this PR fixes alongside #2120")
+			Expect(ev.EventOutcome).To(Equal(audit.OutcomeFailure),
+				"UT-KA-2120-005: EventOutcome must reflect the actual (failed) outcome, not the pre-#2120 "+
+					"unconditional hardcoded success")
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/investigator_gates.go
+++ b/internal/kubernautagent/investigator/investigator_gates.go
@@ -50,15 +50,174 @@ func appendCorrectionMessage(history []llm.Message, correctionMsg string) []llm.
 	return append(retryMessages, llm.Message{Role: "user", Content: correctionMsg})
 }
 
-// extractSubmitContent extracts the tool-call arguments (preferred) or falls
-// back to the raw message content from a gate-retry chat response.
-func extractSubmitContent(resp llm.ChatResponse) string {
+// gateRetryOutcome enumerates why a validation-gate retry ended the way it
+// did, recorded in the gate's audit event Data["retry_outcome"] (#2120,
+// BR-AI-2120, FedRAMP AU-3). The additional values beyond "resolved"/
+// "exhausted" give auditors finer-grained visibility into *why* a retry
+// failed instead of a single opaque "exhausted" bucket.
+type gateRetryOutcome string
+
+const (
+	// gateRetryResolved: the retry's first attempt returned a usable
+	// submit_result content.
+	gateRetryResolved gateRetryOutcome = "resolved"
+	// gateRetryResolvedAfterReminder: the retry's first attempt called an
+	// undeclared tool instead of submit_result; a second attempt (replaying
+	// that call as a tool_result error plus an explicit reminder) recovered
+	// a usable submit_result content (#2120).
+	gateRetryResolvedAfterReminder gateRetryOutcome = "resolved_after_other_tool_retry"
+	// gateRetryOtherToolExhausted: the LLM called an undeclared tool on both
+	// the initial retry and the reminder retry (or the reminder retry itself
+	// errored) — the correction was never answered with submit_result (#2120).
+	gateRetryOtherToolExhausted gateRetryOutcome = "llm_requested_other_tool"
+	// gateRetryEmptyResponse: the retry returned no tool calls and no message
+	// content at all.
+	gateRetryEmptyResponse gateRetryOutcome = "empty_response"
+	// gateRetryParseError: the retry's content could not be parsed as an RCA result.
+	gateRetryParseError gateRetryOutcome = "parse_error"
+	// gateRetryExhausted: a generic/infrastructure failure (LLM call error, or
+	// the parsed retry result still failed the gate's own check) with no more
+	// specific outcome above applying.
+	gateRetryExhausted gateRetryOutcome = "exhausted"
+)
+
+// gateRetrySubmitContent classifies a gate-retry LLM response: returns the
+// submit_result tool-call arguments if the model called that tool, else
+// falls back to the raw message content (for models that respond with bare
+// JSON text instead of a tool call). Any tool call to a name other than
+// submit_result is reported in otherTools -- calling an undeclared tool
+// instead of resubmitting the RCA result is the #2120 failure mode this
+// enables detecting.
+func gateRetrySubmitContent(resp llm.ChatResponse) (content string, otherTools []string) {
 	for _, tc := range resp.ToolCalls {
 		if tc.Name == SubmitResultToolName {
-			return tc.Arguments
+			return tc.Arguments, nil
 		}
+		otherTools = append(otherTools, tc.Name)
 	}
-	return resp.Message.Content
+	if resp.Message.Content != "" {
+		return resp.Message.Content, otherTools
+	}
+	return "", otherTools
+}
+
+// gateRetryAttemptParams groups the fields needed to resolve (and, if
+// necessary, retry) a single gate-retry LLM response. Extracted per
+// AGENTS.md's 8+-param Options-pattern rule -- shared by
+// retryGateOnUnexpectedTool and resolveGateContent below.
+type gateRetryAttemptParams struct {
+	Client        llm.Client
+	RetryMessages []llm.Message
+	Tools         []llm.ToolDefinition
+	Tokens        *TokenAccumulator
+	RuntimeParams llm.RuntimeParams
+	CorrelationID string
+}
+
+// gateContentResult is the outcome of resolveGateContent: either usable
+// submit_result content (Content != ""), or a FailOutcome describing why
+// resolution failed after exhausting the one-shot undeclared-tool recovery.
+// Shared by retryForSameKind and retryForAPIVersion to keep both under the
+// funlen/gocyclo budget.
+type gateContentResult struct {
+	Content      string
+	OtherTools   []string
+	UsedReminder bool
+	Reasoning    *llm.ReasoningBlock
+	// FailOutcome is non-empty only when the undeclared-tool reminder retry
+	// itself was attempted and still failed (errored or repeated the
+	// undeclared tool). A plain empty first response (no tool calls, no
+	// content) leaves this empty -- callers detect that case themselves via
+	// Content == "" && FailOutcome == "".
+	FailOutcome gateRetryOutcome
+	// Err is the reminder call's infrastructure error, if any, for logging.
+	Err error
+}
+
+// resolveGateContent classifies a gate-retry LLM response and, if the model
+// called a tool other than submit_result, performs the one-shot
+// undeclared-tool recovery (#2120, BR-AI-2120, FedRAMP AU-3) via
+// retryGateOnUnexpectedTool before giving up.
+func (inv *Investigator) resolveGateContent(ctx context.Context, resp llm.ChatResponse, p gateRetryAttemptParams) gateContentResult {
+	reasoning := resp.Message.Reasoning
+	content, otherTools := gateRetrySubmitContent(resp)
+	if content != "" || len(otherTools) == 0 {
+		return gateContentResult{Content: content, OtherTools: otherTools, Reasoning: reasoning}
+	}
+
+	// The model called an undeclared tool instead of resubmitting the RCA
+	// result. Retry once with a synthetic tool-error + reminder (live-LLM
+	// spike: 10/10 recovery, see docs/testing/2120/TEST_PLAN.md) before
+	// falling back to the caller's own failure handling.
+	inv.logger.Info("gate retry: LLM called an undeclared tool instead of submit_result, retrying once with reminder",
+		"tools_called", otherTools, "correlation_id", p.CorrelationID)
+
+	retryContent, retryOtherTools, retryReasoning, err := inv.retryGateOnUnexpectedTool(ctx, resp, p)
+	if err != nil {
+		return gateContentResult{OtherTools: retryOtherTools, UsedReminder: true, FailOutcome: gateRetryOtherToolExhausted, Err: err}
+	}
+	if retryContent == "" {
+		return gateContentResult{OtherTools: retryOtherTools, UsedReminder: true, FailOutcome: gateRetryOtherToolExhausted}
+	}
+	return gateContentResult{Content: retryContent, OtherTools: retryOtherTools, UsedReminder: true, Reasoning: retryReasoning}
+}
+
+// retryGateOnUnexpectedTool re-issues a gate-retry call once more after the
+// model called a tool other than submit_result instead of resubmitting the
+// RCA result. It replays the wrong call(s) as synthetic tool_result "not
+// available" errors, plus an explicit reminder to call submit_result --
+// mirroring the real tool-execution message pattern used elsewhere in this
+// package (see the tool-call loop in Investigate). A live-LLM spike against
+// the production Claude/Vertex client (10/10 trials, see
+// docs/testing/2120/TEST_PLAN.md) confirmed this recovers the correct
+// submit_result call on the very next turn. Returns the reminder response's
+// own Reasoning block alongside content/otherTools so callers can attach it
+// to the accepted result (BR-AI-086 AC6, #1578) exactly as the first-attempt
+// path does.
+func (inv *Investigator) retryGateOnUnexpectedTool(
+	ctx context.Context,
+	firstResp llm.ChatResponse,
+	p gateRetryAttemptParams,
+) (content string, otherTools []string, reasoning *llm.ReasoningBlock, err error) {
+	retryMessages := p.RetryMessages
+	assistantMsg := firstResp.Message
+	assistantMsg.ToolCalls = firstResp.ToolCalls
+	retryMessages = append(retryMessages, assistantMsg)
+
+	calledTools := make([]string, 0, len(firstResp.ToolCalls))
+	for _, tc := range firstResp.ToolCalls {
+		calledTools = append(calledTools, tc.Name)
+		retryMessages = append(retryMessages, llm.Message{
+			Role:       "tool",
+			Content:    fmt.Sprintf("Tool %q is not available for this correction step.", tc.Name),
+			ToolCallID: tc.ID,
+			ToolName:   tc.Name,
+		})
+	}
+	retryMessages = append(retryMessages, llm.Message{
+		Role: "user",
+		Content: "You must call submit_result to resubmit your root cause analysis result. " +
+			"No other tool is available for this correction step.",
+	})
+
+	inv.logger.Info("gate retry: LLM called an undeclared tool, retrying once with reminder",
+		"tools_called", calledTools,
+		"correlation_id", p.CorrelationID)
+
+	resp, chatErr := llm.ChatWithParams(ctx, p.Client, llm.ChatRequest{
+		Messages: retryMessages,
+		Tools:    p.Tools,
+		Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
+	}, p.RuntimeParams)
+	if chatErr != nil {
+		return "", nil, nil, chatErr
+	}
+	if p.Tokens != nil {
+		p.Tokens.Add(resp.Usage)
+	}
+
+	content, otherTools = gateRetrySubmitContent(resp)
+	return content, otherTools, resp.Message.Reasoning, nil
 }
 
 func (inv *Investigator) sameKindValidationGate(
@@ -98,6 +257,17 @@ func (inv *Investigator) sameKindValidationGate(
 // sameKindCorrectionMessage builds the LLM correction message asking it to
 // re-evaluate whether a child resource (rather than targetKind, which
 // matches the input signal's kind) is the true root cause.
+//
+// #2118: the original wording asked the LLM only to confirm or change
+// remediation_target.kind. Because that reads as a narrow yes/no question,
+// the LLM often responds with a minimal tool call that answers only the
+// target question and omits (or zeroes) the separately-required confidence
+// field -- silently overwriting a real, previously-validated confidence
+// with a placeholder. The second paragraph makes the full-restatement
+// requirement explicit. This is a best-effort, defense-in-depth
+// improvement: a live-LLM spike (see docs/testing/2118/TEST_PLAN.md)
+// confirmed prompt wording alone is not reliably sufficient, which is why
+// the backfill guard in retryForSameKind is the actual, deterministic fix.
 func sameKindCorrectionMessage(targetKind string) string {
 	return fmt.Sprintf(
 		`Your remediation_target.kind is "%s", which is the same resource kind as the input signal. `+
@@ -106,7 +276,12 @@ func sameKindCorrectionMessage(targetKind string) string {
 			`Please re-evaluate: is a child resource (Deployment, StatefulSet, DaemonSet, Pod) the actual root cause `+
 			`whose configuration should be modified? If after re-evaluation you are confident the %s itself is the `+
 			`correct remediation target, confirm by resubmitting with the same target and explain why in your `+
-			`due_diligence.target_accuracy field.`,
+			`due_diligence.target_accuracy field. `+
+			`Whichever target you conclude is correct, you MUST resubmit a COMPLETE root cause analysis result: `+
+			`restate confidence (genuinely recomputed from the evidence, not a placeholder or default value), `+
+			`severity, and causal_chain at the same rigor as your original submission. Do not omit or zero out `+
+			`confidence just because this is a confirmation -- an incomplete resubmission will be treated as a `+
+			`loss of your prior analysis.`,
 		targetKind, targetKind,
 	)
 }
@@ -114,12 +289,13 @@ func sameKindCorrectionMessage(targetKind string) string {
 // retryForSameKind re-submits the RCA request with a correction message
 // asking the LLM to re-evaluate a same-kind remediation target, and parses
 // the retry response. Falls back to the original result at every failure
-// point: LLM error, empty response, parse error, or a retry result that
-// lost the remediation target.
+// point: LLM error, empty response, parse error, undeclared-tool exhaustion
+// (#2120), or a retry result that lost the remediation target.
 func (inv *Investigator) retryForSameKind(ctx context.Context, result *katypes.InvestigationResult, history []llm.Message, llmCtx LLMInvocationContext, gateEvent *audit.AuditEvent) *katypes.InvestigationResult {
 	tokens, correlationID, client, runtimeParams := llmCtx.Tokens, llmCtx.CorrelationID, llmCtx.Client, llmCtx.RuntimeParams
 	correctionMsg := sameKindCorrectionMessage(result.RemediationTarget.Kind)
 	retryMessages := appendCorrectionMessage(history, correctionMsg)
+	submitOnlyTools := submitOnlyRCATools()
 
 	// #1777 (BR-AUDIT-005, FedRAMP AU-3): the audit event must reflect the
 	// retry prompt actually sent to the LLM. Populating these fields before
@@ -128,7 +304,15 @@ func (inv *Investigator) retryForSameKind(ctx context.Context, result *katypes.I
 	// request.
 	gateEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
 	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages)
-	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
+	// #2120 (BR-AI-2120, FedRAMP AU-3): fire once, after the final outcome is
+	// known, via defer -- StoreBestEffort reads gateEvent.Data/EventOutcome at
+	// the time this deferred call actually executes (function return), not
+	// at the time the defer statement runs. Storing immediately here (as the
+	// pre-#2120 code did) meant retry_outcome/EventOutcome mutations made
+	// below were set on the event in memory but never actually captured by a
+	// production audit store, which serializes Data into an outbound request
+	// synchronously at call time.
+	defer audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
 	// #2088 (main port of #2086): this gate-retry LLM call is non-streamed
 	// (llm.ChatWithParams), so it emits zero sink events for the duration of
@@ -142,29 +326,62 @@ func (inv *Investigator) retryForSameKind(ctx context.Context, result *katypes.I
 
 	resp, err := llm.ChatWithParams(ctx, client, llm.ChatRequest{
 		Messages: retryMessages,
-		Tools:    submitOnlyRCATools(),
+		Tools:    submitOnlyTools,
 		Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
 	}, runtimeParams)
 	if err != nil {
 		inv.logger.Error(err, "same-kind validation gate retry failed, keeping original result",
 			"correlation_id", correlationID)
+		gateEvent.EventOutcome = audit.OutcomeFailure
+		gateEvent.Data["retry_outcome"] = string(gateRetryExhausted)
 		return result
 	}
 	if tokens != nil {
 		tokens.Add(resp.Usage)
 	}
 
-	retryContent := extractSubmitContent(resp)
-	if retryContent == "" {
-		inv.logger.Info("same-kind validation gate: no content in retry response, keeping original",
+	resolved := inv.resolveGateContent(ctx, resp, gateRetryAttemptParams{
+		Client: client, RetryMessages: retryMessages, Tools: submitOnlyTools,
+		Tokens: tokens, RuntimeParams: runtimeParams, CorrelationID: correlationID,
+	})
+	if len(resolved.OtherTools) > 0 {
+		gateEvent.Data["other_tools_called"] = resolved.OtherTools
+	}
+	if resolved.Err != nil {
+		inv.logger.Error(resolved.Err, "same-kind validation gate: retry-on-unexpected-tool call failed, keeping original",
 			"correlation_id", correlationID)
+	}
+	if resolved.FailOutcome != "" {
+		inv.logger.Info("same-kind validation gate: LLM called an undeclared tool, keeping original",
+			"tools_called", resolved.OtherTools, "used_reminder", resolved.UsedReminder,
+			"correlation_id", correlationID)
+		gateEvent.EventOutcome = audit.OutcomeFailure
+		gateEvent.Data["retry_outcome"] = string(resolved.FailOutcome)
 		return result
 	}
+	if resolved.Content == "" {
+		inv.logger.Info("same-kind validation gate: no content in retry response, keeping original",
+			"correlation_id", correlationID)
+		gateEvent.EventOutcome = audit.OutcomeFailure
+		gateEvent.Data["retry_outcome"] = string(gateRetryEmptyResponse)
+		return result
+	}
+	return inv.finalizeSameKindRetry(result, resolved, correlationID, gateEvent)
+}
 
-	retryResult, parseErr := inv.resultParser.Parse(retryContent)
+// finalizeSameKindRetry parses resolveGateContent's output and applies the
+// same-kind gate's acceptance rules: reject a retry that dropped
+// RemediationTarget entirely, backfill a dropped confidence (#2118), carry
+// the winning turn's Reasoning (BR-AI-086 AC6, #1578), and record the final
+// retry_outcome/EventOutcome. Extracted from retryForSameKind to stay under
+// the funlen budget.
+func (inv *Investigator) finalizeSameKindRetry(result *katypes.InvestigationResult, resolved gateContentResult, correlationID string, gateEvent *audit.AuditEvent) *katypes.InvestigationResult {
+	retryResult, parseErr := inv.resultParser.Parse(resolved.Content)
 	if parseErr != nil {
 		inv.logger.Error(parseErr, "same-kind validation gate: retry parse failed, keeping original",
 			"correlation_id", correlationID)
+		gateEvent.EventOutcome = audit.OutcomeFailure
+		gateEvent.Data["retry_outcome"] = string(gateRetryParseError)
 		return result
 	}
 
@@ -172,16 +389,36 @@ func (inv *Investigator) retryForSameKind(ctx context.Context, result *katypes.I
 		inv.logger.Info("same-kind validation gate: retry lost remediation_target, keeping original",
 			"original_target", result.RemediationTarget.Kind+"/"+result.RemediationTarget.Name,
 			"correlation_id", correlationID)
+		gateEvent.EventOutcome = audit.OutcomeFailure
+		gateEvent.Data["retry_outcome"] = string(gateRetryEmptyResponse)
 		return result
+	}
+
+	// #2118: unlike the RemediationTarget.Kind guard above, a lost
+	// confidence does not warrant discarding the whole retry -- the
+	// retry's other content (e.g. an updated due_diligence.target_accuracy
+	// narrative) is genuinely new and worth keeping. Only the regressed
+	// field itself is backfilled from the pre-retry result.
+	if retryResult.Confidence <= 0 && result.Confidence > 0 {
+		inv.logger.Info("same-kind validation gate: retry lost confidence, keeping original",
+			"original_confidence", result.Confidence,
+			"correlation_id", correlationID)
+		retryResult.Confidence = result.Confidence
 	}
 
 	// The retry is a fresh submission on its own turn: its own Reasoning
 	// block (if any) is authoritative for the accepted result, mirroring
 	// runRCA's "winning turn" semantics (BR-AI-086 AC6, #1578). Without this,
-	// resp.Message.Reasoning from the retry call is silently discarded and
-	// the gate-accepted result loses reasoning captured by the LLM client.
-	retryResult.Reasoning = toReasoningSummary(resp.Message.Reasoning)
+	// the retry turn's Reasoning would be silently discarded and the
+	// gate-accepted result would lose reasoning captured by the LLM client.
+	retryResult.Reasoning = toReasoningSummary(resolved.Reasoning)
 
+	gateEvent.EventOutcome = audit.OutcomeSuccess
+	if resolved.UsedReminder {
+		gateEvent.Data["retry_outcome"] = string(gateRetryResolvedAfterReminder)
+	} else {
+		gateEvent.Data["retry_outcome"] = string(gateRetryResolved)
+	}
 	inv.logger.Info("same-kind validation gate: accepted retry result",
 		"original_target", result.RemediationTarget.Kind+"/"+result.RemediationTarget.Name,
 		"retry_target", retryResult.RemediationTarget.Kind+"/"+retryResult.RemediationTarget.Name,
@@ -294,8 +531,9 @@ type retryForAPIVersionParams struct {
 // retryForAPIVersion re-submits the RCA request with a correction message
 // asking the LLM to disambiguate the API group for kind, and parses the
 // retry response. Falls back to apiVersionGateExhaustion (forcing human
-// review) at every failure point: LLM error, empty response, parse error, or
-// a retry result that still lacks api_version.
+// review) at every failure point: LLM error, empty response, parse error,
+// undeclared-tool exhaustion (#2120), or a retry result that still lacks
+// api_version.
 func (inv *Investigator) retryForAPIVersion(ctx context.Context, p retryForAPIVersionParams) *katypes.InvestigationResult {
 	result, history, client, runtimeParams, tokens := p.Result, p.History, p.Client, p.RuntimeParams, p.Tokens
 	kind, groupList, correlationID, gateEvent := p.Kind, p.GroupList, p.CorrelationID, p.GateEvent
@@ -310,6 +548,7 @@ func (inv *Investigator) retryForAPIVersion(ctx context.Context, p retryForAPIVe
 		kind, groupList, kind, result.RemediationTarget.Name,
 	)
 	retryMessages := appendCorrectionMessage(history, correctionMsg)
+	submitOnlyTools := submitOnlyRCATools()
 
 	// #1777 (BR-AUDIT-005, FedRAMP AU-3): the audit event must reflect the
 	// retry prompt actually sent to the LLM. Populating these fields before
@@ -318,7 +557,13 @@ func (inv *Investigator) retryForAPIVersion(ctx context.Context, p retryForAPIVe
 	// request.
 	gateEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
 	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages)
-	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
+	// #2120 (BR-AI-2120, FedRAMP AU-3): fire once, after the final outcome is
+	// known, via defer -- this also fixes a pre-existing bug (#1044) where
+	// gateEvent.Data["retry_outcome"] was mutated below AFTER this store call
+	// fired, so a production audit store (which serializes Data into an
+	// outbound request synchronously at call time) never actually persisted
+	// retry_outcome.
+	defer audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
 	// #2088 (main port of #2086): same silent-gap risk as retryForSameKind
 	// above -- this retry LLM call is non-streamed and emits no sink events
@@ -327,39 +572,70 @@ func (inv *Investigator) retryForAPIVersion(ctx context.Context, p retryForAPIVe
 
 	resp, retryErr := llm.ChatWithParams(ctx, client, llm.ChatRequest{
 		Messages: retryMessages,
-		Tools:    submitOnlyRCATools(),
+		Tools:    submitOnlyTools,
 		Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
 	}, runtimeParams)
 	if retryErr != nil {
 		inv.logger.Error(retryErr, "apiVersionValidationGate: retry failed, triggering human review",
 			"kind", kind, "correlation_id", correlationID)
-		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent)
+		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, gateRetryExhausted)
 	}
 	if tokens != nil {
 		tokens.Add(resp.Usage)
 	}
 
-	retryContent := extractSubmitContent(resp)
-	if retryContent == "" {
+	resolved := inv.resolveGateContent(ctx, resp, gateRetryAttemptParams{
+		Client: client, RetryMessages: retryMessages, Tools: submitOnlyTools,
+		Tokens: tokens, RuntimeParams: runtimeParams, CorrelationID: correlationID,
+	})
+	if len(resolved.OtherTools) > 0 {
+		gateEvent.Data["other_tools_called"] = resolved.OtherTools
+	}
+	if resolved.Err != nil {
+		inv.logger.Error(resolved.Err, "apiVersionValidationGate: retry-on-unexpected-tool call failed, triggering human review",
+			"kind", kind, "correlation_id", correlationID)
+	}
+	if resolved.FailOutcome != "" {
+		inv.logger.Info("apiVersionValidationGate: LLM called an undeclared tool, triggering human review",
+			"kind", kind, "tools_called", resolved.OtherTools, "used_reminder", resolved.UsedReminder,
+			"correlation_id", correlationID)
+		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, resolved.FailOutcome)
+	}
+	if resolved.Content == "" {
 		inv.logger.Info("apiVersionValidationGate: empty retry response, triggering human review",
 			"correlation_id", correlationID)
-		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent)
+		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, gateRetryEmptyResponse)
 	}
+	return inv.finalizeAPIVersionRetry(result, resolved, groupList, kind, correlationID, gateEvent)
+}
 
-	retryResult, parseErr := inv.resultParser.Parse(retryContent)
+// finalizeAPIVersionRetry parses resolveGateContent's output and applies the
+// api-version gate's acceptance rules: trigger human review (via
+// apiVersionGateExhaustion) when the retry still lacks api_version, else
+// clear any parser-set human-review flags, carry the winning turn's
+// Reasoning (BR-AI-086 AC6, #1578), and record the final retry_outcome/
+// EventOutcome. Extracted from retryForAPIVersion to stay under the funlen
+// budget.
+func (inv *Investigator) finalizeAPIVersionRetry(result *katypes.InvestigationResult, resolved gateContentResult, groupList, kind, correlationID string, gateEvent *audit.AuditEvent) *katypes.InvestigationResult {
+	retryResult, parseErr := inv.resultParser.Parse(resolved.Content)
 	if parseErr != nil {
 		inv.logger.Error(parseErr, "apiVersionValidationGate: retry parse failed, triggering human review",
 			"correlation_id", correlationID)
-		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent)
+		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, gateRetryParseError)
 	}
 
 	if retryResult.RemediationTarget.APIVersion == "" {
 		inv.logger.Info("apiVersionValidationGate: retry still missing api_version, triggering human review",
 			"kind", kind, "correlation_id", correlationID)
-		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent)
+		return inv.apiVersionGateExhaustion(result, groupList, kind, correlationID, gateEvent, gateRetryExhausted)
 	}
 
-	gateEvent.Data["retry_outcome"] = "resolved"
+	gateEvent.EventOutcome = audit.OutcomeSuccess
+	if resolved.UsedReminder {
+		gateEvent.Data["retry_outcome"] = string(gateRetryResolvedAfterReminder)
+	} else {
+		gateEvent.Data["retry_outcome"] = string(gateRetryResolved)
+	}
 	// Clear parser-set HumanReviewNeeded from the retry result. The gate's
 	// decision is authoritative: if the retry provided api_version, the
 	// pipeline should continue to workflow selection, not abort.
@@ -368,9 +644,9 @@ func (inv *Investigator) retryForAPIVersion(ctx context.Context, p retryForAPIVe
 	// The retry is a fresh submission on its own turn: its own Reasoning
 	// block (if any) is authoritative for the accepted result, mirroring
 	// runRCA's "winning turn" semantics (BR-AI-086 AC6, #1578). Without this,
-	// resp.Message.Reasoning from the retry call is silently discarded and
-	// the gate-accepted result loses reasoning captured by the LLM client.
-	retryResult.Reasoning = toReasoningSummary(resp.Message.Reasoning)
+	// the retry turn's Reasoning would be silently discarded and the
+	// gate-accepted result would lose reasoning captured by the LLM client.
+	retryResult.Reasoning = toReasoningSummary(resolved.Reasoning)
 	inv.logger.Info("apiVersionValidationGate: retry provided api_version, accepted",
 		"kind", kind,
 		"api_version", retryResult.RemediationTarget.APIVersion,
@@ -382,8 +658,10 @@ func (inv *Investigator) apiVersionGateExhaustion(
 	result *katypes.InvestigationResult,
 	groupList, kind, correlationID string,
 	gateEvent *audit.AuditEvent,
+	outcome gateRetryOutcome,
 ) *katypes.InvestigationResult {
-	gateEvent.Data["retry_outcome"] = "exhausted"
+	gateEvent.Data["retry_outcome"] = string(outcome)
+	gateEvent.EventOutcome = audit.OutcomeFailure
 	result.HumanReviewNeeded = true
 	result.HumanReviewReason = katypes.HumanReviewReasonRCAIncomplete
 
@@ -405,7 +683,7 @@ func (inv *Investigator) apiVersionGateExhaustion(
 			"but LLM did not provide api_version after retry — human review required to prevent "+
 			"incorrect RBAC grants", kind, groupList))
 	inv.logger.Info("apiVersionValidationGate: exhausted, human review required",
-		"kind", kind, "conflicting_groups", groupList, "correlation_id", correlationID)
+		"kind", kind, "conflicting_groups", groupList, "retry_outcome", outcome, "correlation_id", correlationID)
 	return result
 }
 

--- a/internal/kubernautagent/investigator/samekind_confidence_2118_test.go
+++ b/internal/kubernautagent/investigator/samekind_confidence_2118_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// #2118 (BR-AI-2118, FedRAMP SI-11/AU-3): sameKindValidationGate's retry
+// confirms the LLM's original remediation target is correct, but the LLM's
+// tool call arguments for that confirmation frequently omit `confidence`
+// entirely (the model treats the correction turn as a yes/no confirmation,
+// not a full RCA restatement). Because the gate accepted retryResult.Confidence
+// as-is whenever RemediationTarget.Kind was non-empty, this silently dropped a
+// previously-computed, real confidence score down to 0.0 -- corrupting the
+// audit-visible RCA record (AU-3) and, downstream, any confidence-gated
+// automation (BR-AI-2118) that trusts InvestigationResult.Confidence.
+//
+// v1.6 clone of the release/v1.5.6 fix (#2118 -> #2119 tracking issue).
+// These specs exercise the gate through the real Investigate() production
+// path (mirroring apiversion_gate_test.go's established pattern in this
+// package) rather than calling the unexported gate function directly.
+var _ = Describe("#2118/#2119: sameKindValidationGate must not silently drop RCA confidence on retry", func() {
+
+	var (
+		logger     logr.Logger
+		auditStore *gateRecordingAuditStore
+		mockClient *gateMockLLMClient
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+	)
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+		auditStore = &gateRecordingAuditStore{}
+		mockClient = &gateMockLLMClient{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		enricher = enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, auditStore, logger)
+		phaseTools = investigator.DefaultPhaseToolMap()
+	})
+
+	signal := katypes.SignalContext{
+		ResourceKind: "Node",
+		ResourceName: "ip-10-0-1-23",
+		Name:         "ip-10-0-1-23",
+		Namespace:    "",
+		Severity:     "critical",
+		Message:      "Node DiskPressure",
+	}
+
+	Describe("UT-KA-2118-001 (regression): retry confirms the same target but omits confidence", func() {
+		It("must backfill the pre-retry confidence instead of silently zeroing it out (BR-AI-2118 AC1)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				// Turn 1: RCA submit — same-kind gate fires (target.Kind == signal.ResourceKind == "Node").
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Node under DiskPressure due to accumulated container logs",
+					"confidence":0.88,
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				// Turn 2: gate retry — LLM re-confirms the same target but the tool
+				// call arguments omit confidence entirely (the observed #2118 failure mode).
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Confirmed: Node itself is the correct target, log accumulation is host-level",
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"},
+					"due_diligence":{"target_accuracy":"host-level log rotation misconfiguration confirmed via kubectl describe node"}
+				}`}},
+				// Phase 3 (workflow selection) also omits confidence here -- a
+				// realistic case, since the LLM often treats workflow selection
+				// as a separate concern from the RCA confidence score. This
+				// isolates whether Phase 1's own post-gate confidence (what
+				// BuildPhase1Context/MergePhase1Fallbacks propagate as p1) was
+				// corrupted by the gate retry, independent of Phase 3's own
+				// (unrelated) confidence value.
+				gateWfToolResp(`{"workflow_id":"rotate-node-logs"}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.RemediationTarget.Kind).To(Equal("Node"),
+				"UT-KA-2118-001: retry confirming the same target must be accepted")
+			Expect(result.Confidence).To(BeNumerically("==", 0.88),
+				"UT-KA-2118-001: the pre-retry confidence (0.88) must be backfilled when the retry response omits "+
+					"confidence, not silently dropped to 0 (#2118)")
+		})
+	})
+
+	Describe("UT-KA-2118-002: retry provides its own genuine, non-zero confidence", func() {
+		It("must preserve the retry's own confidence unchanged, not overwrite it with the pre-retry value (BR-AI-2118 AC2)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Node under DiskPressure",
+					"confidence":0.88,
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				// Gate retry: LLM re-evaluates and returns a deliberately lower,
+				// genuinely-recomputed confidence for the same target.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Re-confirmed Node as target, but evidence is less conclusive than initially assessed",
+					"confidence":0.55,
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"rotate-node-logs"}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Confidence).To(BeNumerically("==", 0.55),
+				"UT-KA-2118-002: a genuine, non-zero retry confidence must be preserved as-is -- "+
+					"the backfill guard must not clobber a real re-assessment")
+		})
+	})
+
+	Describe("UT-KA-2118-003: original pre-retry confidence was itself never set (0)", func() {
+		It("must leave confidence at 0 rather than backfilling from a meaningless zero value (BR-AI-2118 edge case)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Node under DiskPressure",
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				// Gate retry also omits confidence.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Confirmed Node as target",
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"rotate-node-logs"}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Confidence).To(BeNumerically("==", 0),
+				"UT-KA-2118-003: backfill must only trigger when the pre-retry confidence was a real (>0) value -- "+
+					"it must not fabricate a non-zero confidence out of another zero value")
+		})
+	})
+
+	Describe("UT-KA-2118-004: correction message must instruct a full RCA restatement, not a bare confirmation", func() {
+		It("must ask the LLM to restate confidence alongside the target (BR-AI-2118 AC3, defense-in-depth)", func() {
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Node under DiskPressure",
+					"confidence":0.88,
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Confirmed Node as target",
+					"confidence":0.88,
+					"remediation_target":{"kind":"Node","name":"ip-10-0-1-23"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"rotate-node-logs","confidence":0.9}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockClient.calls).To(HaveLen(3),
+				"UT-KA-2118-004: expected RCA submit + gate retry + workflow-selection LLM calls")
+			gateCall := mockClient.calls[1]
+			lastMsg := gateCall.Messages[len(gateCall.Messages)-1]
+			Expect(lastMsg.Content).To(ContainSubstring("confidence"),
+				"UT-KA-2118-004: correction message must explicitly instruct the LLM to restate its confidence, "+
+					"not just confirm/deny the target (#2118)")
+			Expect(lastMsg.Content).To(SatisfyAny(
+				ContainSubstring("full"),
+				ContainSubstring("restate"),
+				ContainSubstring("entire"),
+			), "UT-KA-2118-004: correction message must instruct a full RCA restatement, not a bare yes/no confirmation")
+		})
+	})
+})

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -4873,6 +4873,26 @@ components:
           items:
             type: string
           description: List of MCP servers
+        retry_outcome:
+          type: string
+          description: >-
+            Present only on sameKindValidationGate/apiVersionValidationGate
+            retry audit events (#2119/#2120/#2121, BR-AI-2120, FedRAMP AU-3):
+            why the gate retry ended the way it did, e.g. "resolved",
+            "resolved_after_other_tool_retry", "llm_requested_other_tool",
+            "empty_response", "parse_error", "exhausted".
+        ambiguous_kind:
+          type: string
+          description: >-
+            Present only on apiVersionValidationGate audit events (#1044,
+            BR-AI-1044): the Kind that resolved to multiple API groups,
+            triggering the gate.
+        conflicting_groups:
+          type: string
+          description: >-
+            Present only on apiVersionValidationGate audit events (#1044,
+            BR-AI-1044): comma-joined list of the conflicting API groups
+            for ambiguous_kind.
 
     LLMResponsePayload:
       type: object

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -16653,6 +16653,24 @@ func (s AuditEventEventData) encodeFields(e *jx.Encoder) {
 					e.ArrEnd()
 				}
 			}
+			{
+				if s.RetryOutcome.Set {
+					e.FieldStart("retry_outcome")
+					s.RetryOutcome.Encode(e)
+				}
+			}
+			{
+				if s.AmbiguousKind.Set {
+					e.FieldStart("ambiguous_kind")
+					s.AmbiguousKind.Encode(e)
+				}
+			}
+			{
+				if s.ConflictingGroups.Set {
+					e.FieldStart("conflicting_groups")
+					s.ConflictingGroups.Encode(e)
+				}
+			}
 		}
 	case LLMResponsePayloadAuditEventEventData:
 		e.FieldStart("event_type")
@@ -21635,6 +21653,24 @@ func (s AuditEventRequestEventData) encodeFields(e *jx.Encoder) {
 						e.Str(elem)
 					}
 					e.ArrEnd()
+				}
+			}
+			{
+				if s.RetryOutcome.Set {
+					e.FieldStart("retry_outcome")
+					s.RetryOutcome.Encode(e)
+				}
+			}
+			{
+				if s.AmbiguousKind.Set {
+					e.FieldStart("ambiguous_kind")
+					s.AmbiguousKind.Encode(e)
+				}
+			}
+			{
+				if s.ConflictingGroups.Set {
+					e.FieldStart("conflicting_groups")
+					s.ConflictingGroups.Encode(e)
 				}
 			}
 		}
@@ -32166,18 +32202,39 @@ func (s *LLMRequestPayload) encodeFields(e *jx.Encoder) {
 			e.ArrEnd()
 		}
 	}
+	{
+		if s.RetryOutcome.Set {
+			e.FieldStart("retry_outcome")
+			s.RetryOutcome.Encode(e)
+		}
+	}
+	{
+		if s.AmbiguousKind.Set {
+			e.FieldStart("ambiguous_kind")
+			s.AmbiguousKind.Encode(e)
+		}
+	}
+	{
+		if s.ConflictingGroups.Set {
+			e.FieldStart("conflicting_groups")
+			s.ConflictingGroups.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfLLMRequestPayload = [9]string{
-	0: "event_type",
-	1: "event_id",
-	2: "incident_id",
-	3: "model",
-	4: "prompt_length",
-	5: "prompt_preview",
-	6: "max_tokens",
-	7: "toolsets_enabled",
-	8: "mcp_servers",
+var jsonFieldsNameOfLLMRequestPayload = [12]string{
+	0:  "event_type",
+	1:  "event_id",
+	2:  "incident_id",
+	3:  "model",
+	4:  "prompt_length",
+	5:  "prompt_preview",
+	6:  "max_tokens",
+	7:  "toolsets_enabled",
+	8:  "mcp_servers",
+	9:  "retry_outcome",
+	10: "ambiguous_kind",
+	11: "conflicting_groups",
 }
 
 // Decode decodes LLMRequestPayload from json.
@@ -32306,6 +32363,36 @@ func (s *LLMRequestPayload) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"mcp_servers\"")
+			}
+		case "retry_outcome":
+			if err := func() error {
+				s.RetryOutcome.Reset()
+				if err := s.RetryOutcome.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"retry_outcome\"")
+			}
+		case "ambiguous_kind":
+			if err := func() error {
+				s.AmbiguousKind.Reset()
+				if err := s.AmbiguousKind.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"ambiguous_kind\"")
+			}
+		case "conflicting_groups":
+			if err := func() error {
+				s.ConflictingGroups.Reset()
+				if err := s.ConflictingGroups.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"conflicting_groups\"")
 			}
 		default:
 			return d.Skip()

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -19144,6 +19144,17 @@ type LLMRequestPayload struct {
 	ToolsetsEnabled []string `json:"toolsets_enabled"`
 	// List of MCP servers.
 	McpServers []string `json:"mcp_servers"`
+	// Present only on sameKindValidationGate/apiVersionValidationGate retry audit events
+	// (#2119/#2120/#2121, BR-AI-2120, FedRAMP AU-3): why the gate retry ended the way it did, e.g.
+	// "resolved", "resolved_after_other_tool_retry", "llm_requested_other_tool", "empty_response",
+	// "parse_error", "exhausted".
+	RetryOutcome OptString `json:"retry_outcome"`
+	// Present only on apiVersionValidationGate audit events (#1044, BR-AI-1044): the Kind that resolved
+	// to multiple API groups, triggering the gate.
+	AmbiguousKind OptString `json:"ambiguous_kind"`
+	// Present only on apiVersionValidationGate audit events (#1044, BR-AI-1044): comma-joined list of
+	// the conflicting API groups for ambiguous_kind.
+	ConflictingGroups OptString `json:"conflicting_groups"`
 }
 
 // GetEventType returns the value of EventType.
@@ -19191,6 +19202,21 @@ func (s *LLMRequestPayload) GetMcpServers() []string {
 	return s.McpServers
 }
 
+// GetRetryOutcome returns the value of RetryOutcome.
+func (s *LLMRequestPayload) GetRetryOutcome() OptString {
+	return s.RetryOutcome
+}
+
+// GetAmbiguousKind returns the value of AmbiguousKind.
+func (s *LLMRequestPayload) GetAmbiguousKind() OptString {
+	return s.AmbiguousKind
+}
+
+// GetConflictingGroups returns the value of ConflictingGroups.
+func (s *LLMRequestPayload) GetConflictingGroups() OptString {
+	return s.ConflictingGroups
+}
+
 // SetEventType sets the value of EventType.
 func (s *LLMRequestPayload) SetEventType(val LLMRequestPayloadEventType) {
 	s.EventType = val
@@ -19234,6 +19260,21 @@ func (s *LLMRequestPayload) SetToolsetsEnabled(val []string) {
 // SetMcpServers sets the value of McpServers.
 func (s *LLMRequestPayload) SetMcpServers(val []string) {
 	s.McpServers = val
+}
+
+// SetRetryOutcome sets the value of RetryOutcome.
+func (s *LLMRequestPayload) SetRetryOutcome(val OptString) {
+	s.RetryOutcome = val
+}
+
+// SetAmbiguousKind sets the value of AmbiguousKind.
+func (s *LLMRequestPayload) SetAmbiguousKind(val OptString) {
+	s.AmbiguousKind = val
+}
+
+// SetConflictingGroups sets the value of ConflictingGroups.
+func (s *LLMRequestPayload) SetConflictingGroups(val OptString) {
+	s.ConflictingGroups = val
 }
 
 // Event type for discriminator (matches parent event_type).

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -4873,6 +4873,26 @@ components:
           items:
             type: string
           description: List of MCP servers
+        retry_outcome:
+          type: string
+          description: >-
+            Present only on sameKindValidationGate/apiVersionValidationGate
+            retry audit events (#2119/#2120/#2121, BR-AI-2120, FedRAMP AU-3):
+            why the gate retry ended the way it did, e.g. "resolved",
+            "resolved_after_other_tool_retry", "llm_requested_other_tool",
+            "empty_response", "parse_error", "exhausted".
+        ambiguous_kind:
+          type: string
+          description: >-
+            Present only on apiVersionValidationGate audit events (#1044,
+            BR-AI-1044): the Kind that resolved to multiple API groups,
+            triggering the gate.
+        conflicting_groups:
+          type: string
+          description: >-
+            Present only on apiVersionValidationGate audit events (#1044,
+            BR-AI-1044): comma-joined list of the conflicting API groups
+            for ambiguous_kind.
 
     LLMResponsePayload:
       type: object

--- a/test/e2e/kubernautagent/apiversion_gate_e2e_test.go
+++ b/test/e2e/kubernautagent/apiversion_gate_e2e_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package kubernautagent
 
 import (
+	"net/http"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	kaaudit "github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/pkg/agentclient"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	"github.com/jordigilh/kubernaut/test/infrastructure"
+	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
 )
 
 // apiVersion Validation Gate E2E Tests — Issue #1044
@@ -42,6 +49,22 @@ import (
 var _ = Describe("E2E-KA-1044: apiVersion Validation Gate", Label("e2e", "ka", "apiversion-gate", "1044"), func() {
 
 	Context("BR-AI-1044: Gate exhaustion with ambiguous CRD kind", func() {
+
+		var dataStorageClient *ogenclient.Client
+
+		BeforeEach(func() {
+			saToken, err := infrastructure.GetServiceAccountToken(ctx, sharedNamespace, "kubernaut-agent-e2e-sa", kubeconfigPath)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get ServiceAccount token")
+
+			dataStorageClient, err = ogenclient.NewClient(
+				dataStorageURL,
+				ogenclient.WithClient(&http.Client{
+					Transport: testauth.NewServiceAccountTransport(saToken),
+					Timeout:   30 * time.Second,
+				}),
+			)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create authenticated DataStorage client")
+		})
 
 		It("E2E-KA-1044-001: Pod signal with RCA targeting ambiguous TestWidget triggers human review", func() {
 			// ========================================
@@ -97,6 +120,47 @@ var _ = Describe("E2E-KA-1044: apiVersion Validation Gate", Label("e2e", "ka", "
 
 			Expect(result.Warnings).NotTo(BeEmpty(),
 				"warnings should be present when gate exhausts retries for ambiguous kind")
+
+			// ========================================
+			// ASSERT (#2141, BR-AI-2120, FedRAMP AU-3): gate-retry diagnostic
+			// fields are reconstructable from the real persisted audit trail,
+			// not just from the in-process InvestigationResult above -- this
+			// is the full journey the UT (ds_store_test.go) and IT
+			// (IT-KA-2141-001) tiers prove piecewise: real gate exhaustion,
+			// through the real binary's DSAuditStore, into real Data
+			// Storage/Postgres, queryable by remediation_id.
+			// ========================================
+			var gateEvent *ogenclient.AuditEvent
+			Eventually(func() bool {
+				params := ogenclient.QueryAuditEventsParams{}
+				params.CorrelationID.SetTo(req.RemediationID)
+				params.EventType.SetTo(kaaudit.EventTypeLLMRequest)
+				params.Limit.SetTo(100)
+
+				resp, qErr := dataStorageClient.QueryAuditEvents(ctx, params)
+				if qErr != nil {
+					return false
+				}
+				for i := range resp.Data {
+					if resp.Data[i].EventAction == kaaudit.ActionAPIVersionGate {
+						gateEvent = &resp.Data[i]
+						return true
+					}
+				}
+				return false
+			}, 30*time.Second, 2*time.Second).Should(BeTrue(),
+				"api_version_validation_gate audit event must be persisted and queryable by remediation_id")
+
+			payload, ok := gateEvent.EventData.GetLLMRequestPayload()
+			Expect(ok).To(BeTrue(), "persisted event_data must decode as LLMRequestPayload")
+
+			ambiguousKind, hasAmbiguousKind := payload.AmbiguousKind.Get()
+			Expect(hasAmbiguousKind).To(BeTrue(), "ambiguous_kind must survive the full journey into Data Storage")
+			Expect(ambiguousKind).NotTo(BeEmpty())
+
+			retryOutcome, hasRetryOutcome := payload.RetryOutcome.Get()
+			Expect(hasRetryOutcome).To(BeTrue(), "retry_outcome must survive the full journey into Data Storage")
+			Expect(retryOutcome).To(Equal("exhausted"))
 		})
 
 		It("E2E-KA-1044-002: TestWidget signal directly triggers gate exhaustion and human review", func() {

--- a/test/integration/kubernautagent/investigator/apiversion_gate_integration_test.go
+++ b/test/integration/kubernautagent/investigator/apiversion_gate_integration_test.go
@@ -18,6 +18,8 @@ package investigator_test
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -31,6 +33,7 @@ import (
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 )
@@ -309,6 +312,96 @@ var _ = Describe("TP-1044: apiVersionValidationGate Integration — Full Investi
 			}
 			Expect(found).To(BeTrue(),
 				"IT-KA-1044-005: api_version_validation_gate audit event must be persisted")
+		})
+	})
+
+	Describe("IT-KA-2141-001: retry_outcome/ambiguous_kind/conflicting_groups actually reach Data Storage (BR-AI-1044, BR-AI-2120, FedRAMP AU-3)", func() {
+		It("must be queryable from DS by correlation_id after a real gate-exhaustion Investigate() call", func() {
+			correlationID := fmt.Sprintf("test-2141-gate-retry-%d", time.Now().UnixNano())
+
+			k8s := &k8sFixtureClient{ownerChain: nil, err: nil}
+			localEnricher := enrichment.NewEnricher(k8s, suiteDSAdapter, auditStore, invLogger)
+			resolver := investigator.NewMapperScopeResolver(newITAmbiguousMapper())
+
+			// Same shape as IT-KA-1044-002: gate exhausts because the LLM
+			// never supplies api_version, guaranteeing ambiguous_kind/
+			// conflicting_groups/retry_outcome=exhausted are set on the
+			// audit event -- this is the exact scenario that motivated
+			// #2141 (these fields previously never reached DS regardless
+			// of the in-process ordering fix from #2119/#2121, since
+			// LLMRequestPayload had no carrier field for them).
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: localEnricher, AuditStore: auditStore, Logger: invLogger,
+				MaxTurns: 15, PhaseTools: phaseTools, ScopeResolver: resolver,
+			})
+
+			gateSignal := signal
+			gateSignal.RemediationID = correlationID
+
+			_, err := inv.Investigate(context.Background(), gateSignal)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Querying DS for the api_version_validation_gate audit event")
+			var events []ogenclient.AuditEvent
+			Eventually(func() bool {
+				params := ogenclient.QueryAuditEventsParams{}
+				params.CorrelationID.SetTo(correlationID)
+				params.EventType.SetTo(audit.EventTypeLLMRequest)
+				params.Limit.SetTo(100)
+
+				resp, qErr := ogenClient.QueryAuditEvents(context.Background(), params)
+				if qErr != nil {
+					GinkgoWriter.Printf("  ⚠️  Audit query failed: %v\n", qErr)
+					return false
+				}
+				events = resp.Data
+				return len(events) > 0
+			}, 15*time.Second, 1*time.Second).Should(BeTrue(),
+				fmt.Sprintf("DS should contain %s event(s) for correlation_id=%s", audit.EventTypeLLMRequest, correlationID))
+
+			var gateEvent *ogenclient.AuditEvent
+			for i := range events {
+				if events[i].EventAction == audit.ActionAPIVersionGate {
+					gateEvent = &events[i]
+					break
+				}
+			}
+			Expect(gateEvent).NotTo(BeNil(),
+				"IT-KA-2141-001: api_version_validation_gate event must be among the persisted events")
+
+			payload, ok := gateEvent.EventData.GetLLMRequestPayload()
+			Expect(ok).To(BeTrue(), "IT-KA-2141-001: persisted event_data must decode as LLMRequestPayload")
+
+			ambiguousKind, hasAmbiguousKind := payload.AmbiguousKind.Get()
+			Expect(hasAmbiguousKind).To(BeTrue(),
+				"IT-KA-2141-001: ambiguous_kind must be reconstructable from DS, not just from an in-memory test double")
+			Expect(ambiguousKind).To(Equal("Subscription"))
+
+			conflictingGroups, hasConflictingGroups := payload.ConflictingGroups.Get()
+			Expect(hasConflictingGroups).To(BeTrue(),
+				"IT-KA-2141-001: conflicting_groups must be reconstructable from DS")
+			Expect(conflictingGroups).NotTo(BeEmpty())
+
+			retryOutcome, hasRetryOutcome := payload.RetryOutcome.Get()
+			Expect(hasRetryOutcome).To(BeTrue(),
+				"IT-KA-2141-001: retry_outcome must be reconstructable from DS -- this is the field #2119/#2121's "+
+					"deferred-StoreAudit ordering fix was written to protect, now proven end-to-end rather than "+
+					"just via a snapshotting test double")
+			Expect(retryOutcome).To(Equal("exhausted"))
 		})
 	})
 })

--- a/test/integration/kubernautagent/investigator/suite_test.go
+++ b/test/integration/kubernautagent/investigator/suite_test.go
@@ -84,7 +84,22 @@ func newCapturingAuditStore(delegate audit.AuditStore) *capturingAuditStore {
 }
 
 func (c *capturingAuditStore) StoreAudit(ctx context.Context, event *audit.AuditEvent) error {
-	c.events = append(c.events, event)
+	// #2120/#2121: snapshot Data at call time rather than capturing the raw
+	// pointer. The real DSAuditStore (internal/kubernautagent/audit/ds_store.go)
+	// reads event.Data/event.EventOutcome synchronously while building the
+	// outbound request, then never sees the *event again — mirroring that
+	// here means an assertion against c.events reflects what was actually
+	// handed to the store at call time, not any mutation a caller makes to
+	// the same event.Data map afterward. Capturing the raw pointer would
+	// mask exactly the class of bug #2120/#2121 fixed (a retry_outcome/
+	// EventOutcome mutation made after StoreAudit already returned).
+	snapshot := *event
+	dataCopy := make(map[string]interface{}, len(event.Data))
+	for k, v := range event.Data {
+		dataCopy[k] = v
+	}
+	snapshot.Data = dataCopy
+	c.events = append(c.events, &snapshot)
 	return c.real.StoreAudit(ctx, event)
 }
 


### PR DESCRIPTION
## Summary

Ports two confirmed v1.5.6 bug fixes to `main`/v1.6, plus a schema gap discovered
while verifying the audit trail for both:

- **#2119** (v1.6 clone of #2118): `sameKindValidationGate` silently dropped RCA
  confidence during a retry when the LLM omitted it from the correction response.
  Confidence is now backfilled from the pre-retry result when omitted, preserved
  when recomputed, and the correction prompt explicitly instructs the LLM to
  restate full RCA (including confidence).

- **#2121** (v1.6 clone of #2120): both gates send their retry LLM call with only
  `submit_result` declared, but models frequently ignore this and call an
  undeclared tool instead (e.g. `kubectl_describe`). Pre-fix this silently fell
  back to "no content in retry response, keeping original" -- indistinguishable
  from a genuinely empty response. The gate now retries once more with a reminder
  message, and the audit trail records a new `retry_outcome` (`resolved`,
  `resolved_after_other_tool_retry`, `llm_requested_other_tool`, `exhausted`, ...)
  so "LLM re-evaluated and confirmed/changed the target" is distinguishable from
  "LLM never engaged with the correction at all."

- **Test-fixture hardening**: `gateRecordingAuditStore` (unit) and
  `capturingAuditStore` (integration) previously captured a raw pointer into
  `event.Data`, masking a real defect where `retry_outcome`/`EventOutcome` were
  mutated *after* `StoreAudit` returned. Both now snapshot `Data` at call time,
  matching how the real `DSAuditStore` actually observes it.

- **#2141** (discovered during FedRAMP AU-3 verification of the above): even with
  the in-process ordering fixed, `retry_outcome`/`ambiguous_kind`/`conflicting_groups`
  never reached Data Storage -- the `LLMRequestPayload` OpenAPI schema had no
  fields for them, so they were silently dropped before persistence. Added the
  3 fields to `api/openapi/data-storage-v1.yaml`, regenerated the ogen client,
  and wired `buildLLMRequestPayload` to populate them. Folded into this PR
  (rather than a separate one) due to GH Actions resource constraints.

Adapted from `main`'s diverged gate structure (`LLMInvocationContext` plumbing,
split `sameKindValidationGate`/`retryForSameKind` and
`apiVersionValidationGate`/`retryForAPIVersion` functions) rather than a direct
cherry-pick from `release/v1.5`. Full details: `docs/testing/2119/TEST_PLAN.md`,
`docs/testing/2121/TEST_PLAN.md`.

## Test plan

Pyramid invariant fully closed, verified locally (not just compiled):

- **Unit**: `go test ./internal/kubernautagent/investigator/...` -- 366/366 pass
  (10 new specs across #2119/#2121); `go test ./internal/kubernautagent/audit/...`
  -- pass, including new `UT-KA-2141-001`.
- **Integration**: `KUBEBUILDER_ASSETS=$(setup-envtest use 1.36 -p path) ginkgo
  ./test/integration/kubernautagent/investigator/...` against real envtest +
  Podman-backed Data Storage/Postgres -- **142/142 specs pass**, including
  `IT-KA-2141-001` (real DB round-trip: gate-exhaustion event queried back from
  Postgres by `correlation_id`, fields decode correctly).
- **E2E**: `ginkgo --focus="BR-AI-1044" ./test/e2e/kubernautagent/...` against a
  real Kind cluster (full stack: Data Storage, Postgres, Mock LLM, Kubernaut
  Agent) -- **2/2 focused specs pass**, including the extended `E2E-KA-1044-001`
  which queries Data Storage by `remediation_id` post-investigation and confirms
  `ambiguous_kind`/`retry_outcome=exhausted` are reconstructable end-to-end.
- `go build ./...`, `go vet ./...`, `golangci-lint run` -- clean, no new issues.
- `make generate` -- zero unexpected drift (only the 3 intentionally-touched
  generated files changed).

Closes #2119, #2121, #2141.