### PR TITLE
feat(#2148): auth-only fallback for console-access gate when unconfigured

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -52,7 +52,7 @@ func run() int {
 	defer func() { _ = zapLogger.Sync() }()
 	ctrl.SetLogger(logger.WithName("controller-runtime"))
 
-	sarChecker, err := buildSARClient(logger, cfg.RBAC.SARCacheTTL)
+	sarChecker, err := buildSARClient(logger, cfg.RBAC.SARCacheTTL, cfg.RBAC.ConsoleAccessAuthOnly)
 	if err != nil {
 		return 1
 	}
@@ -387,8 +387,11 @@ func setupConfigAndLogger() (*config.Config, logr.Logger, *zap.Logger, error) {
 }
 
 // buildSARClient wires the SelfSubjectAccessReview-based authorizer used for
-// K8s-tool RBAC gating.
-func buildSARClient(logger logr.Logger, sarCacheTTL time.Duration) (auth.ToolAuthorizer, error) {
+// K8s-tool RBAC gating. consoleAccessAuthOnly configures the coarse-grained
+// console gate (only) to skip its SAR call and grant any authenticated user
+// -- see RBACConfig.ConsoleAccessAuthOnly (#2148); per-tool checks are
+// unaffected and always call SAR.
+func buildSARClient(logger logr.Logger, sarCacheTTL time.Duration, consoleAccessAuthOnly bool) (auth.ToolAuthorizer, error) {
 	restCfg, err := ctrl.GetConfig()
 	if err != nil {
 		logger.Error(err, "failed to get in-cluster config for SAR client")
@@ -399,7 +402,12 @@ func buildSARClient(logger logr.Logger, sarCacheTTL time.Duration) (auth.ToolAut
 		logger.Error(err, "failed to create kubernetes client for SAR")
 		return nil, err
 	}
-	return auth.NewSARChecker(k8sClient, sarCacheTTL, logger.WithName("sar")), nil
+	checker := auth.NewSARChecker(k8sClient, sarCacheTTL, logger.WithName("sar"))
+	checker.SetConsoleAccessAuthOnly(consoleAccessAuthOnly)
+	if consoleAccessAuthOnly {
+		logger.Info("console-access gate running in auth-only mode: no consoleAccessGroups/roleBindings configured, SAR is skipped for the console gate and any authenticated user is granted; per-tool RBAC checks are unaffected")
+	}
+	return checker, nil
 }
 
 // buildAuditWiring wires AF's audit trail to the shared BufferedAuditStore

--- a/pkg/apifrontend/auth/sar.go
+++ b/pkg/apifrontend/auth/sar.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -53,6 +54,15 @@ type SARChecker struct {
 	logger   logr.Logger
 	mu       sync.RWMutex
 	cache    map[string]cacheEntry
+
+	// consoleAccessAuthOnly, when true, makes CheckConsoleAccess grant any
+	// authenticated (non-empty) user without calling SAR at all -- an
+	// explicit, narrowly-scoped exception to fail-closed for the
+	// coarse-grained console gate only (#2148). Check (per-tool
+	// authorization) never consults this flag and always calls SAR.
+	// Set via SetConsoleAccessAuthOnly; defaults to false (today's
+	// unconditional fail-closed behavior, unchanged).
+	consoleAccessAuthOnly atomic.Bool
 }
 
 // NewSARChecker creates a SARChecker that performs SubjectAccessReview calls
@@ -108,8 +118,28 @@ func (s *SARChecker) Check(ctx context.Context, user string, groups []string, to
 // resource (verb=use, no resourceName). Results are cached for the
 // configured TTL, in the same cache but keyed distinctly from Check's
 // "tools" entries so the two never collide.
+//
+// When SetConsoleAccessAuthOnly(true) has been set, this degrades to an
+// authentication-only check (empty user still fails closed) and skips the
+// SAR call entirely (#2148) -- a narrow, explicit exception scoped to this
+// coarse-grained gate alone; Check (per-tool) is never affected and always
+// calls SAR.
 func (s *SARChecker) CheckConsoleAccess(ctx context.Context, user string, groups []string) (bool, error) {
+	if s.consoleAccessAuthOnly.Load() {
+		if user == "" {
+			return false, fmt.Errorf("user must not be empty")
+		}
+		return true, nil
+	}
 	return s.checkSAR(ctx, user, groups, "console", "")
+}
+
+// SetConsoleAccessAuthOnly configures whether CheckConsoleAccess grants any
+// authenticated user without an authorization (SAR) check -- see the
+// consoleAccessAuthOnly field doc. Safe for concurrent use; typically set
+// once at startup based on RBACConfig.ConsoleAccessAuthOnly.
+func (s *SARChecker) SetConsoleAccessAuthOnly(v bool) {
+	s.consoleAccessAuthOnly.Store(v)
 }
 
 // checkSAR is the shared SAR-call-plus-cache implementation behind both

--- a/pkg/apifrontend/auth/sar_test.go
+++ b/pkg/apifrontend/auth/sar_test.go
@@ -261,6 +261,44 @@ var _ = Describe("SARChecker", func() {
 		})
 	})
 
+	Describe("UT-AF-2148-001: CheckConsoleAccess auth-only mode skips SAR for any authenticated user [AC-3]", func() {
+		It("should allow access without calling SAR when ConsoleAccessAuthOnly is enabled", func() {
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", denyAll)
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+			checker.SetConsoleAccessAuthOnly(true)
+
+			allowed, err := checker.CheckConsoleAccess(ctx, "alice", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue(), "auth-only mode grants any authenticated user, regardless of groups/RBAC")
+			Expect(sarCalls.Load()).To(Equal(int32(0)), "auth-only mode must not call the SAR API at all")
+		})
+	})
+
+	Describe("UT-AF-2148-002: CheckConsoleAccess auth-only mode still fail-closed on empty user [AC-3]", func() {
+		It("should reject an empty user even in auth-only mode", func() {
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+			checker.SetConsoleAccessAuthOnly(true)
+
+			allowed, err := checker.CheckConsoleAccess(ctx, "", nil)
+			Expect(err).To(HaveOccurred(), "authentication is still mandatory in auth-only mode")
+			Expect(allowed).To(BeFalse(), "fail-closed on invalid/missing identity")
+			Expect(sarCalls.Load()).To(Equal(int32(0)))
+		})
+	})
+
+	Describe("UT-AF-2148-003: Check (per-tool) is unaffected by ConsoleAccessAuthOnly [AC-3]", func() {
+		It("should still call SAR and enforce per-tool RBAC even when ConsoleAccessAuthOnly is enabled", func() {
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", denyAll)
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+			checker.SetConsoleAccessAuthOnly(true)
+
+			allowed, err := checker.Check(ctx, "alice", []string{"sre"}, "kubernaut_approve")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeFalse(), "per-tool SAR checks must remain fully fail-closed regardless of the console auth-only flag")
+			Expect(sarCalls.Load()).To(Equal(int32(1)), "per-tool Check must still call the SAR API")
+		})
+	})
+
 	Describe("UT-AF-1919: tools and console SAR cache entries do not collide", func() {
 		It("should call the SAR API separately for Check(tools) and CheckConsoleAccess even with identical user/groups", func() {
 			callCount := atomic.Int32{}

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -252,6 +252,16 @@ type RBACConfig struct {
 	// SARCacheTTL controls how long SubjectAccessReview results are cached.
 	// Zero disables caching (every call hits the API server).
 	SARCacheTTL time.Duration `yaml:"sarCacheTTL"`
+
+	// ConsoleAccessAuthOnly, when true, makes the coarse-grained console
+	// gate (GET /a2a/access and its inline per-request equivalent) grant
+	// any authenticated user without an authorization (SAR) check --
+	// authentication is still mandatory, only the group-based authz step
+	// is skipped (#2148). Per-tool SAR checks are never affected by this
+	// and always fail closed. Intended for deployments where no console
+	// access groups have been configured at all; defaults to false
+	// (today's unconditional fail-closed behavior, unchanged).
+	ConsoleAccessAuthOnly bool `yaml:"consoleAccessAuthOnly,omitempty"`
 }
 
 // DefaultConfig returns a Config populated with production defaults.


### PR DESCRIPTION
## Summary

Closes #2148.

- AF's coarse-grained `kubernaut.ai/console` SAR gate (#1919) is fail-closed with no permissive default: when no `consoleAccessGroups`/`roleBindings` are configured at all, every authenticated user (including `cluster-admin`) gets `403` on the Console and on every `/mcp`/`/a2a/invoke` call's inline console check, with zero fallback. This was hit by a real customer deployment and is now a documented hard install prerequisite (kubernaut-operator#334/#335) -- correct for anyone who *has* configured RBAC, but an all-or-nothing cliff otherwise.
- Adds `RBACConfig.ConsoleAccessAuthOnly` (default `false`, today's behavior unchanged). When `true`, `SARChecker.CheckConsoleAccess` grants any authenticated (non-empty) user without calling SAR -- authentication stays mandatory, only the group-based authorization step is skipped.
- `Check` (per-tool authorization) is **completely unaffected** -- always calls SAR, always fail-closed, no bypass. This narrows the scope of the existing "AF must always require SAR, no dev-mode fallback" invariant to exclude only the advisory, coarse-grained console gate, which per its own design docs was never itself the primary security boundary (per-tool RBAC is).
- A companion `kubernaut-operator` PR will set this flag based on `spec.apiFrontend.rbac == nil` (i.e. RBAC never configured at all -- any deployment with even one `roleBindings` entry or an explicit `consoleAccessGroups` is unaffected).

## Test plan
- [x] `UT-AF-2148-001`: auth-only mode grants any authenticated user without calling SAR.
- [x] `UT-AF-2148-002`: auth-only mode still fail-closed on empty user (authentication remains mandatory).
- [x] `UT-AF-2148-003`: per-tool `Check` is unaffected by the flag -- still calls SAR, still fail-closed.
- [x] Full `pkg/apifrontend/...` + `cmd/apifrontend/...` suite passes.
- [x] `go vet` clean.