### PR TITLE
fix(test-infra): poll Dex EndpointSlice before oauth2-proxy OIDC discovery in smoke test

### DIFF
--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -1103,6 +1103,32 @@ EOF
     return 1
   fi
 
+  # Issue #2144 RCA: run_console_live_001's oauth2-proxy has TCP-timed-out
+  # reaching Dex's ClusterIP moments after the rollout-status check above
+  # returned -- Deployment readiness only proves the Pod passed its own
+  # readiness probe, not that kube-proxy/CNI has finished programming this
+  # Service's data-plane rules for that Pod yet. Poll the EndpointSlice
+  # (not the deprecated v1 Endpoints -- see the "Endpoints is deprecated"
+  # warnings already elsewhere in this suite's output) for a populated
+  # address before returning, to close that race at its source rather than
+  # relying on incidental delay between here and oauth2-proxy's startup.
+  local dex_ep_ready=false attempt
+  for attempt in $(seq 1 15); do
+    local ready_addr
+    ready_addr=$(kubectl get endpointslices -n "$NAMESPACE" \
+      -l kubernetes.io/service-name=dex \
+      -o jsonpath='{.items[*].endpoints[*].addresses[*]}' 2>/dev/null || echo "")
+    if [[ -n "$ready_addr" ]]; then
+      dex_ep_ready=true
+      break
+    fi
+    sleep 2
+  done
+  if ! $dex_ep_ready; then
+    tap_not_ok "$desc" "Dex Deployment was ready, but its Service had no EndpointSlice address after 30s (data-plane not yet programmed)"
+    return 1
+  fi
+
   kubectl create secret generic console-oauth-creds -n "$NAMESPACE" \
     --from-literal=client-id=kubernaut-console \
     --from-literal=client-secret="$DEX_CLIENT_SECRET" \


### PR DESCRIPTION
## Summary

- `ST-CHART-CONSOLE-LIVE-001` has failed twice on `main` with an identical signature: `oauth2-proxy`'s OIDC discovery TCP-timed-out reaching Dex's ClusterIP, even though Dex's own logs showed a clean startup ~85s earlier with no crashes (see #2144 for the full RCA).
- `deploy_dex` only waited on `kubectl rollout status deployment/dex`, which proves the Pod passed its own readiness probe — it says nothing about whether kube-proxy/CNI has finished programming the Service's data-plane rules for that Pod yet. That gap is exactly the kind of race that produces a transient "Pod ready, Service still unreachable" window.
- Closes the race at its source: after rollout-status succeeds, poll the Service's `EndpointSlice` (not the deprecated `v1 Endpoints`) for a populated address, bounded at 30s (15 attempts × 2s), before `deploy_dex` returns. If it never populates, this now fails `ST-CHART-CONSOLE-LIVE-000` (the Dex deploy step) with a message naming the actual gap, instead of letting the failure surface downstream — misleadingly — on `ST-CHART-CONSOLE-LIVE-001` as if oauth2-proxy or its OIDC config were at fault.

## Test plan

- `bash -n scripts/helm-smoke-test.sh` and `shellcheck scripts/helm-smoke-test.sh` — no new warnings introduced by this change.
- This is test-infra-only (no application code); the real validation is the next `Helm Smoke Tests (Kind, tls=hook)` / `(tls=cert-manager)` CI runs on this PR closing the previously-observed race. If the flake recurs even with this fix, that's useful signal that the root cause is something else (per #2144's fallback: investigate the Kind/CNI-level cause more deeply).

Ref #2144