### PR TITLE
fix(kubernautagent): close takeover/investigation race with a completion signal, not a retry budget (#2156)

### DIFF
--- a/docs/testing/2156/TEST_PLAN.md
+++ b/docs/testing/2156/TEST_PLAN.md
@@ -2,11 +2,12 @@
 
 > **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
 
-**Test Plan Identifier**: TP-2156-v1.0
-**Feature**: Bound-retry context reconstruction on takeover to close the race between
-`TransitionToUserDriving`'s synchronous status flip and the autonomous investigation
-goroutine's own (slightly later) result write.
-**Version**: 1.0
+**Test Plan Identifier**: TP-2156-v2.0
+**Feature**: Close the race between `TransitionToUserDriving`'s synchronous status flip
+and the autonomous investigation goroutine's own (slightly later) result write, by having
+`handleTakeover` wait on a real completion signal (`WaitForCompletionByRemediationID`)
+instead of retrying context reconstruction on a fixed sleep schedule.
+**Version**: 2.0 (v1.0's fixed 5×100ms retry design was replaced — see §16 changelog)
 **Created**: 2026-08-15
 **Author**: AI agent (Cursor) + jgil
 **Status**: Complete
@@ -50,28 +51,36 @@ eventually stored at all. The same race exists on `release/v1.5`: the relevant c
 both branches, even though it had not yet manifested as an observed CI failure on
 `release/v1.5` at the time of this port.
 
-This plan documents the port of the RED→GREEN TDD sequence used on `main` to reproduce
-the race deterministically and close it with the same short bounded retry.
+This plan originally documented a port of `main`'s fixed-retry TDD sequence (see §16 for
+why that design was replaced). The v2.0 design closes the same race deterministically
+instead of probabilistically: rather than guessing how long the investigation goroutine
+might still take and sleeping on a fixed schedule, `handleTakeover` now waits on a real
+completion signal — a `done` channel on `session.Session`, closed by the investigation
+goroutine's own deferred cleanup only after it has fully finished mutating session state
+(including the `storePartialResult` fallback write). This is a Go memory-model
+happens-before guarantee (channel close/receive), not a timing guess.
 
 ### 1.2 Objectives
 
 1. **Deterministic reproduction**: an integration test forces the investigation's
-   result-write to land strictly *after* takeover's status transition and strictly
-   *before* the retry budget is exhausted, so the test is not a timing-dependent flake
-   in either direction.
-2. **Bounded fix**: the retry adds no latency on the common path (result already
-   present, or a genuinely fresh investigation with no history) and caps worst-case
-   added latency at `reconstructionRetryAttempts * reconstructionRetryInterval` (400ms)
-   only in the narrow race window.
-3. **Scoped blast radius**: only `handleTakeover`'s call site is changed.
-   `handleStart` (fresh session, no result to race against) and
+   result-write to land strictly *after* takeover's status transition, exercising a real
+   `session.Manager`-backed completion signal end to end (not a mocked channel), so the
+   test proves the actual synchronization primitive, not a stand-in for it.
+2. **No arbitrary bound on the common path**: waiting on the real signal costs nothing
+   when there's nothing to wait for (an already-closed channel is returned immediately
+   for a genuinely fresh investigation, a pending/never-launched session, or a session
+   whose investigation already fully finished) — there is no fixed-schedule "tax" on
+   these paths, unlike the fixed-retry design this replaces (see §16).
+3. **Scoped blast radius**: only `handleTakeover`'s call site (plus the new
+   `Session.done`/`Manager.WaitForCompletionByRemediationID` primitive it depends on) is
+   changed. `handleStart` (fresh session, no result to race against) and
    `discover_workflows` (called well after the user's first interactive message, by
    which point the race window has closed) are unaffected.
 4. **Compliance-control regression check**: prove the one FedRAMP/SOC2-mapped audit
    event on this code path (`aiagent.interactive.started`, AU-2/CC8.1 per
    `docs/services/stateless/kubernaut-agent/security/AUDIT_EVENT_CATALOG.md`) keeps its
-   correct `session_id`/`acting_user` attribution regardless of how many reconstruction
-   retry attempts run underneath it.
+   correct `session_id`/`acting_user` attribution regardless of how long the wait for the
+   completion signal takes.
 
 ### 1.4 FedRAMP/SOC2 Control Objective Assessment (ported from `main`, see §16)
 
@@ -109,7 +118,8 @@ on the `release/v1.5` port — the same code paths and audit event catalog apply
 | Unit test pass rate | 100% | `go test ./internal/kubernautagent/mcp/tools/... -run TestMCPToolsUnit -args -ginkgo.focus=2155` |
 | Integration test pass rate | 100% | `bin/ginkgo --focus="IT-KA-2155-001" ./test/integration/kubernautagent/mcp/...` |
 | Backward compatibility | 0 regressions | `go test ./internal/kubernautagent/...` |
-| Port parity with `main` | Same fix logic, same test coverage | recorded below |
+| No arbitrary latency tax | 0 (was: 400ms in the v1.0 retry design) added latency when there's nothing to wait for | `UT-KA-2155-002` |
+| Race-detector clean | 0 data races on the new `Session.done` channel | `go test -race ./internal/kubernautagent/mcp/tools/... ./internal/kubernautagent/session/...` |
 
 ---
 
@@ -135,15 +145,16 @@ on the `release/v1.5` port — the same code paths and audit event catalog apply
 
 | ID | Risk | Impact | Probability | Affected Tests | Mitigation |
 |----|------|--------|-------------|----------------|------------|
-| R1 | Retry adds latency to every takeover, even when there is no race | User-visible slowdown | Low | UT-KA-2155-001/002 | Retry only fires when the first read finds 0 turns; common path (result present or genuinely empty) returns on attempt 1 |
-| R2 | Retry loop ignores session/inactivity cancellation and blocks | Hung takeover call | Low | UT-KA-2155-003 | `select` on `ctx.Done()` between attempts; `handleTakeover` already wraps `ctx` with `withInactivityCancel` (#1949) |
-| R3 | Retry masks a genuine "no prior investigation" case by waiting the full budget every time | Latency regression for the common cold-start case | Medium | UT-KA-2155-002 | Bounded to 5 attempts / 400ms; only `handleTakeover`'s call site retries (not `handleStart`) |
+| R1 | Waiting on the signal adds latency to every takeover, even when there is no race | User-visible slowdown | Low | UT-KA-2155-002 | `WaitForCompletionByRemediationID` returns an already-closed channel when there's nothing to wait for (no investigation, or one that already fully finished); the `select` resolves immediately in that case |
+| R2 | The wait ignores session/inactivity cancellation and blocks | Hung takeover call | Low | UT-KA-2155-003 | `select` on `ctx.Done()` alongside the completion channel; `handleTakeover` already wraps `ctx` with `withInactivityCancel` (#1949) |
+| R3 | `Session.done` is closed more than once (panic) or never closed (goroutine leak/hang) | Panic on double-close, or a takeover that hangs forever | Low | `go test -race`, UT-KA-2155-001/002/003 | `close(done)` is a single `defer` registered once per investigation launch in `launchInvestigation`, guaranteed to run exactly once via Go's defer semantics (including on panic, via `recoverPanic`'s defer ordering) |
+| R4 (superseded, was primary risk in v1.0) | A fixed retry budget is an unfounded guess with no principled bound, and unconditionally taxes the "no prior investigation" case with its full budget | Correctness bug masked as "good enough," plus a real latency regression | N/A (design replaced) | N/A | Replaced by the completion-signal design (§16); no longer applicable |
 
 ### 3.1 Risk-to-Test Traceability
 
-All three risks (R1–R3) are directly covered: R1/R2 by unit tests exercising the retry
-helper's decision logic and cancellation handling in isolation; R3 is bounded by
-construction (fixed attempt budget) and proven by `UT-KA-2155-002`.
+R1/R2 are covered by unit tests exercising `handleTakeover`'s wait behavior in isolation
+(via a controllable `WaitForCompletionByRemediationID` mock). R3 is covered by the
+race detector plus the full unit/integration suite exercising real goroutine lifecycles.
 
 ---
 
@@ -151,15 +162,16 @@ construction (fixed attempt budget) and proven by `UT-KA-2155-002`.
 
 ### 4.1 Features to be Tested
 
-- **`storeReconstructedContextWithRetry`** (`internal/kubernautagent/mcp/tools/investigate.go`
-  on `release/v1.5`, consolidated from `main`'s `investigate_autonomous.go`): bounded-retry
-  wrapper around `storeReconstructedContext`. Validates: retries until a non-zero result
-  appears, gives up after the attempt budget, and aborts immediately on context
-  cancellation.
-- **`handleTakeover`** (same `investigate.go` file, consolidated from `main`'s
-  `investigate_takeover.go`): wiring — the takeover path now calls the retrying wrapper,
-  closing the race against a real `session.Manager`-driven autonomous investigation
-  goroutine.
+- **`Session.done` / `Manager.WaitForCompletionByRemediationID`**
+  (`internal/kubernautagent/session/{store,manager}.go`): the new completion signal.
+  Validates: closed exactly once after the investigation goroutine fully finishes
+  mutating session state (including the `storePartialResult` fallback), and resolves to
+  an already-closed channel when there's nothing to wait for.
+- **`handleTakeover`** (`internal/kubernautagent/mcp/tools/investigate.go`): wiring — the
+  takeover path now `select`s on the completion signal (bounded only by the existing
+  request `ctx`, already wrapped with `withInactivityCancel`) before reading
+  reconstructed context, closing the race against a real `session.Manager`-driven
+  autonomous investigation goroutine with no new arbitrary timeout.
 
 ### 4.2 Features Not to be Tested
 
@@ -173,9 +185,11 @@ construction (fixed attempt budget) and proven by `UT-KA-2155-002`.
 
 | Decision | Rationale |
 |----------|-----------|
-| Retry only in `handleTakeover`, not inside `storeReconstructedContext` itself | Keeps the latency cost scoped to the one call site actually exposed to the race; `handleStart`/`discover_workflows` callers would pay for a race they can't hit |
-| Fixed attempt budget (5 × 100ms = 400ms) instead of a context-deadline-based loop | Simple, predictable worst case; identical to the `main` fix, kept unchanged for port parity |
-| Deterministic IT reproduction via a goroutine that closes an unblock channel exactly 50ms after the investigation reaches `StatusRunning`, ahead of `tool.Handle`'s synchronous takeover call | Avoids a flaky sleep-based test in either direction: pre-fix, the single immediate read always loses (read happens in low single-digit ms); post-fix, the second retry attempt (~100–105ms in) always wins (write lands at ~50ms) |
+| A real completion signal (`done chan struct{}` on `Session`) instead of a fixed retry/sleep schedule | The fixed retry (v1.0 of this plan) had no principled bound — 5×100ms was a guess, not a measurement — and unconditionally taxed the "no prior investigation" case with the full budget (proven by the retired `UT-KA-2155-002`, which asserted all 5 attempts were burned in exactly that case). A channel close/receive is a real Go memory-model happens-before guarantee: `handleTakeover` observes the investigation goroutine's state exactly when it's actually safe to, never more and never less. |
+| `done` closed via `defer` registered first (so it runs last, per Go's LIFO defer order) in the investigation goroutine | Guarantees `close(done)` fires only after every other deferred cleanup in that goroutine (`recoverPanic`, which itself calls `Store.Update` on panic) has completed — so `done` firing is a true "fully finished mutating state" signal, not just "the happy path returned" |
+| `WaitForCompletionByRemediationID` (looked up by remediation ID, re-scanning the store) rather than threading a specific session ID through `TransitionToUserDriving`'s return value | Mirrors the existing `GetLatestRCASummaryByRemediationID` "latest session for this RR" lookup pattern already used by the same code path; handles both the `TransitionToUserDriving` and `ForceTransitionToUserDriving` (terminal-session force-through) cases uniformly without new interface surface on those methods |
+| Bounded only by the existing request `ctx` (already carries the inactivity-cancel wrapper, #1949) — no new timeout constant introduced | The investigation goroutine's own runtime is already bounded upstream by `ToolCallTimeout`/LLM `TimeoutSeconds`, so it cannot hang forever underneath the wait; inventing a second, shorter arbitrary timeout here would just reintroduce the same "how do we know it's enough" problem this design replaces |
+| Deterministic IT reproduction via a goroutine that closes an unblock channel exactly 50ms after the investigation reaches `StatusRunning`, ahead of `tool.Handle`'s synchronous takeover call | Avoids a flaky sleep-based test in either direction: pre-fix, the single immediate read always loses (read happens in low single-digit ms); post-fix, the wait resolves the instant the real `done` channel closes (~50ms in, when the gate releases), regardless of exact scheduling jitter |
 
 ---
 
@@ -183,10 +197,12 @@ construction (fixed attempt budget) and proven by `UT-KA-2155-002`.
 
 ### 5.1 Coverage Policy
 
-- **Unit**: 100% of the new retry decision logic (`storeReconstructedContextWithRetry`):
-  succeed-on-retry, exhaust-budget, cancel-aborts-early.
+- **Unit**: 100% of the new wait decision logic in `handleTakeover`: waits for the signal
+  before reading, adds no latency when there's nothing to wait for, aborts immediately on
+  context cancellation. Plus `go test -race` coverage of `Session.done`'s lifecycle.
 - **Integration**: the real race, through the real production entry point
-  (`InvestigateTool.Handle` → `handleTakeover`), against a real `session.Manager`.
+  (`InvestigateTool.Handle` → `handleTakeover`), against a real `session.Manager` and its
+  real `WaitForCompletionByRemediationID` implementation (not a mocked channel).
 - **E2E**: no new E2E test added — same rationale as `main`: the equivalent
   `test/e2e/fullpipeline/10_interactive_investigation_test.go` journey already exercises
   this code path end-to-end; a `release/v1.5`-specific occurrence of the flake was not
@@ -201,7 +217,7 @@ UT (logic) + IT (wiring) — both present. See Section 8.
 The business outcome under test is: "when a user takes over an autonomous investigation
 that finishes moments after the takeover's status transition, the interactive session
 still has that investigation's context available for its first `discover_workflows`/message
-turn" — not merely "the retry function was called."
+turn" — not merely "the completion signal was awaited."
 
 ### 5.4 Pass/Fail Criteria
 
@@ -224,13 +240,15 @@ turn" — not merely "the retry function was called."
 
 | File | Functions/Methods | Lines (approx) |
 |------|-------------------|-----------------|
-| `internal/kubernautagent/mcp/tools/investigate.go` | `storeReconstructedContextWithRetry` | ~25 |
+| `internal/kubernautagent/mcp/tools/investigate.go` | `handleTakeover` (wait-on-signal call site) | ~8 |
+| `internal/kubernautagent/session/manager.go` | `WaitForCompletionByRemediationID` | ~25 |
 
 ### 6.2 Integration-Testable Code
 
 | File | Functions/Methods | Lines (approx) |
 |------|-------------------|-----------------|
-| `internal/kubernautagent/mcp/tools/investigate.go` | `handleTakeover` (call-site change) | ~1 |
+| `internal/kubernautagent/session/manager.go` | `launchInvestigation` (`done` channel creation/close wiring) | ~10 |
+| `internal/kubernautagent/mcp/tools/investigate.go` | `handleTakeover` → `Manager.WaitForCompletionByRemediationID` (real end-to-end wiring) | ~8 |
 
 ---
 
@@ -238,11 +256,11 @@ turn" — not merely "the retry function was called."
 
 | BR ID | Description | Priority | Tier | Test ID | Status |
 |-------|-------------|----------|------|---------|--------|
-| BR-INTERACTIVE-010 | Context reconstruction on takeover must observe a same-moment-completing investigation, not just an already-completed one | P0 | Unit | UT-KA-2155-001 | Pass |
-| BR-INTERACTIVE-010 | Retry must not run forever when there is genuinely no prior investigation | P1 | Unit | UT-KA-2155-002 | Pass |
-| BR-KA-267 / #1949 | Retry must honor session-inactivity cascade cancellation | P1 | Unit | UT-KA-2155-003 | Pass |
-| BR-INTERACTIVE-010 SC-3 | End-to-end: takeover through the real production entry point must not lose context to this race | P0 | Integration | IT-KA-2155-001 | Pass |
-| AU-2, CC8.1 (audit identity attribution, per `AUDIT_EVENT_CATALOG.md`) | `aiagent.interactive.started`'s `session_id`/`acting_user` attribution must remain correct regardless of reconstruction retry outcome | P1 | Unit | UT-KA-2155-AUDIT-001 | Pass |
+| BR-INTERACTIVE-010 | Context reconstruction on takeover must wait for a same-moment-completing investigation's real completion signal, not just read an already-completed one | P0 | Unit | UT-KA-2155-001 | Pass |
+| BR-INTERACTIVE-010 | Waiting must add no latency when there is genuinely no prior investigation to wait for | P1 | Unit | UT-KA-2155-002 | Pass |
+| BR-KA-267 / #1949 | The wait must honor session-inactivity cascade cancellation | P1 | Unit | UT-KA-2155-003 | Pass |
+| BR-INTERACTIVE-010 SC-3 | End-to-end: takeover through the real production entry point, against a real `session.Manager`'s real completion signal, must not lose context to this race | P0 | Integration | IT-KA-2155-001 | Pass |
+| AU-2, CC8.1 (audit identity attribution, per `AUDIT_EVENT_CATALOG.md`) | `aiagent.interactive.started`'s `session_id`/`acting_user` attribution must remain correct regardless of how long the wait for the completion signal takes | P1 | Unit | UT-KA-2155-AUDIT-001 | Pass |
 
 ---
 
@@ -254,15 +272,15 @@ turn" — not merely "the retry function was called."
 
 | ID | Business Outcome Under Test | Phase |
 |----|----------------------------|-------|
-| `UT-KA-2155-001` | Retry observes a delayed result once it lands, instead of giving up on the first empty read | Pass |
-| `UT-KA-2155-002` | Retry gives up after exactly the configured attempt budget when there is genuinely no result | Pass |
-| `UT-KA-2155-003` | Retry aborts immediately (not after the full budget) when the context is already cancelled | Pass |
+| `UT-KA-2155-001` | Takeover waits for the completion signal to fire before reading, and returns the turns that landed by then, instead of reading too early | Pass |
+| `UT-KA-2155-002` | Takeover adds no latency when there is nothing to wait for (a genuinely empty investigation history still resolves to 0, but fast) | Pass |
+| `UT-KA-2155-003` | Takeover aborts the wait immediately (not after any fixed budget) when the context is already cancelled | Pass |
 
 **File**: `internal/kubernautagent/mcp/tools/takeover_test.go`
 
 | ID | Business Outcome Under Test | Phase |
 |----|----------------------------|-------|
-| `UT-KA-2155-AUDIT-001` | The AU-2/CC8.1-mapped `aiagent.interactive.started` audit event keeps correct `session_id`/`acting_user`/`correlation_id` attribution even while the reconstruction retry is still running underneath it | Pass |
+| `UT-KA-2155-AUDIT-001` | The AU-2/CC8.1-mapped `aiagent.interactive.started` audit event keeps correct `session_id`/`acting_user`/`correlation_id` attribution even while the takeover is still waiting on the completion signal | Pass |
 
 ### Tier 2: Integration Tests
 
@@ -270,7 +288,7 @@ turn" — not merely "the retry function was called."
 
 | ID | Business Outcome Under Test | Phase |
 |----|----------------------------|-------|
-| `IT-KA-2155-001` | A takeover whose target investigation completes 50ms after the status transition still reports >=1 reconstructed turn, through the real `InvestigateTool.Handle` → `handleTakeover` → real `session.Manager` path | Pass |
+| `IT-KA-2155-001` | A takeover whose target investigation completes 50ms after the status transition still reports >=1 reconstructed turn, through the real `InvestigateTool.Handle` → `handleTakeover` → real `session.Manager.WaitForCompletionByRemediationID` path (real completion signal, not mocked) | Pass |
 
 ### Tier Skip Rationale
 
@@ -299,8 +317,11 @@ turn" — not merely "the retry function was called."
 4. **Then**: the response's `Response` field matches `[1-9]\d* prior turns reconstructed`
    (not `0 prior turns reconstructed`).
 
-**Port verification result**: passes in 0.109s, confirmed 2026-08-15 against
-`release/v1.5` (`fix/2156-takeover-reconstruction-race`), 1 of 104 specs, SUCCESS.
+**Verification result**: passes in 0.055s (v2.0, completion-signal design), confirmed
+2026-08-15 against `release/v1.5` (`fix/2156-takeover-reconstruction-race`), 1 of 104
+specs, SUCCESS. (v1.0's fixed-retry design passed in 0.109s on the same test — the v2.0
+design is faster here because it resolves the instant the real signal fires (~50ms, the
+gate delay) rather than on the next 100ms-aligned retry tick after it.)
 
 **Dependencies**: envtest (Leases), Podman (PostgreSQL/Redis/DataStorage + Mock LLM containers).
 
@@ -312,7 +333,7 @@ turn" — not merely "the retry function was called."
 
 - **Framework**: Ginkgo/Gomega BDD
 - **Location**: `internal/kubernautagent/mcp/tools/reconstruction_test.go`
-- **Mocks**: `delayedReconstructor` (in-package test double controlling per-call turn availability) — the only "external dependency" being simulated is the DS-backed audit reconstruction call
+- **Mocks**: `interactiveAutoMgr.waitCh` / `takeoverAutoMgr.waitCh` (in-package test double fields exposing a controllable channel for `WaitForCompletionByRemediationID`) and `mockContextReconstructor` (DS-backed audit reconstruction call stub)
 
 ### 10.2 Integration Tests
 
@@ -330,17 +351,30 @@ None — self-contained port of the `main` fix, scoped to `internal/kubernautage
 
 ### 11.2 Execution Order
 
-1. **Phase 1**: ported `storeReconstructedContextWithRetry` + constants into
-   `investigate.go` (consolidated equivalent of `main`'s `investigate_autonomous.go`).
-2. **Phase 2**: updated `handleTakeover`'s call site in the same file (consolidated
-   equivalent of `main`'s `investigate_takeover.go`).
-3. **Phase 3**: ported `UT-KA-2155-001/002/003`, `UT-KA-2155-AUDIT-001`, and
-   `IT-KA-2155-001`, adapting only to the diverged test-double signatures already present
-   on `release/v1.5` (e.g. `newReconSessionMgr` returning a tuple).
-4. **Phase 4 (REFACTOR)**: N/A — direct logic port, no follow-up cleanup needed.
-5. **Phase 5 (VERIFY)**: `go build ./...`, `go vet ./internal/kubernautagent/...`,
-   `golangci-lint run`, unit suite (232/232 pass), and `IT-KA-2155-001` run locally against
-   real envtest + Podman infrastructure (pass).
+1. **Phase 1 (v1.0, retired)**: ported `main`'s fixed 5×100ms retry design
+   (`storeReconstructedContextWithRetry`) into `investigate.go`.
+2. **Phase 2 (v2.0, current)**: replaced the retry design after review flagged it as an
+   unfounded/arbitrary bound (see §16):
+   - Added `done chan struct{}` to `session.Session` (`store.go`), closed exactly once by
+     the investigation goroutine's own deferred cleanup (`manager.go`
+     `launchInvestigation`).
+   - Added `Manager.WaitForCompletionByRemediationID` (`manager.go`).
+   - Added `WaitForCompletionByRemediationID` to the `AutonomousSessionManager` interface
+     and every test double implementing it.
+   - Updated `handleTakeover` to `select` on the completion signal (bounded only by the
+     existing request `ctx`) instead of retrying on a fixed schedule; removed
+     `storeReconstructedContextWithRetry` and its constants entirely.
+3. **Phase 3**: rewrote `UT-KA-2155-001/002/003` and `UT-KA-2155-AUDIT-001` against the
+   new wait-based behavior (via `Handle(ActionTakeover)` + a controllable `waitCh`
+   test-double field, rather than testing a removed retry helper directly); `IT-KA-2155-001`
+   required only a doc-comment update — it already exercised the real production entry
+   point end to end, and now exercises the real completion signal too.
+4. **Phase 4 (REFACTOR)**: N/A — this was a targeted redesign of the fix itself in
+   response to review feedback, not a refactor of otherwise-complete GREEN-phase code.
+5. **Phase 5 (VERIFY)**: `go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues),
+   `go test -race ./internal/kubernautagent/mcp/tools/... ./internal/kubernautagent/session/...`
+   (pass), and `IT-KA-2155-001` run locally against real envtest + Podman infrastructure
+   (pass, 0.055s).
 
 ---
 
@@ -352,7 +386,7 @@ None — self-contained port of the `main` fix, scoped to `internal/kubernautage
 | Unit tests | `internal/kubernautagent/mcp/tools/reconstruction_test.go` | UT-KA-2155-001/002/003 |
 | Unit test (compliance) | `internal/kubernautagent/mcp/tools/takeover_test.go` | UT-KA-2155-AUDIT-001 |
 | Integration test | `test/integration/kubernautagent/mcp/takeover_test.go` | IT-KA-2155-001 |
-| Fix | `internal/kubernautagent/mcp/tools/investigate.go`, `export_test.go` | `storeReconstructedContextWithRetry` + call-site update |
+| Fix | `internal/kubernautagent/session/store.go`, `manager.go`; `internal/kubernautagent/mcp/tools/investigate.go`, `export_test.go` | `Session.done`, `Manager.WaitForCompletionByRemediationID`, `handleTakeover` call-site update |
 
 ---
 
@@ -378,7 +412,8 @@ golangci-lint run --timeout=5m ./internal/kubernautagent/mcp/tools/... ./test/in
 
 | Code Path | Entry Point | Exit Point | Wiring IT | Status |
 |-----------|-------------|------------|-----------|--------|
-| `storeReconstructedContextWithRetry` | `InvestigateTool.Handle(ActionTakeover)` (MCP tool call) | `InvestigateOutput.Response` ("N prior turns reconstructed") | `IT-KA-2155-001` | Pass |
+| `Manager.WaitForCompletionByRemediationID` | `InvestigateTool.Handle(ActionTakeover)` (MCP tool call) → `handleTakeover`'s `select` | `InvestigateOutput.Response` ("N prior turns reconstructed") | `IT-KA-2155-001` | Pass |
+| `Session.done` close (`launchInvestigation`'s deferred cleanup) | Investigation goroutine completion (success, failure, or panic) | Unblocks the `select` above via channel close | `IT-KA-2155-001` | Pass |
 
 ---
 
@@ -395,4 +430,5 @@ investigation's completion.
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 1.0 | 2026-08-15 | Initial test plan, porting the `main` fix (#2155, PR #2157) to `release/v1.5` as #2156 |
+| 1.0 | 2026-08-15 | Initial test plan, porting the `main` fix (#2155, PR #2157) to `release/v1.5` as #2156. Design: fixed 5×100ms retry budget on `handleTakeover`'s reconstruction read. |
+| 2.0 | 2026-08-15 | **Design replaced** following review feedback that the fixed retry budget was arbitrary and did not actually solve the underlying synchronization problem: (1) it had no principled bound — 5×100ms was a guess, not derived from any measurement of how long the goroutine's own state-mutation could take; (2) it proved the "genuinely no prior investigation" case unconditionally paid the *entire* 400ms budget (the retired `UT-KA-2155-002` asserted exactly this), directly contradicting the v1.0 code comment's claim that this case "still returns on the first attempt." Replaced with a real completion signal: `session.Session` gained a `done chan struct{}`, closed exactly once by the investigation goroutine's own deferred cleanup only after it fully finishes mutating state (including the `storePartialResult` fallback). `handleTakeover` now `select`s on `Manager.WaitForCompletionByRemediationID(rrID)` (bounded only by the existing request `ctx`, no new arbitrary timeout) instead of retrying on a schedule. This closes the same race deterministically (a Go memory-model happens-before guarantee) rather than probabilistically, and eliminates the latency tax on the empty-history case entirely. Applies to both this `release/v1.5` port and the `main` fix (#2155/PR #2157), which is being fixed forward in a follow-up PR. |

--- a/docs/testing/2156/TEST_PLAN.md
+++ b/docs/testing/2156/TEST_PLAN.md
@@ -1,0 +1,398 @@
+# Test Plan: Takeover races ahead of a still-finishing autonomous investigation
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-2156-v1.0
+**Feature**: Bound-retry context reconstruction on takeover to close the race between
+`TransitionToUserDriving`'s synchronous status flip and the autonomous investigation
+goroutine's own (slightly later) result write.
+**Version**: 1.0
+**Created**: 2026-08-15
+**Author**: AI agent (Cursor) + jgil
+**Status**: Complete
+**Branch**: `fix/2156-takeover-reconstruction-race`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This is the `release/v1.5` / v1.5.7 port of the `main` fix for issue
+[#2155](https://github.com/jordigilh/kubernaut/issues/2155), tracked here as
+[#2156](https://github.com/jordigilh/kubernaut/issues/2156) (v1.5.7 clone). See
+[`main`'s `docs/testing/2155/TEST_PLAN.md`](https://github.com/jordigilh/kubernaut/blob/main/docs/testing/2155/TEST_PLAN.md)
+(PR [#2157](https://github.com/jordigilh/kubernaut/pull/2157)) for the original RCA and
+RED→GREEN sequence; this document records the port to `release/v1.5`'s diverged code
+layout (the takeover/autonomous logic that lives in separate
+`investigate_takeover.go`/`investigate_autonomous.go` files on `main` is consolidated
+into a single `investigate.go` on `release/v1.5`).
+
+`E2E-1293-006` (`test/e2e/fullpipeline/10_interactive_investigation_test.go`) intermittently
+failed in CI on `main` with "0 prior turns reconstructed" during interactive takeover
+(https://github.com/jordigilh/kubernaut/actions/runs/31883551415/job/95012656186?pr=2153).
+RCA (captured in issue #2155) identified a race: `handleTakeover`
+(`internal/kubernautagent/mcp/tools/investigate.go` on `release/v1.5`) calls
+`TransitionToUserDriving`/`ForceTransitionToUserDriving`, which synchronously cancels the
+in-flight autonomous investigation's context and flips its session status to
+`user_driving` — then, in the very next lines, reads context via
+`storeReconstructedContext`. If the investigation goroutine had already produced a valid
+result and only needed a few more milliseconds to land it via `storePartialResult`
+(`internal/kubernautagent/session/manager.go` `handleInvestigationSuccess`), the
+immediate read observes zero turns even though the investigation succeeded moments
+later. This is architecturally distinct from the #1425 fix (which protects the *stored
+result* itself via `Store.SetResult`'s first-write-wins) because `TransitionToUserDriving`
+bypasses `Store.Update` and thus the deterministic-ordering guarantee `Store.Update`
+provides; the race is in `handleTakeover`'s *own read*, not in whether the result is
+eventually stored at all. The same race exists on `release/v1.5`: the relevant code
+(`handleTakeover`, `storeReconstructedContext`, `TransitionToUserDriving`, `Store.Update`,
+`Store.SetResult`) and the failing test (`E2E-1293-006`) are architecturally identical on
+both branches, even though it had not yet manifested as an observed CI failure on
+`release/v1.5` at the time of this port.
+
+This plan documents the port of the RED→GREEN TDD sequence used on `main` to reproduce
+the race deterministically and close it with the same short bounded retry.
+
+### 1.2 Objectives
+
+1. **Deterministic reproduction**: an integration test forces the investigation's
+   result-write to land strictly *after* takeover's status transition and strictly
+   *before* the retry budget is exhausted, so the test is not a timing-dependent flake
+   in either direction.
+2. **Bounded fix**: the retry adds no latency on the common path (result already
+   present, or a genuinely fresh investigation with no history) and caps worst-case
+   added latency at `reconstructionRetryAttempts * reconstructionRetryInterval` (400ms)
+   only in the narrow race window.
+3. **Scoped blast radius**: only `handleTakeover`'s call site is changed.
+   `handleStart` (fresh session, no result to race against) and
+   `discover_workflows` (called well after the user's first interactive message, by
+   which point the race window has closed) are unaffected.
+4. **Compliance-control regression check**: prove the one FedRAMP/SOC2-mapped audit
+   event on this code path (`aiagent.interactive.started`, AU-2/CC8.1 per
+   `docs/services/stateless/kubernaut-agent/security/AUDIT_EVENT_CATALOG.md`) keeps its
+   correct `session_id`/`acting_user` attribution regardless of how many reconstruction
+   retry attempts run underneath it.
+
+### 1.4 FedRAMP/SOC2 Control Objective Assessment (ported from `main`, see §16)
+
+**Finding**: this bug and its fix are **not** tied to any documented FedRAMP/SOC2 control
+objective for audit-completeness. `BR-INTERACTIVE-010` (the governing BR) contains no
+compliance-control references at all; the design authority for takeover
+(`docs/architecture/decisions/DD-INTERACTIVE-002-dynamic-takeover-model.md`) frames
+context-reconstruction correctness as a **UX** concern ("must feel like joining a Slack
+thread") and a **security** concern distinct from compliance — SEC-TAKEOVER-001,
+preventing "investigation hacking" via poisoned LLM context flowing back into
+autonomous execution. The separate, unrelated "reconstruction" concept that *is*
+CC8.1-mapped (ADR-034: reconstructing a full `RemediationRequest` from the audit trail
+for SOC2 forensic purposes) is unaffected by this bug: the autonomous investigation's
+own audit trail is written independently of whether the *interactive* session's
+in-memory LLM context successfully reloads it, so CC8.1 reconstruction-from-audit-trail
+holds regardless of this race.
+
+The one audit event actually on this code path, `aiagent.interactive.started`
+(AU-2/CC8.1 — user identity attribution for session start, per the audit event catalog),
+is emitted *before* the (possibly retried) reconstruction call and carries no
+reconstruction-count data — so it cannot be corrupted by this race. `UT-KA-2155-AUDIT-001`
+(ported below) proves this explicitly rather than leaving it as an inference from reading
+the call order in `handleTakeover`.
+
+**Conclusion**: no #2141-style audit-schema gap exists here. This is a legitimate
+business-logic/decision-quality bug (an SRE taking over sees an artificially empty
+conversation history) with one adjacent, now-explicitly-tested compliance control
+(AU-2/CC8.1 identity attribution) confirmed unaffected. This assessment holds unchanged
+on the `release/v1.5` port — the same code paths and audit event catalog apply.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./internal/kubernautagent/mcp/tools/... -run TestMCPToolsUnit -args -ginkgo.focus=2155` |
+| Integration test pass rate | 100% | `bin/ginkgo --focus="IT-KA-2155-001" ./test/integration/kubernautagent/mcp/...` |
+| Backward compatibility | 0 regressions | `go test ./internal/kubernautagent/...` |
+| Port parity with `main` | Same fix logic, same test coverage | recorded below |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- BR-INTERACTIVE-010: Interactive takeover context reconstruction
+- Issue #2155: takeover races ahead of a still-finishing autonomous investigation (`main`)
+- Issue #2156: v1.5.7 clone of #2155, ported by this test plan
+- Issue #1425 (prior, related but distinct fix): result preservation through takeover via `Store.SetResult`
+- PR #2157 (`main` fix this plan ports)
+
+### 2.2 Cross-References
+
+- `internal/kubernautagent/session/manager.go` — `handleInvestigationSuccess`, `storePartialResult`
+- `internal/kubernautagent/session/manager_interactive.go` — `TransitionToUserDriving`
+- `test/integration/kubernautagent/mcp/takeover_test.go` — `IT-KA-1425-001` (related, does not cover this race)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Retry adds latency to every takeover, even when there is no race | User-visible slowdown | Low | UT-KA-2155-001/002 | Retry only fires when the first read finds 0 turns; common path (result present or genuinely empty) returns on attempt 1 |
+| R2 | Retry loop ignores session/inactivity cancellation and blocks | Hung takeover call | Low | UT-KA-2155-003 | `select` on `ctx.Done()` between attempts; `handleTakeover` already wraps `ctx` with `withInactivityCancel` (#1949) |
+| R3 | Retry masks a genuine "no prior investigation" case by waiting the full budget every time | Latency regression for the common cold-start case | Medium | UT-KA-2155-002 | Bounded to 5 attempts / 400ms; only `handleTakeover`'s call site retries (not `handleStart`) |
+
+### 3.1 Risk-to-Test Traceability
+
+All three risks (R1–R3) are directly covered: R1/R2 by unit tests exercising the retry
+helper's decision logic and cancellation handling in isolation; R3 is bounded by
+construction (fixed attempt budget) and proven by `UT-KA-2155-002`.
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **`storeReconstructedContextWithRetry`** (`internal/kubernautagent/mcp/tools/investigate.go`
+  on `release/v1.5`, consolidated from `main`'s `investigate_autonomous.go`): bounded-retry
+  wrapper around `storeReconstructedContext`. Validates: retries until a non-zero result
+  appears, gives up after the attempt budget, and aborts immediately on context
+  cancellation.
+- **`handleTakeover`** (same `investigate.go` file, consolidated from `main`'s
+  `investigate_takeover.go`): wiring — the takeover path now calls the retrying wrapper,
+  closing the race against a real `session.Manager`-driven autonomous investigation
+  goroutine.
+
+### 4.2 Features Not to be Tested
+
+- **`handleStart`'s reconstruction call**: unaffected by this fix (return value already
+  discarded there; no prior investigation to race against for a fresh session).
+- **`discover_workflows`' reconstruction call**: unaffected; by the time it runs the user
+  has already exchanged at least one interactive message, so the race window from
+  takeover has long closed.
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Retry only in `handleTakeover`, not inside `storeReconstructedContext` itself | Keeps the latency cost scoped to the one call site actually exposed to the race; `handleStart`/`discover_workflows` callers would pay for a race they can't hit |
+| Fixed attempt budget (5 × 100ms = 400ms) instead of a context-deadline-based loop | Simple, predictable worst case; identical to the `main` fix, kept unchanged for port parity |
+| Deterministic IT reproduction via a goroutine that closes an unblock channel exactly 50ms after the investigation reaches `StatusRunning`, ahead of `tool.Handle`'s synchronous takeover call | Avoids a flaky sleep-based test in either direction: pre-fix, the single immediate read always loses (read happens in low single-digit ms); post-fix, the second retry attempt (~100–105ms in) always wins (write lands at ~50ms) |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: 100% of the new retry decision logic (`storeReconstructedContextWithRetry`):
+  succeed-on-retry, exhaust-budget, cancel-aborts-early.
+- **Integration**: the real race, through the real production entry point
+  (`InvestigateTool.Handle` → `handleTakeover`), against a real `session.Manager`.
+- **E2E**: no new E2E test added — same rationale as `main`: the equivalent
+  `test/e2e/fullpipeline/10_interactive_investigation_test.go` journey already exercises
+  this code path end-to-end; a `release/v1.5`-specific occurrence of the flake was not
+  observed, but the fix closes the same race by construction.
+
+### 5.2 Two-Tier Minimum
+
+UT (logic) + IT (wiring) — both present. See Section 8.
+
+### 5.3 Business Outcome Quality Bar
+
+The business outcome under test is: "when a user takes over an autonomous investigation
+that finishes moments after the takeover's status transition, the interactive session
+still has that investigation's context available for its first `discover_workflows`/message
+turn" — not merely "the retry function was called."
+
+### 5.4 Pass/Fail Criteria
+
+**PASS**:
+1. `UT-KA-2155-001/002/003` all pass.
+2. `IT-KA-2155-001` passes against a real `session.Manager`, reproducing and then
+   closing the exact race ported from `main`.
+3. No regressions: `go build ./...`, `go vet ./internal/kubernautagent/...`, and
+   `golangci-lint run ./internal/kubernautagent/mcp/tools/... ./test/integration/kubernautagent/mcp/...`
+   all clean.
+4. `UT-KA-2155-AUDIT-001` passes, confirming AU-2/CC8.1 attribution is unaffected.
+
+**FAIL**: any of the above not met.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/mcp/tools/investigate.go` | `storeReconstructedContextWithRetry` | ~25 |
+
+### 6.2 Integration-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/mcp/tools/investigate.go` | `handleTakeover` (call-site change) | ~1 |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-INTERACTIVE-010 | Context reconstruction on takeover must observe a same-moment-completing investigation, not just an already-completed one | P0 | Unit | UT-KA-2155-001 | Pass |
+| BR-INTERACTIVE-010 | Retry must not run forever when there is genuinely no prior investigation | P1 | Unit | UT-KA-2155-002 | Pass |
+| BR-KA-267 / #1949 | Retry must honor session-inactivity cascade cancellation | P1 | Unit | UT-KA-2155-003 | Pass |
+| BR-INTERACTIVE-010 SC-3 | End-to-end: takeover through the real production entry point must not lose context to this race | P0 | Integration | IT-KA-2155-001 | Pass |
+| AU-2, CC8.1 (audit identity attribution, per `AUDIT_EVENT_CATALOG.md`) | `aiagent.interactive.started`'s `session_id`/`acting_user` attribution must remain correct regardless of reconstruction retry outcome | P1 | Unit | UT-KA-2155-AUDIT-001 | Pass |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+**File**: `internal/kubernautagent/mcp/tools/reconstruction_test.go`
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-2155-001` | Retry observes a delayed result once it lands, instead of giving up on the first empty read | Pass |
+| `UT-KA-2155-002` | Retry gives up after exactly the configured attempt budget when there is genuinely no result | Pass |
+| `UT-KA-2155-003` | Retry aborts immediately (not after the full budget) when the context is already cancelled | Pass |
+
+**File**: `internal/kubernautagent/mcp/tools/takeover_test.go`
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-2155-AUDIT-001` | The AU-2/CC8.1-mapped `aiagent.interactive.started` audit event keeps correct `session_id`/`acting_user`/`correlation_id` attribution even while the reconstruction retry is still running underneath it | Pass |
+
+### Tier 2: Integration Tests
+
+**File**: `test/integration/kubernautagent/mcp/takeover_test.go`
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-KA-2155-001` | A takeover whose target investigation completes 50ms after the status transition still reports >=1 reconstructed turn, through the real `InvestigateTool.Handle` → `handleTakeover` → real `session.Manager` path | Pass |
+
+### Tier Skip Rationale
+
+- **E2E**: not added as a new test, matching the `main` fix's rationale — the equivalent
+  `test/e2e/fullpipeline/10_interactive_investigation_test.go` journey already covers this
+  exact scenario end-to-end.
+
+---
+
+## 9. Test Cases
+
+### IT-KA-2155-001: Takeover races ahead of a still-finishing autonomous investigation
+
+**BR**: BR-INTERACTIVE-010 SC-3
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/mcp/takeover_test.go`
+
+**Test Steps**:
+1. **Given**: a real `session.Manager`-backed autonomous investigation is `StatusRunning`
+   for `rr-2155-it-001`, blocked on an unbuffered gate channel.
+2. **Given**: a goroutine is scheduled to close the gate exactly 50ms after the
+   investigation reaches `StatusRunning` — i.e., strictly after takeover's status
+   transition fires (which happens synchronously, in low single-digit ms).
+3. **When**: `InvestigateTool.Handle(ActionTakeover)` is called for `rr-2155-it-001`.
+4. **Then**: the response's `Response` field matches `[1-9]\d* prior turns reconstructed`
+   (not `0 prior turns reconstructed`).
+
+**Port verification result**: passes in 0.109s, confirmed 2026-08-15 against
+`release/v1.5` (`fix/2156-takeover-reconstruction-race`), 1 of 104 specs, SUCCESS.
+
+**Dependencies**: envtest (Leases), Podman (PostgreSQL/Redis/DataStorage + Mock LLM containers).
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Location**: `internal/kubernautagent/mcp/tools/reconstruction_test.go`
+- **Mocks**: `delayedReconstructor` (in-package test double controlling per-call turn availability) — the only "external dependency" being simulated is the DS-backed audit reconstruction call
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Infrastructure**: envtest (Lease CRD), Podman (PostgreSQL, Redis, DataStorage, Mock LLM) — reuses the existing `test/integration/kubernautagent/mcp` suite bootstrap
+- **Location**: `test/integration/kubernautagent/mcp/takeover_test.go`
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+None — self-contained port of the `main` fix, scoped to `internal/kubernautagent/mcp/tools`.
+
+### 11.2 Execution Order
+
+1. **Phase 1**: ported `storeReconstructedContextWithRetry` + constants into
+   `investigate.go` (consolidated equivalent of `main`'s `investigate_autonomous.go`).
+2. **Phase 2**: updated `handleTakeover`'s call site in the same file (consolidated
+   equivalent of `main`'s `investigate_takeover.go`).
+3. **Phase 3**: ported `UT-KA-2155-001/002/003`, `UT-KA-2155-AUDIT-001`, and
+   `IT-KA-2155-001`, adapting only to the diverged test-double signatures already present
+   on `release/v1.5` (e.g. `newReconSessionMgr` returning a tuple).
+4. **Phase 4 (REFACTOR)**: N/A — direct logic port, no follow-up cleanup needed.
+5. **Phase 5 (VERIFY)**: `go build ./...`, `go vet ./internal/kubernautagent/...`,
+   `golangci-lint run`, unit suite (232/232 pass), and `IT-KA-2155-001` run locally against
+   real envtest + Podman infrastructure (pass).
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|--------------|
+| This test plan | `docs/testing/2156/TEST_PLAN.md` | Strategy and test design (port of `docs/testing/2155/TEST_PLAN.md`) |
+| Unit tests | `internal/kubernautagent/mcp/tools/reconstruction_test.go` | UT-KA-2155-001/002/003 |
+| Unit test (compliance) | `internal/kubernautagent/mcp/tools/takeover_test.go` | UT-KA-2155-AUDIT-001 |
+| Integration test | `test/integration/kubernautagent/mcp/takeover_test.go` | IT-KA-2155-001 |
+| Fix | `internal/kubernautagent/mcp/tools/investigate.go`, `export_test.go` | `storeReconstructedContextWithRetry` + call-site update |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test ./internal/kubernautagent/mcp/tools/... -run TestMCPToolsUnit -args -ginkgo.focus="2155" -ginkgo.v
+
+# Integration test (requires KUBEBUILDER_ASSETS + Podman)
+export KUBEBUILDER_ASSETS="$(setup-envtest use -p path)"
+ginkgo --focus="IT-KA-2155-001" -v ./test/integration/kubernautagent/mcp/...
+
+# Regression
+go build ./...
+go vet ./internal/kubernautagent/...
+golangci-lint run --timeout=5m ./internal/kubernautagent/mcp/tools/... ./test/integration/kubernautagent/mcp/...
+```
+
+---
+
+## 14. Wiring Verification
+
+| Code Path | Entry Point | Exit Point | Wiring IT | Status |
+|-----------|-------------|------------|-----------|--------|
+| `storeReconstructedContextWithRetry` | `InvestigateTool.Handle(ActionTakeover)` (MCP tool call) | `InvestigateOutput.Response` ("N prior turns reconstructed") | `IT-KA-2155-001` | Pass |
+
+---
+
+## 15. Existing Tests Requiring Updates
+
+None. `IT-KA-1425-001` and `IT-KA-TAKE-001` (same file) continue to pass unmodified —
+they test a different aspect of takeover (result preservation via `Store.SetResult`,
+and basic status transition) and don't race the reconstruction read against the
+investigation's completion.
+
+---
+
+## 16. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-08-15 | Initial test plan, porting the `main` fix (#2155, PR #2157) to `release/v1.5` as #2156 |

--- a/docs/testing/2156/TEST_PLAN.md
+++ b/docs/testing/2156/TEST_PLAN.md
@@ -419,10 +419,14 @@ golangci-lint run --timeout=5m ./internal/kubernautagent/mcp/tools/... ./test/in
 
 ## 15. Existing Tests Requiring Updates
 
-None. `IT-KA-1425-001` and `IT-KA-TAKE-001` (same file) continue to pass unmodified —
-they test a different aspect of takeover (result preservation via `Store.SetResult`,
-and basic status transition) and don't race the reconstruction read against the
-investigation's completion.
+`IT-KA-1425-001` (same file) required a fix (see §16 v2.1): its investigation
+function blocked on an artificial gate channel that ignored `ctx` cancellation,
+which now hangs `handleTakeover`'s wait indefinitely since it legitimately waits
+for the goroutine's real completion signal rather than reading once and moving on.
+Updated to respect `ctx.Done()` like real production `RunFullInvestigation`/LLM
+calls do -- the test's actual assertions (result preserved through takeover,
+`discover_workflows` finds it) are unchanged. `IT-KA-TAKE-001` continues to pass
+unmodified (its investigation function already selects on `ctx.Done()`).
 
 ---
 
@@ -432,3 +436,4 @@ investigation's completion.
 |---------|------|---------|
 | 1.0 | 2026-08-15 | Initial test plan, porting the `main` fix (#2155, PR #2157) to `release/v1.5` as #2156. Design: fixed 5×100ms retry budget on `handleTakeover`'s reconstruction read. |
 | 2.0 | 2026-08-15 | **Design replaced** following review feedback that the fixed retry budget was arbitrary and did not actually solve the underlying synchronization problem: (1) it had no principled bound — 5×100ms was a guess, not derived from any measurement of how long the goroutine's own state-mutation could take; (2) it proved the "genuinely no prior investigation" case unconditionally paid the *entire* 400ms budget (the retired `UT-KA-2155-002` asserted exactly this), directly contradicting the v1.0 code comment's claim that this case "still returns on the first attempt." Replaced with a real completion signal: `session.Session` gained a `done chan struct{}`, closed exactly once by the investigation goroutine's own deferred cleanup only after it fully finishes mutating state (including the `storePartialResult` fallback). `handleTakeover` now `select`s on `Manager.WaitForCompletionByRemediationID(rrID)` (bounded only by the existing request `ctx`, no new arbitrary timeout) instead of retrying on a schedule. This closes the same race deterministically (a Go memory-model happens-before guarantee) rather than probabilistically, and eliminates the latency tax on the empty-history case entirely. Applies to both this `release/v1.5` port and the `main` fix (#2155/PR #2157), which is being fixed forward in a follow-up PR. |
+| 2.1 | 2026-08-15 | **Found and fixed a latent hang exposed by v2.0's design change**: a full-suite run (not just the `IT-KA-2155-001`-focused run recorded in §9) revealed `IT-KA-1425-001` timing out after 3 minutes. Its investigation function blocked on an artificial `gate` channel that ignored `ctx` entirely, so `TransitionToUserDriving`'s cancellation had no way to unblock it — under the v1.0 retry design this didn't matter (a single immediate read just returned 0 and moved on), but under v2.0's real wait-for-completion design, `handleTakeover` now blocks until the goroutine's `done` channel closes, which never happened. Fixed by making the test's investigation function respect `ctx.Done()` (as real production `RunFullInvestigation`/LLM calls do), removing the artificial gate. Full suite (104/104 specs) and `go vet`/`golangci-lint` reconfirmed clean after the fix. |

--- a/internal/kubernautagent/mcp/tools/export_test.go
+++ b/internal/kubernautagent/mcp/tools/export_test.go
@@ -52,14 +52,8 @@ func (t *InvestigateTool) GetReconstructedHistory(rrID string) []LLMMessage {
 	return msgs
 }
 
-// StoreReconstructedContextWithRetry exposes storeReconstructedContextWithRetry
-// for external test packages (#2156, v1.5.7 clone of #2155).
-func (t *InvestigateTool) StoreReconstructedContextWithRetry(ctx context.Context, rrID, sessionID string) int {
-	return t.storeReconstructedContextWithRetry(ctx, rrID, sessionID)
-}
-
-// ReconstructionRetryAttempts exposes reconstructionRetryAttempts for
-// external test packages (#2156, v1.5.7 clone of #2155).
-func ReconstructionRetryAttempts() int {
-	return reconstructionRetryAttempts
+// StoreReconstructedContext exposes storeReconstructedContext for external
+// test packages (#2156, v1.5.7 clone of #2155).
+func (t *InvestigateTool) StoreReconstructedContext(ctx context.Context, rrID, sessionID string) int {
+	return t.storeReconstructedContext(ctx, rrID, sessionID)
 }

--- a/internal/kubernautagent/mcp/tools/export_test.go
+++ b/internal/kubernautagent/mcp/tools/export_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tools
 
 import (
+	"context"
+
 	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
@@ -48,4 +50,16 @@ func (t *InvestigateTool) GetReconstructedHistory(rrID string) []LLMMessage {
 		return nil
 	}
 	return msgs
+}
+
+// StoreReconstructedContextWithRetry exposes storeReconstructedContextWithRetry
+// for external test packages (#2156, v1.5.7 clone of #2155).
+func (t *InvestigateTool) StoreReconstructedContextWithRetry(ctx context.Context, rrID, sessionID string) int {
+	return t.storeReconstructedContextWithRetry(ctx, rrID, sessionID)
+}
+
+// ReconstructionRetryAttempts exposes reconstructionRetryAttempts for
+// external test packages (#2156, v1.5.7 clone of #2155).
+func ReconstructionRetryAttempts() int {
+	return reconstructionRetryAttempts
 }

--- a/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_it_test.go
+++ b/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_it_test.go
@@ -67,6 +67,9 @@ func (m *itFallbackAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string
 func (m *itFallbackAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
 	return nil, false
 }
+func (m *itFallbackAutoMgr) WaitForCompletionByRemediationID(_ string) <-chan struct{} {
+	return mcptools.ClosedChan()
+}
 func (m *itFallbackAutoMgr) StartInvestigation(_ context.Context, _ session.InvestigateFunc, _ map[string]string) (string, error) {
 	m.startCalled.Add(1)
 	return m.startResult, m.startErr

--- a/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_test.go
+++ b/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_test.go
@@ -88,6 +88,9 @@ func (m *fallbackAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, 
 func (m *fallbackAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
 	return m.rcaResult, m.rcaOK
 }
+func (m *fallbackAutoMgr) WaitForCompletionByRemediationID(_ string) <-chan struct{} {
+	return mcptools.ClosedChan()
+}
 func (m *fallbackAutoMgr) StartInvestigation(_ context.Context, fn session.InvestigateFunc, metadata map[string]string) (string, error) {
 	m.startCalled.Add(1)
 	m.mu.Lock()
@@ -145,7 +148,8 @@ func (c *reattachHTTPCompleter) CompleteUserDriving(_ string, _ *katypes.Investi
 func (c *reattachHTTPCompleter) ForceCompleteByRemediationID(_ string, _ *katypes.InvestigationResult) error {
 	return nil
 }
-func (c *reattachHTTPCompleter) PersistPendingDecisionResult(_ string, _ *katypes.InvestigationResult) {}
+func (c *reattachHTTPCompleter) PersistPendingDecisionResult(_ string, _ *katypes.InvestigationResult) {
+}
 
 var _ = Describe("Fix #1440: handleStart robustness — SC-24", func() {
 

--- a/internal/kubernautagent/mcp/tools/interactive_start_test.go
+++ b/internal/kubernautagent/mcp/tools/interactive_start_test.go
@@ -43,6 +43,12 @@ type interactiveAutoMgr struct {
 	pendingOK     bool
 	launchErr     error
 	launchCalled  atomic.Int32
+
+	// waitCh, if set, is returned by WaitForCompletionByRemediationID
+	// (#2155/#2156). nil means "nothing to wait for" -- returns an
+	// already-closed channel, matching the default AutonomousSessionManager
+	// behavior when no investigation is racing the takeover.
+	waitCh chan struct{}
 }
 
 func (m *interactiveAutoMgr) FindByRemediationID(_ string) (string, bool) {
@@ -81,6 +87,13 @@ func (m *interactiveAutoMgr) Subscribe(_ context.Context, _ string) (<-chan sess
 }
 func (m *interactiveAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool) {
 	return "", false
+}
+
+func (m *interactiveAutoMgr) WaitForCompletionByRemediationID(_ string) <-chan struct{} {
+	if m.waitCh != nil {
+		return m.waitCh
+	}
+	return mcptools.ClosedChan()
 }
 func (m *interactiveAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
 	return nil, false
@@ -418,14 +431,14 @@ var _ = Describe("Fix #1452: handleStart prefers AF-provided session ID — BR-I
 // sessionIDTrackingAutoMgr tracks the session ID passed to LaunchDeferredInvestigation
 // and whether FindPendingByRemediationID was called.
 type sessionIDTrackingAutoMgr struct {
-	findResult         string
-	findOK             bool
-	pendingResult      string
-	pendingOK          bool
-	launchOK           bool
-	launchErr          error
-	launchedID         string
-	findPendingCalled  atomic.Int32
+	findResult        string
+	findOK            bool
+	pendingResult     string
+	pendingOK         bool
+	launchOK          bool
+	launchErr         error
+	launchedID        string
+	findPendingCalled atomic.Int32
 }
 
 func (m *sessionIDTrackingAutoMgr) FindByRemediationID(_ string) (string, bool) {
@@ -461,6 +474,9 @@ func (m *sessionIDTrackingAutoMgr) Subscribe(_ context.Context, _ string) (<-cha
 }
 func (m *sessionIDTrackingAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool) {
 	return "", false
+}
+func (m *sessionIDTrackingAutoMgr) WaitForCompletionByRemediationID(_ string) <-chan struct{} {
+	return mcptools.ClosedChan()
 }
 func (m *sessionIDTrackingAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
 	return nil, false
@@ -503,6 +519,9 @@ func (m *upgradeTrackingAutoMgr) FindPendingByRemediationID(_ string) (string, b
 func (m *upgradeTrackingAutoMgr) LaunchDeferredInvestigation(_ string) error { return nil }
 func (m *upgradeTrackingAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool) {
 	return "", false
+}
+func (m *upgradeTrackingAutoMgr) WaitForCompletionByRemediationID(_ string) <-chan struct{} {
+	return mcptools.ClosedChan()
 }
 func (m *upgradeTrackingAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
 	return nil, false

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -33,6 +33,22 @@ import (
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
 
+// #2156 (v1.5.7 clone of #2155): bounds how long handleTakeover retries
+// context reconstruction after an immediate read finds zero turns.
+// TransitionToUserDriving cancels the in-flight autonomous investigation's
+// context and flips its status synchronously, but the investigation
+// goroutine may already have produced a valid result and only need a few
+// more milliseconds to land it via storePartialResult (session/manager.go
+// handleInvestigationSuccess) -- without a retry, a single immediate read
+// loses that race and silently drops the completed investigation's context.
+// 5 attempts * 100ms bounds the worst case at 400ms of added latency, and
+// only in that narrow race window: the common case (result already landed,
+// or genuinely no prior investigation) still returns on the first attempt.
+const (
+	reconstructionRetryAttempts = 5
+	reconstructionRetryInterval = 100 * time.Millisecond
+)
+
 // LLMMessage represents a single conversation message for the investigator.
 type LLMMessage struct {
 	Role    string
@@ -703,7 +719,7 @@ func (t *InvestigateTool) handleTakeover(ctx context.Context, input InvestigateI
 	ctx, cancelInactivity := t.withInactivityCancel(ctx, sess.SessionID)
 	defer cancelInactivity()
 
-	reconCount := t.storeReconstructedContext(ctx, input.RRID, sess.SessionID)
+	reconCount := t.storeReconstructedContextWithRetry(ctx, input.RRID, sess.SessionID)
 	contextSummary := fmt.Sprintf("%d prior turns reconstructed", reconCount)
 
 	return InvestigateOutput{
@@ -1466,6 +1482,33 @@ func (t *InvestigateTool) storeReconstructedContext(ctx context.Context, rrID, s
 	}
 	t.reconHistory.Store(rrID, history)
 	return len(history)
+}
+
+// storeReconstructedContextWithRetry wraps storeReconstructedContext with a
+// short bounded retry when the first attempt finds zero turns (#2156, v1.5.7
+// clone of #2155). See the reconstructionRetryAttempts/Interval doc comment
+// for the race this closes. Only handleTakeover uses this: it is the sole
+// caller exposed to an immediate read racing a takeover's own status
+// transition against the investigation goroutine it just cancelled.
+// handleStart's call has no prior investigation to race against, and
+// investigate_discovery's call happens well after the user has already sent
+// at least one interactive message, by which time the race window has long
+// closed -- retrying there would only add latency without protecting
+// against a real race.
+func (t *InvestigateTool) storeReconstructedContextWithRetry(ctx context.Context, rrID, sessionID string) int {
+	for attempt := 0; ; attempt++ {
+		if count := t.storeReconstructedContext(ctx, rrID, sessionID); count > 0 {
+			return count
+		}
+		if attempt >= reconstructionRetryAttempts-1 {
+			return 0
+		}
+		select {
+		case <-ctx.Done():
+			return 0
+		case <-time.After(reconstructionRetryInterval):
+		}
+	}
 }
 
 // appendConversationTurn appends a user message and the LLM response to

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -33,22 +33,6 @@ import (
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
 
-// #2156 (v1.5.7 clone of #2155): bounds how long handleTakeover retries
-// context reconstruction after an immediate read finds zero turns.
-// TransitionToUserDriving cancels the in-flight autonomous investigation's
-// context and flips its status synchronously, but the investigation
-// goroutine may already have produced a valid result and only need a few
-// more milliseconds to land it via storePartialResult (session/manager.go
-// handleInvestigationSuccess) -- without a retry, a single immediate read
-// loses that race and silently drops the completed investigation's context.
-// 5 attempts * 100ms bounds the worst case at 400ms of added latency, and
-// only in that narrow race window: the common case (result already landed,
-// or genuinely no prior investigation) still returns on the first attempt.
-const (
-	reconstructionRetryAttempts = 5
-	reconstructionRetryInterval = 100 * time.Millisecond
-)
-
 // LLMMessage represents a single conversation message for the investigator.
 type LLMMessage struct {
 	Role    string
@@ -135,6 +119,12 @@ type AutonomousSessionManager interface {
 	LaunchDeferredInvestigation(id string) error
 	// BR-INTERACTIVE-010: Get RCA summary from latest completed session for context reconstruction.
 	GetLatestRCASummaryByRemediationID(rrID string) (string, bool)
+	// #2155/#2156: returns a channel that closes once the latest investigation
+	// goroutine for rrID has fully finished mutating session state, letting
+	// handleTakeover wait deterministically instead of retrying on a fixed
+	// schedule. Always closes eventually (already-closed if there's nothing
+	// to wait for).
+	WaitForCompletionByRemediationID(rrID string) <-chan struct{}
 	// Get full RCA result from latest completed session for workflow discovery.
 	GetLatestRCAResultByRemediationID(rrID string) (*katypes.InvestigationResult, bool)
 
@@ -215,6 +205,23 @@ func (t *InvestigateTool) withInactivityCancel(ctx context.Context, sessionID st
 	}
 }
 
+// closedChan is an already-closed channel shared by no-op
+// WaitForCompletionByRemediationID implementations that have nothing to
+// wait for.
+var closedChan = func() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}()
+
+// ClosedChan returns an already-closed channel. Exported for
+// AutonomousSessionManager implementations (including test doubles outside
+// this package) that have nothing to wait for from
+// WaitForCompletionByRemediationID (#2155/#2156).
+func ClosedChan() <-chan struct{} {
+	return closedChan
+}
+
 // NopAutonomousManager is a no-op implementation for tests that exercise
 // actions unrelated to autonomous session management (start, message, etc.).
 type NopAutonomousManager struct{}
@@ -229,6 +236,9 @@ func (NopAutonomousManager) FindPendingByRemediationID(string) (string, bool)   
 func (NopAutonomousManager) LaunchDeferredInvestigation(string) error                    { return nil }
 func (NopAutonomousManager) GetLatestRCASummaryByRemediationID(string) (string, bool) {
 	return "", false
+}
+func (NopAutonomousManager) WaitForCompletionByRemediationID(string) <-chan struct{} {
+	return closedChan
 }
 func (NopAutonomousManager) GetLatestRCAResultByRemediationID(string) (*katypes.InvestigationResult, bool) {
 	return nil, false
@@ -719,7 +729,15 @@ func (t *InvestigateTool) handleTakeover(ctx context.Context, input InvestigateI
 	ctx, cancelInactivity := t.withInactivityCancel(ctx, sess.SessionID)
 	defer cancelInactivity()
 
-	reconCount := t.storeReconstructedContextWithRetry(ctx, input.RRID, sess.SessionID)
+	// #2155/#2156: wait for the real completion signal (if any investigation
+	// is still finishing for this RR) instead of guessing a retry schedule.
+	// Bounded only by ctx (already carries the inactivity-cancel wrapper
+	// above) -- no new arbitrary timeout invented here.
+	select {
+	case <-t.autoMgr.WaitForCompletionByRemediationID(input.RRID):
+	case <-ctx.Done():
+	}
+	reconCount := t.storeReconstructedContext(ctx, input.RRID, sess.SessionID)
 	contextSummary := fmt.Sprintf("%d prior turns reconstructed", reconCount)
 
 	return InvestigateOutput{
@@ -1482,33 +1500,6 @@ func (t *InvestigateTool) storeReconstructedContext(ctx context.Context, rrID, s
 	}
 	t.reconHistory.Store(rrID, history)
 	return len(history)
-}
-
-// storeReconstructedContextWithRetry wraps storeReconstructedContext with a
-// short bounded retry when the first attempt finds zero turns (#2156, v1.5.7
-// clone of #2155). See the reconstructionRetryAttempts/Interval doc comment
-// for the race this closes. Only handleTakeover uses this: it is the sole
-// caller exposed to an immediate read racing a takeover's own status
-// transition against the investigation goroutine it just cancelled.
-// handleStart's call has no prior investigation to race against, and
-// investigate_discovery's call happens well after the user has already sent
-// at least one interactive message, by which time the race window has long
-// closed -- retrying there would only add latency without protecting
-// against a real race.
-func (t *InvestigateTool) storeReconstructedContextWithRetry(ctx context.Context, rrID, sessionID string) int {
-	for attempt := 0; ; attempt++ {
-		if count := t.storeReconstructedContext(ctx, rrID, sessionID); count > 0 {
-			return count
-		}
-		if attempt >= reconstructionRetryAttempts-1 {
-			return 0
-		}
-		select {
-		case <-ctx.Done():
-			return 0
-		case <-time.After(reconstructionRetryInterval):
-		}
-	}
 }
 
 // appendConversationTurn appends a user message and the LLM response to

--- a/internal/kubernautagent/mcp/tools/reconstruction_test.go
+++ b/internal/kubernautagent/mcp/tools/reconstruction_test.go
@@ -19,7 +19,6 @@ package tools_test
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -202,34 +201,23 @@ var _ = Describe("BR-INTERACTIVE-010: Context reconstruction from audit trail", 
 	})
 })
 
-// delayedReconstructor returns empty turns for the first emptyAttempts
-// calls, then returns the configured turns thereafter (#2156, v1.5.7 clone
-// of #2155): simulates an in-flight autonomous investigation whose result
-// lands a few retry attempts after the takeover's first (immediate)
-// reconstruction read.
-type delayedReconstructor struct {
-	emptyAttempts int32
-	calls         atomic.Int32
-	turns         []mcpinternal.ConversationTurn
-}
+// #2155/#2156: takeover now waits on AutonomousSessionManager.WaitForCompletionByRemediationID
+// (a real completion signal closed by the investigation goroutine itself)
+// instead of retrying context reconstruction on a fixed sleep schedule. The
+// fixed-schedule retry design was replaced because it (a) had no principled
+// bound -- 5x100ms was a guess, not a measurement -- and (b) unconditionally
+// taxed every "genuinely no prior investigation" takeover with its full
+// retry budget (proven by the old UT-KA-2155-002, which asserted all 5
+// attempts were burned in exactly that case).
+var _ = Describe("BR-INTERACTIVE-010 SC-3, #2156 (v1.5.7 clone of #2155): takeover waits for a real completion signal to close the race with a still-finishing autonomous investigation", func() {
 
-func (d *delayedReconstructor) Reconstruct(_ context.Context, _, _ string) ([]mcpinternal.ConversationTurn, error) {
-	n := d.calls.Add(1)
-	if n <= d.emptyAttempts {
-		return nil, nil
-	}
-	return d.turns, nil
-}
-
-var _ = Describe("BR-INTERACTIVE-010 SC-3, #2156 (v1.5.7 clone of #2155): takeover retries context reconstruction to close the race with a still-finishing autonomous investigation", func() {
-
-	Describe("UT-KA-2155-001: reconstruction succeeds on a later retry attempt", func() {
-		It("should return the reconstructed turn count once the delayed result becomes available", func() {
+	Describe("UT-KA-2155-001: takeover waits for the completion signal before reading reconstructed context", func() {
+		It("should not read until the signal fires, then return the turns that landed by then", func() {
 			const rrID = "rr-2155-001"
 			_, sessionMgr := newReconSessionMgr(rrID, "sess-2155-001")
-			autoMgr := &interactiveAutoMgr{}
-			recon := &delayedReconstructor{
-				emptyAttempts: 2, // first 2 calls (initial + 1 retry) find nothing
+			waitCh := make(chan struct{})
+			autoMgr := &interactiveAutoMgr{waitCh: waitCh}
+			recon := &mockContextReconstructor{
 				turns: []mcpinternal.ConversationTurn{
 					{Role: "assistant", Content: "prior RCA landed just after takeover"},
 				},
@@ -237,41 +225,58 @@ var _ = Describe("BR-INTERACTIVE-010 SC-3, #2156 (v1.5.7 clone of #2155): takeov
 			runner := &messagesCapturingInvestigatorRunner{response: "n/a"}
 			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr)
 
-			count := tool.StoreReconstructedContextWithRetry(context.Background(), rrID, "sess-2155-001")
+			const signalDelay = 30 * time.Millisecond
+			go func() {
+				time.Sleep(signalDelay)
+				close(waitCh)
+			}()
 
-			Expect(count).To(Equal(1),
-				"#2156: retry must observe the result once it lands, instead of giving up on the first empty read")
-			Expect(recon.calls.Load()).To(BeNumerically(">=", int32(3)),
-				"must have retried past the 2 empty attempts before succeeding")
+			start := time.Now()
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   rrID,
+				Action: mcptools.ActionTakeover,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			elapsed := time.Since(start)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Response).To(Equal("1 prior turns reconstructed"),
+				"#2156: must read only after the completion signal fires, observing the landed result")
+			Expect(elapsed).To(BeNumerically(">=", signalDelay),
+				"must actually wait for the real signal rather than reading immediately and getting lucky on timing")
 		})
 	})
 
-	Describe("UT-KA-2155-002: reconstruction gives up after exhausting the retry budget", func() {
-		It("should return 0 and stop retrying once the attempt budget is spent", func() {
+	Describe("UT-KA-2155-002: takeover proceeds immediately when there is nothing to wait for", func() {
+		It("should not add any latency for a genuinely empty investigation history", func() {
 			const rrID = "rr-2155-002"
 			_, sessionMgr := newReconSessionMgr(rrID, "sess-2155-002")
-			autoMgr := &interactiveAutoMgr{}
-			recon := &delayedReconstructor{
-				emptyAttempts: 1000, // never produces turns — genuinely no prior investigation
-			}
+			autoMgr := &interactiveAutoMgr{} // default WaitForCompletionByRemediationID: already-closed channel
+			recon := &mockContextReconstructor{}
 			runner := &messagesCapturingInvestigatorRunner{response: "n/a"}
 			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr)
 
-			count := tool.StoreReconstructedContextWithRetry(context.Background(), rrID, "sess-2155-002")
+			start := time.Now()
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   rrID,
+				Action: mcptools.ActionTakeover,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			elapsed := time.Since(start)
 
-			Expect(count).To(Equal(0),
-				"a genuinely empty investigation history must still resolve to 0, not retry forever")
-			Expect(recon.calls.Load()).To(Equal(int32(mcptools.ReconstructionRetryAttempts())),
-				"must stop after exactly the configured attempt budget, bounding worst-case added latency")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Response).To(Equal("0 prior turns reconstructed"),
+				"a genuinely empty investigation history must still resolve to 0")
+			Expect(elapsed).To(BeNumerically("<", 50*time.Millisecond),
+				"#2156: must not pay any fixed retry-budget tax when there's nothing to wait for -- "+
+					"the prior retry-based design unconditionally burned its full 400ms budget in exactly this case")
 		})
 	})
 
-	Describe("UT-KA-2155-003: reconstruction stops retrying when the context is cancelled", func() {
-		It("should return 0 promptly instead of exhausting the full retry budget", func() {
+	Describe("UT-KA-2155-003: takeover stops waiting when the context is cancelled", func() {
+		It("should return promptly instead of blocking on a signal that never fires", func() {
 			const rrID = "rr-2155-003"
 			_, sessionMgr := newReconSessionMgr(rrID, "sess-2155-003")
-			autoMgr := &interactiveAutoMgr{}
-			recon := &delayedReconstructor{emptyAttempts: 1000}
+			autoMgr := &interactiveAutoMgr{waitCh: make(chan struct{})} // never closes
+			recon := &mockContextReconstructor{}
 			runner := &messagesCapturingInvestigatorRunner{response: "n/a"}
 			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr)
 
@@ -279,13 +284,17 @@ var _ = Describe("BR-INTERACTIVE-010 SC-3, #2156 (v1.5.7 clone of #2155): takeov
 			cancel()
 
 			start := time.Now()
-			count := tool.StoreReconstructedContextWithRetry(ctx, rrID, "sess-2155-003")
+			out, err := tool.Handle(ctx, mcptools.InvestigateInput{
+				RRID:   rrID,
+				Action: mcptools.ActionTakeover,
+			}, mcpinternal.UserInfo{Username: "alice"})
 			elapsed := time.Since(start)
 
-			Expect(count).To(Equal(0))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("takeover_started"))
 			Expect(elapsed).To(BeNumerically("<", 100*time.Millisecond),
 				"BR-KA-267/#1949: an already-cancelled context (e.g. inactivity timeout) must abort "+
-					"the retry loop immediately rather than sleeping through the full retry budget")
+					"the wait immediately rather than blocking on a signal that will never fire")
 		})
 	})
 })

--- a/internal/kubernautagent/mcp/tools/reconstruction_test.go
+++ b/internal/kubernautagent/mcp/tools/reconstruction_test.go
@@ -19,6 +19,8 @@ package tools_test
 import (
 	"context"
 	"errors"
+	"sync/atomic"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -196,6 +198,94 @@ var _ = Describe("BR-INTERACTIVE-010: Context reconstruction from audit trail", 
 			Expect(runner.capturedMessages[0]).To(Equal(mcptools.LLMMessage{
 				Role: "user", Content: "start fresh",
 			}))
+		})
+	})
+})
+
+// delayedReconstructor returns empty turns for the first emptyAttempts
+// calls, then returns the configured turns thereafter (#2156, v1.5.7 clone
+// of #2155): simulates an in-flight autonomous investigation whose result
+// lands a few retry attempts after the takeover's first (immediate)
+// reconstruction read.
+type delayedReconstructor struct {
+	emptyAttempts int32
+	calls         atomic.Int32
+	turns         []mcpinternal.ConversationTurn
+}
+
+func (d *delayedReconstructor) Reconstruct(_ context.Context, _, _ string) ([]mcpinternal.ConversationTurn, error) {
+	n := d.calls.Add(1)
+	if n <= d.emptyAttempts {
+		return nil, nil
+	}
+	return d.turns, nil
+}
+
+var _ = Describe("BR-INTERACTIVE-010 SC-3, #2156 (v1.5.7 clone of #2155): takeover retries context reconstruction to close the race with a still-finishing autonomous investigation", func() {
+
+	Describe("UT-KA-2155-001: reconstruction succeeds on a later retry attempt", func() {
+		It("should return the reconstructed turn count once the delayed result becomes available", func() {
+			const rrID = "rr-2155-001"
+			_, sessionMgr := newReconSessionMgr(rrID, "sess-2155-001")
+			autoMgr := &interactiveAutoMgr{}
+			recon := &delayedReconstructor{
+				emptyAttempts: 2, // first 2 calls (initial + 1 retry) find nothing
+				turns: []mcpinternal.ConversationTurn{
+					{Role: "assistant", Content: "prior RCA landed just after takeover"},
+				},
+			}
+			runner := &messagesCapturingInvestigatorRunner{response: "n/a"}
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr)
+
+			count := tool.StoreReconstructedContextWithRetry(context.Background(), rrID, "sess-2155-001")
+
+			Expect(count).To(Equal(1),
+				"#2156: retry must observe the result once it lands, instead of giving up on the first empty read")
+			Expect(recon.calls.Load()).To(BeNumerically(">=", int32(3)),
+				"must have retried past the 2 empty attempts before succeeding")
+		})
+	})
+
+	Describe("UT-KA-2155-002: reconstruction gives up after exhausting the retry budget", func() {
+		It("should return 0 and stop retrying once the attempt budget is spent", func() {
+			const rrID = "rr-2155-002"
+			_, sessionMgr := newReconSessionMgr(rrID, "sess-2155-002")
+			autoMgr := &interactiveAutoMgr{}
+			recon := &delayedReconstructor{
+				emptyAttempts: 1000, // never produces turns — genuinely no prior investigation
+			}
+			runner := &messagesCapturingInvestigatorRunner{response: "n/a"}
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr)
+
+			count := tool.StoreReconstructedContextWithRetry(context.Background(), rrID, "sess-2155-002")
+
+			Expect(count).To(Equal(0),
+				"a genuinely empty investigation history must still resolve to 0, not retry forever")
+			Expect(recon.calls.Load()).To(Equal(int32(mcptools.ReconstructionRetryAttempts())),
+				"must stop after exactly the configured attempt budget, bounding worst-case added latency")
+		})
+	})
+
+	Describe("UT-KA-2155-003: reconstruction stops retrying when the context is cancelled", func() {
+		It("should return 0 promptly instead of exhausting the full retry budget", func() {
+			const rrID = "rr-2155-003"
+			_, sessionMgr := newReconSessionMgr(rrID, "sess-2155-003")
+			autoMgr := &interactiveAutoMgr{}
+			recon := &delayedReconstructor{emptyAttempts: 1000}
+			runner := &messagesCapturingInvestigatorRunner{response: "n/a"}
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			start := time.Now()
+			count := tool.StoreReconstructedContextWithRetry(ctx, rrID, "sess-2155-003")
+			elapsed := time.Since(start)
+
+			Expect(count).To(Equal(0))
+			Expect(elapsed).To(BeNumerically("<", 100*time.Millisecond),
+				"BR-KA-267/#1949: an already-cancelled context (e.g. inactivity timeout) must abort "+
+					"the retry loop immediately rather than sleeping through the full retry budget")
 		})
 	})
 })

--- a/internal/kubernautagent/mcp/tools/status_test.go
+++ b/internal/kubernautagent/mcp/tools/status_test.go
@@ -52,20 +52,29 @@ type statusAutoMgr struct {
 	found bool
 }
 
-func (m *statusAutoMgr) FindByRemediationID(_ string) (string, bool) { return "auto-sess", m.found }
-func (m *statusAutoMgr) CancelInvestigation(_ string) error                              { return nil }
-func (m *statusAutoMgr) SuspendInvestigation(_ string) error                             { return nil }
-func (m *statusAutoMgr) TransitionToUserDriving(_ string, _ string, _ []string) error    { return nil }
-func (m *statusAutoMgr) ForceTransitionToUserDriving(_ string, _ string, _ []string) error { return nil }
-func (m *statusAutoMgr) UpgradeToInteractive(_ string, _ string, _ []string) error         { return nil }
-func (m *statusAutoMgr) FindPendingByRemediationID(_ string) (string, bool)              { return "", false }
-func (m *statusAutoMgr) LaunchDeferredInvestigation(_ string) error                       { return nil }
-func (m *statusAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool)       { return "", false }
+func (m *statusAutoMgr) FindByRemediationID(_ string) (string, bool)                  { return "auto-sess", m.found }
+func (m *statusAutoMgr) CancelInvestigation(_ string) error                           { return nil }
+func (m *statusAutoMgr) SuspendInvestigation(_ string) error                          { return nil }
+func (m *statusAutoMgr) TransitionToUserDriving(_ string, _ string, _ []string) error { return nil }
+func (m *statusAutoMgr) ForceTransitionToUserDriving(_ string, _ string, _ []string) error {
+	return nil
+}
+func (m *statusAutoMgr) UpgradeToInteractive(_ string, _ string, _ []string) error  { return nil }
+func (m *statusAutoMgr) FindPendingByRemediationID(_ string) (string, bool)         { return "", false }
+func (m *statusAutoMgr) LaunchDeferredInvestigation(_ string) error                 { return nil }
+func (m *statusAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool) { return "", false }
+func (m *statusAutoMgr) WaitForCompletionByRemediationID(_ string) <-chan struct{} {
+	return mcptools.ClosedChan()
+}
 func (m *statusAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
 	return nil, false
 }
-func (m *statusAutoMgr) StartInvestigation(_ context.Context, _ session.InvestigateFunc, _ map[string]string) (string, error) { return "", nil }
-func (m *statusAutoMgr) Subscribe(_ context.Context, _ string) (<-chan session.InvestigationEvent, error) { return nil, nil }
+func (m *statusAutoMgr) StartInvestigation(_ context.Context, _ session.InvestigateFunc, _ map[string]string) (string, error) {
+	return "", nil
+}
+func (m *statusAutoMgr) Subscribe(_ context.Context, _ string) (<-chan session.InvestigationEvent, error) {
+	return nil, nil
+}
 func (m *statusAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) { return nil, false }
 func (m *statusAutoMgr) EmitSessionEndedByRR(_, _ string)                      {}
 

--- a/internal/kubernautagent/mcp/tools/takeover_test.go
+++ b/internal/kubernautagent/mcp/tools/takeover_test.go
@@ -575,4 +575,50 @@ var _ = Describe("kubernaut_investigate — Dynamic Takeover (PR4, BR-INTERACTIV
 			Expect(found).To(BeTrue(), "should find aiagent.interactive.completed event with reason=complete_already_released")
 		})
 	})
+
+	// #2156 (v1.5.7 clone of #2155): proves the AU-2/CC8.1-mapped
+	// aiagent.interactive.started audit event
+	// (docs/services/stateless/kubernaut-agent/security/AUDIT_EVENT_CATALOG.md)
+	// is unaffected by the context-reconstruction race the
+	// storeReconstructedContextWithRetry fix closes. emitInteractiveStarted
+	// runs before the (possibly retried) reconstruction call, so its
+	// session_id/acting_user attribution must be correct regardless of how
+	// many reconstruction attempts the retry takes.
+	Describe("UT-KA-2155-AUDIT-001: interactive.started audit (AU-2/CC8.1) is correctly attributed even when reconstruction races", func() {
+		It("should emit aiagent.interactive.started with correct session_id/acting_user while reconstruction is still retrying", func() {
+			auditRecorder := &recordingAuditStore{}
+			delayedRecon := &delayedReconstructor{
+				emptyAttempts: 2, // first 2 reconstruction attempts find nothing — retry must run
+				turns: []mcpinternal.ConversationTurn{
+					{Role: "assistant", Content: "prior RCA landed just after takeover"},
+				},
+			}
+			toolWithAudit := tools.NewInvestigateTool(sessMgr, runner, delayedRecon, autoMgr,
+				tools.WithAuditStore(auditRecorder, logr.Discard()),
+			)
+
+			input := tools.InvestigateInput{
+				RRID:   "rr-001",
+				Action: tools.ActionTakeover,
+			}
+			out, err := toolWithAudit.Handle(ctx, input, testUser)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("takeover_started"))
+			Expect(out.Response).To(MatchRegexp(`[1-9]\d* prior turns reconstructed`),
+				"#2156: retry must have observed the delayed reconstruction result")
+
+			found := false
+			for _, e := range auditRecorder.events {
+				if e.EventType == audit.EventTypeInteractiveStarted {
+					found = true
+					Expect(e.SessionID).To(Equal("interactive-session-456"),
+						"AU-2/CC8.1: interactive.started must carry the correct session_id even though reconstruction retried")
+					Expect(e.ActingUser).To(Equal(testUser.Username),
+						"AU-2/CC8.1: interactive.started must attribute the correct acting_user even though reconstruction retried")
+					Expect(e.CorrelationID).To(Equal("rr-001"))
+				}
+			}
+			Expect(found).To(BeTrue(), "aiagent.interactive.started must be emitted on takeover regardless of reconstruction retry outcome")
+		})
+	})
 })

--- a/internal/kubernautagent/mcp/tools/takeover_test.go
+++ b/internal/kubernautagent/mcp/tools/takeover_test.go
@@ -59,6 +59,11 @@ type takeoverAutoMgr struct {
 	suspendCalled    atomic.Int32
 	transitionCalled atomic.Int32
 	cancelDelay      time.Duration
+
+	// waitCh, if set, is returned by WaitForCompletionByRemediationID
+	// (#2155/#2156). nil means "nothing to wait for" -- returns an
+	// already-closed channel.
+	waitCh chan struct{}
 }
 
 func (m *takeoverAutoMgr) FindByRemediationID(_ string) (string, bool) {
@@ -102,14 +107,26 @@ func (m *takeoverAutoMgr) UpgradeToInteractive(_ string, _ string, _ []string) e
 	return nil
 }
 
-func (m *takeoverAutoMgr) FindPendingByRemediationID(_ string) (string, bool)         { return "", false }
-func (m *takeoverAutoMgr) LaunchDeferredInvestigation(_ string) error                  { return nil }
-func (m *takeoverAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool)  { return "", false }
+func (m *takeoverAutoMgr) FindPendingByRemediationID(_ string) (string, bool) { return "", false }
+func (m *takeoverAutoMgr) LaunchDeferredInvestigation(_ string) error         { return nil }
+func (m *takeoverAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool) {
+	return "", false
+}
+func (m *takeoverAutoMgr) WaitForCompletionByRemediationID(_ string) <-chan struct{} {
+	if m.waitCh != nil {
+		return m.waitCh
+	}
+	return tools.ClosedChan()
+}
 func (m *takeoverAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
 	return nil, false
 }
-func (m *takeoverAutoMgr) StartInvestigation(_ context.Context, _ session.InvestigateFunc, _ map[string]string) (string, error) { return "", nil }
-func (m *takeoverAutoMgr) Subscribe(_ context.Context, _ string) (<-chan session.InvestigationEvent, error) { return nil, nil }
+func (m *takeoverAutoMgr) StartInvestigation(_ context.Context, _ session.InvestigateFunc, _ map[string]string) (string, error) {
+	return "", nil
+}
+func (m *takeoverAutoMgr) Subscribe(_ context.Context, _ string) (<-chan session.InvestigationEvent, error) {
+	return nil, nil
+}
 func (m *takeoverAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) { return nil, false }
 func (m *takeoverAutoMgr) EmitSessionEndedByRR(_, _ string)                      {}
 
@@ -144,12 +161,12 @@ func (m *takeoverSessMgr) TouchActivity(_ string) {}
 
 // recordingToolMetrics captures metric calls for assertion.
 type recordingToolMetrics struct {
-	takeoverOutcomes   []string
-	sessionStarted     int
-	sessionEnded       int
-	leaseContentions   int
-	commandDurations   []float64
-	mu                 sync.Mutex
+	takeoverOutcomes []string
+	sessionStarted   int
+	sessionEnded     int
+	leaseContentions int
+	commandDurations []float64
+	mu               sync.Mutex
 }
 
 func (m *recordingToolMetrics) RecordInteractiveSessionStarted() {
@@ -580,15 +597,20 @@ var _ = Describe("kubernaut_investigate — Dynamic Takeover (PR4, BR-INTERACTIV
 	// aiagent.interactive.started audit event
 	// (docs/services/stateless/kubernaut-agent/security/AUDIT_EVENT_CATALOG.md)
 	// is unaffected by the context-reconstruction race the
-	// storeReconstructedContextWithRetry fix closes. emitInteractiveStarted
-	// runs before the (possibly retried) reconstruction call, so its
+	// WaitForCompletionByRemediationID fix closes. emitInteractiveStarted
+	// runs before the (possibly-waiting) reconstruction call, so its
 	// session_id/acting_user attribution must be correct regardless of how
-	// many reconstruction attempts the retry takes.
-	Describe("UT-KA-2155-AUDIT-001: interactive.started audit (AU-2/CC8.1) is correctly attributed even when reconstruction races", func() {
-		It("should emit aiagent.interactive.started with correct session_id/acting_user while reconstruction is still retrying", func() {
+	// long the wait for the completion signal takes.
+	Describe("UT-KA-2155-AUDIT-001: interactive.started audit (AU-2/CC8.1) is correctly attributed even when reconstruction waits on the completion signal", func() {
+		It("should emit aiagent.interactive.started with correct session_id/acting_user while reconstruction is still waiting", func() {
 			auditRecorder := &recordingAuditStore{}
-			delayedRecon := &delayedReconstructor{
-				emptyAttempts: 2, // first 2 reconstruction attempts find nothing — retry must run
+			waitCh := make(chan struct{})
+			autoMgr.waitCh = waitCh
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				close(waitCh)
+			}()
+			delayedRecon := &takeoverRecon{
 				turns: []mcpinternal.ConversationTurn{
 					{Role: "assistant", Content: "prior RCA landed just after takeover"},
 				},
@@ -605,7 +627,7 @@ var _ = Describe("kubernaut_investigate — Dynamic Takeover (PR4, BR-INTERACTIV
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out.Status).To(Equal("takeover_started"))
 			Expect(out.Response).To(MatchRegexp(`[1-9]\d* prior turns reconstructed`),
-				"#2156: retry must have observed the delayed reconstruction result")
+				"#2156: must have waited for the completion signal before observing the reconstruction result")
 
 			found := false
 			for _, e := range auditRecorder.events {

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -156,6 +156,7 @@ func (m *Manager) StartInvestigationWithContext(ctx context.Context, fn Investig
 // context, lazy sink, emits the started audit event, and spawns the goroutine.
 func (m *Manager) launchInvestigation(ctx context.Context, id string, fn InvestigateFunc, correlationID, signalName, severity string, startExtra []string) (string, error) {
 	bgCtx, cancelFn := context.WithCancel(context.Background())
+	done := make(chan struct{})
 
 	ls := &LazySink{}
 	bgCtx = WithLazySink(bgCtx, ls)
@@ -164,6 +165,7 @@ func (m *Manager) launchInvestigation(ctx context.Context, id string, fn Investi
 	m.store.mu.Lock()
 	sess := m.store.sessions[id]
 	sess.cancel = cancelFn
+	sess.done = done
 	sess.lazySink = ls
 	bgCtx = WithInteractiveUpgrade(bgCtx, sess.interactiveUpgrade)
 	m.logger.Info("launchInvestigation: LazySink attached to session",
@@ -182,6 +184,13 @@ func (m *Manager) launchInvestigation(ctx context.Context, id string, fn Investi
 
 	go func() {
 		start := time.Now()
+		// #2155/#2156: deferred first, so (by Go's LIFO defer order) it runs
+		// LAST -- after recoverPanic and recordSessionMetrics below, and
+		// after every session-state mutation later in this goroutine body
+		// (Store.Update, storePartialResult). done only closes once this
+		// goroutine has fully finished mutating session state, giving
+		// WaitForCompletionByRemediationID a real happens-before signal.
+		defer close(done)
 		defer m.recordSessionMetrics(id, start)
 		defer m.recoverPanic(id, correlationID)
 
@@ -547,6 +556,45 @@ func (m *Manager) FindPendingByRemediationID(rrID string) (string, bool) {
 // if it were real investigation output (#1640).
 func isFallbackSession(sess *Session) bool {
 	return sess.Metadata["mode"] == "interactive_fallback"
+}
+
+// WaitForCompletionByRemediationID returns a channel that closes once the
+// most recent investigation goroutine for the given remediation_id has fully
+// finished mutating session state (including any storePartialResult fallback
+// write). #2155/#2156: this is the synchronization handleTakeover's
+// context-reconstruction read waits on to close the race against a
+// still-finishing autonomous investigation, replacing an earlier
+// fixed-schedule retry loop that had no principled bound and unconditionally
+// taxed every "genuinely no prior investigation" takeover with its full
+// retry budget.
+//
+// Returns an already-closed channel if no session exists for rrID, or if the
+// latest matching session never launched an investigation goroutine (e.g. a
+// StatusPending deferred-interactive session) -- callers can unconditionally
+// select on the result without special-casing "nothing to wait for".
+func (m *Manager) WaitForCompletionByRemediationID(rrID string) <-chan struct{} {
+	m.store.mu.RLock()
+	var latest *Session
+	for _, sess := range m.store.sessions {
+		if sess.Metadata["remediation_id"] != rrID {
+			continue
+		}
+		if latest == nil || sess.CreatedAt.After(latest.CreatedAt) {
+			latest = sess
+		}
+	}
+	var done chan struct{}
+	if latest != nil {
+		done = latest.done
+	}
+	m.store.mu.RUnlock()
+
+	if done == nil {
+		closed := make(chan struct{})
+		close(closed)
+		return closed
+	}
+	return done
 }
 
 // GetLatestRCASummaryByRemediationID returns the RCA summary from the most

--- a/internal/kubernautagent/session/store.go
+++ b/internal/kubernautagent/session/store.go
@@ -60,11 +60,25 @@ type Session struct {
 	Context   SessionContext
 	Metadata  map[string]string // Deprecated: use Context. Retained for backward compat.
 
-	// cancel, eventChan, and lazySink are manager-managed internal fields.
-	// They are NOT part of the public copy surface (clone excludes them).
+	// cancel, done, eventChan, and lazySink are manager-managed internal
+	// fields. They are NOT part of the public copy surface (clone excludes
+	// them).
 	cancel    context.CancelFunc
 	eventChan chan InvestigationEvent
 	lazySink  *LazySink
+
+	// done is closed exactly once, by the investigation goroutine's own
+	// deferred cleanup, after it has fully finished mutating session state
+	// (including the storePartialResult fallback write when its terminal
+	// Store.Update is rejected). #2155/#2156: this gives WaitForCompletionByRemediationID
+	// a real happens-before signal (Go channel close/receive) that a takeover's
+	// context-reconstruction read can wait on, instead of guessing how long
+	// the goroutine might still take to land its result after cancellation --
+	// eliminating both the arbitrary retry/sleep schedule and its side effect
+	// of taxing every "genuinely no prior investigation" takeover with the
+	// full retry budget's worth of latency. nil until the investigation is
+	// actually launched (e.g. a StatusPending deferred-interactive session).
+	done chan struct{}
 
 	// interactiveUpgrade is set by UpgradeToInteractive under store.mu.
 	// Checked by store.Update under the same lock to guarantee deterministic
@@ -190,6 +204,7 @@ func (s *Session) clone() *Session {
 	cp.cancel = nil
 	cp.eventChan = nil
 	cp.lazySink = nil
+	cp.done = nil
 	if s.Metadata != nil {
 		cp.Metadata = make(map[string]string, len(s.Metadata))
 		for k, v := range s.Metadata {

--- a/test/integration/kubernautagent/mcp/golden_path_test.go
+++ b/test/integration/kubernautagent/mcp/golden_path_test.go
@@ -69,8 +69,8 @@ func (r *goldenPathRecon) Reconstruct(_ context.Context, _, _ string) ([]mcpinte
 }
 
 type goldenPathAutoMgr struct {
-	cancelled  bool
-	suspended  bool
+	cancelled bool
+	suspended bool
 }
 
 func (m *goldenPathAutoMgr) FindByRemediationID(_ string) (string, bool) { return "auto-001", true }
@@ -94,9 +94,14 @@ func (m *goldenPathAutoMgr) UpgradeToInteractive(_ string, _ string, _ []string)
 	return nil
 }
 
-func (m *goldenPathAutoMgr) FindPendingByRemediationID(_ string) (string, bool)         { return "", false }
-func (m *goldenPathAutoMgr) LaunchDeferredInvestigation(_ string) error                  { return nil }
-func (m *goldenPathAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool)  { return "", false }
+func (m *goldenPathAutoMgr) FindPendingByRemediationID(_ string) (string, bool) { return "", false }
+func (m *goldenPathAutoMgr) LaunchDeferredInvestigation(_ string) error         { return nil }
+func (m *goldenPathAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool) {
+	return "", false
+}
+func (m *goldenPathAutoMgr) WaitForCompletionByRemediationID(_ string) <-chan struct{} {
+	return mcptools.ClosedChan()
+}
 func (m *goldenPathAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
 	return nil, false
 }
@@ -115,9 +120,9 @@ func (m *goldenPathAutoMgr) EmitSessionEndedByRR(_, _ string) {}
 
 // sessionIDForwardingAutoMgr tracks whether AF-provided SessionID was used for direct lookup.
 type sessionIDForwardingAutoMgr struct {
-	launchOK           bool
-	launchedID         string
-	findPendingCalled  int32
+	launchOK          bool
+	launchedID        string
+	findPendingCalled int32
 }
 
 func (m *sessionIDForwardingAutoMgr) FindByRemediationID(_ string) (string, bool) {
@@ -153,6 +158,9 @@ func (m *sessionIDForwardingAutoMgr) Subscribe(_ context.Context, _ string) (<-c
 }
 func (m *sessionIDForwardingAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool) {
 	return "", false
+}
+func (m *sessionIDForwardingAutoMgr) WaitForCompletionByRemediationID(_ string) <-chan struct{} {
+	return mcptools.ClosedChan()
 }
 func (m *sessionIDForwardingAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
 	return nil, false

--- a/test/integration/kubernautagent/mcp/takeover_test.go
+++ b/test/integration/kubernautagent/mcp/takeover_test.go
@@ -121,6 +121,10 @@ func (m *mockAutoMgrIT) GetLatestRCASummaryByRemediationID(rrID string) (string,
 	return m.mgr.GetLatestRCASummaryByRemediationID(rrID)
 }
 
+func (m *mockAutoMgrIT) WaitForCompletionByRemediationID(rrID string) <-chan struct{} {
+	return m.mgr.WaitForCompletionByRemediationID(rrID)
+}
+
 func (m *mockAutoMgrIT) GetLatestRCAResultByRemediationID(rrID string) (*katypes.InvestigationResult, bool) {
 	return m.mgr.GetLatestRCAResultByRemediationID(rrID)
 }
@@ -504,10 +508,13 @@ var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", 
 	// storeReconstructedContext read can observe 0 turns even though the
 	// investigation succeeds moments later. This test deterministically
 	// forces that ordering (the investigation's result lands 50ms *after*
-	// takeover's status transition fires) and asserts the takeover response
-	// still reports >=1 reconstructed turn.
+	// takeover's status transition fires) and uses the REAL session.Manager
+	// (via mockAutoMgrIT's delegation), so it exercises the real
+	// WaitForCompletionByRemediationID completion signal end to end -- not
+	// just a mocked channel -- asserting the takeover response still
+	// reports >=1 reconstructed turn.
 	// ---------------------------------------------------------------
-	Describe("IT-KA-2155-001: takeover retries context reconstruction when it races ahead of a still-finishing autonomous investigation [BR-INTERACTIVE-010 SC-3]", func() {
+	Describe("IT-KA-2155-001: takeover waits for the real completion signal when it races ahead of a still-finishing autonomous investigation [BR-INTERACTIVE-010 SC-3]", func() {
 		It("should reconstruct at least 1 prior turn even when the investigation's result lands moments after takeover's status transition", func() {
 			nsName := uniqueNamespace("take2155")
 			createNamespace(context.Background(), sharedK8sClient, nsName)

--- a/test/integration/kubernautagent/mcp/takeover_test.go
+++ b/test/integration/kubernautagent/mcp/takeover_test.go
@@ -489,4 +489,77 @@ var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", 
 			GinkgoWriter.Println("SEC-TAKEOVER-001: Takeover abandonment validated — autonomous NOT resumed")
 		})
 	})
+
+	// ---------------------------------------------------------------
+	// IT-KA-2155-001: Takeover races ahead of a still-finishing autonomous
+	// investigation
+	// BR: BR-INTERACTIVE-010 SC-3, #2156 (v1.5.7 clone of #2155)
+	//
+	// Reproduces the CI flake in E2E-1293-006: TransitionToUserDriving
+	// cancels the investigation's context and flips its status
+	// synchronously, but the investigation goroutine may have already
+	// produced a valid result and only needs a few more milliseconds to
+	// land it via storePartialResult (session/manager.go
+	// handleInvestigationSuccess). A single immediate
+	// storeReconstructedContext read can observe 0 turns even though the
+	// investigation succeeds moments later. This test deterministically
+	// forces that ordering (the investigation's result lands 50ms *after*
+	// takeover's status transition fires) and asserts the takeover response
+	// still reports >=1 reconstructed turn.
+	// ---------------------------------------------------------------
+	Describe("IT-KA-2155-001: takeover retries context reconstruction when it races ahead of a still-finishing autonomous investigation [BR-INTERACTIVE-010 SC-3]", func() {
+		It("should reconstruct at least 1 prior turn even when the investigation's result lands moments after takeover's status transition", func() {
+			nsName := uniqueNamespace("take2155")
+			createNamespace(context.Background(), sharedK8sClient, nsName)
+
+			store := session.NewStore(30 * time.Minute)
+			mgr := session.NewManager(store, logr.Discard(), nil, nil)
+			autoMgr := &mockAutoMgrIT{mgr: mgr}
+
+			gate := make(chan struct{})
+			expectedResult := &katypes.InvestigationResult{
+				RCASummary: "Deployment memory-eater OOMKilled",
+			}
+
+			By("Starting an autonomous investigation whose own Chat() call already returned, so it completes successfully once released")
+			autoSessionID, err := mgr.StartInvestigation(context.Background(), func(_ context.Context) (*katypes.InvestigationResult, error) {
+				<-gate
+				return expectedResult, nil
+			}, map[string]string{"remediation_id": "rr-2155-it-001"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := mgr.GetSession(autoSessionID)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}).Should(Equal(session.StatusRunning))
+
+			By("Scheduling the investigation's completion to land 50ms after takeover's status transition")
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				close(gate)
+			}()
+
+			By("Taking over — races the investigation's own result-write against the reconstruction read")
+			logger := logr.Discard()
+			leaseMgr := mcpinternal.NewLeaseSessionManagerConcrete(sharedK8sClient, nsName, logger)
+			runner := &delayedMockRunner{delay: 10 * time.Millisecond, response: "interactive response"}
+			recon := &mockReconIT{}
+			tool := tools.NewInvestigateTool(leaseMgr, runner, recon, autoMgr)
+
+			user := mcpinternal.UserInfo{Username: "sre@example.com"}
+			out, err := tool.Handle(context.Background(), tools.InvestigateInput{
+				RRID:   "rr-2155-it-001",
+				Action: tools.ActionTakeover,
+			}, user)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("takeover_started"))
+			Expect(out.Response).To(MatchRegexp(`[1-9]\d* prior turns reconstructed`),
+				"BR-INTERACTIVE-010 SC-3 / #2156: takeover must retry reconstruction long enough to observe "+
+					"a result the in-flight investigation goroutine lands moments after the status transition, "+
+					"instead of returning a stale '0 prior turns reconstructed' from a single immediate read")
+		})
+	})
 })

--- a/test/integration/kubernautagent/mcp/takeover_test.go
+++ b/test/integration/kubernautagent/mcp/takeover_test.go
@@ -305,6 +305,14 @@ var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", 
 	// investigation goroutine's result is preserved via storePartialResult
 	// (first-write-wins on SetResult), and discover_workflows finds the
 	// stored RCA through the normal preferred path.
+	//
+	// #2156: the investigation function below respects ctx cancellation
+	// (like production RunFullInvestigation/LLM calls do) instead of
+	// blocking on an artificial gate that ignores ctx -- handleTakeover now
+	// legitimately waits for this goroutine's done signal before returning,
+	// so a fn that never observes cancellation would hang the takeover call
+	// itself, which is exactly the scenario CHECKPOINT-worthy production
+	// code must not exhibit.
 	// ---------------------------------------------------------------
 	Describe("IT-KA-1425-001: takeover preserves investigation result, discover_workflows succeeds [SC-24, IR-4(1)]", func() {
 		It("should preserve investigation result through takeover and use it for discover_workflows", func() {
@@ -315,7 +323,6 @@ var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", 
 			mgr := session.NewManager(store, logr.Discard(), nil, nil)
 			autoMgr := &mockAutoMgrIT{mgr: mgr}
 
-			gate := make(chan struct{})
 			expectedResult := &katypes.InvestigationResult{
 				RCASummary: "OOMKilled in api-server deployment",
 				WorkflowID: "restart-pod-v1",
@@ -327,7 +334,7 @@ var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", 
 
 			By("Starting autonomous investigation that returns result on cancellation")
 			autoSessionID, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
-				<-gate
+				<-ctx.Done()
 				return expectedResult, ctx.Err()
 			}, map[string]string{"remediation_id": "rr-1425-it-001"})
 			Expect(err).NotTo(HaveOccurred())
@@ -340,7 +347,7 @@ var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", 
 				return s.Status
 			}).Should(Equal(session.StatusRunning))
 
-			By("Taking over the autonomous investigation (cancels context)")
+			By("Taking over the autonomous investigation (cancels context, waits for the goroutine's completion signal)")
 			logger := logr.Discard()
 			leaseMgr := mcpinternal.NewLeaseSessionManagerConcrete(sharedK8sClient, nsName, logger)
 			runner := &delayedMockRunner{delay: 10 * time.Millisecond, response: "interactive response"}
@@ -361,10 +368,7 @@ var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out.Status).To(Equal("takeover_started"))
 
-			By("Unblocking investigation goroutine (returns result + context.Canceled)")
-			close(gate)
-
-			By("Waiting for investigation result to be stored via storePartialResult")
+			By("Verifying the investigation result was stored via storePartialResult by the time takeover returned")
 			Eventually(func() bool {
 				result, ok := mgr.GetLatestRCAResultByRemediationID("rr-1425-it-001")
 				return ok && result != nil


### PR DESCRIPTION
## Summary

v1.5.7 clone of #2155, porting the fix from #2157 (`main`) to `release/v1.5`.

**Root cause**: `handleTakeover` calls `TransitionToUserDriving`, which synchronously
cancels the in-flight autonomous investigation's context and flips its session status —
then immediately calls `storeReconstructedContext`. If the investigation goroutine had
already produced a valid result and only needed a few more milliseconds to land it, the
immediate read observes zero turns even though the investigation succeeded moments later
(surfaces as "0 prior turns reconstructed").

Ported to `release/v1.5`'s diverged code layout: the fix lives in the consolidated
`internal/kubernautagent/mcp/tools/investigate.go` (on `main` the same logic is split
across `investigate_takeover.go`/`investigate_autonomous.go`).

**Fix (redesigned, superseding the initial retry-based port)**: the first version of this
port used a bounded retry (5×100ms), mirroring the initial `main` fix. That budget was an
arbitrary guess with no principled bound, and unconditionally taxed every "genuinely no
prior investigation" takeover with up to the full 400ms even when there was nothing to
wait for. Replaced with a real completion signal, matching the redesign landed on `main`
in #2157:

- `session.Session` gains a `done chan struct{}`, closed exactly once by the investigation
  goroutine's own deferred cleanup, only after it has fully finished mutating session
  state (including the `storePartialResult` fallback write).
- `session.Manager.WaitForCompletionByRemediationID(rrID)` returns that channel (or an
  already-closed one if there's nothing in flight for that `remediation_id`).
- `handleTakeover` now `select`s on that channel instead of retrying on a fixed schedule,
  bounded only by the existing request context — no new arbitrary timeout invented.

This closes the race deterministically (Go memory-model happens-before guarantee on
channel close/receive) rather than probabilistically, and eliminates the latency tax on
the empty-history path entirely.

Also fixes a latent hang in `IT-KA-1425-001`, discovered while porting: its investigation
function blocked on an artificial `gate` channel that ignored `ctx.Done()`. Harmless under
the old retry design, but deadlocks `handleTakeover`'s new wait indefinitely. Fixed to
respect `ctx.Done()`, matching real production behavior.

Closes #2156.

## Test plan

- `docs/testing/2156/TEST_PLAN.md` — v2.0/v2.1 changelog documents the redesign and the
  `IT-KA-1425-001` hang fix
- `IT-KA-2155-001`: deterministically reproduces the race against a real `session.Manager`.
  RED confirmed failing pre-fix, GREEN confirmed passing post-fix (both designs).
- `UT-KA-2155-001/002/003`: rewritten to exercise `handleTakeover`'s wait behavior (waits
  for the signal; returns immediately when nothing to wait for; aborts promptly on context
  cancellation).
- `UT-KA-2155-AUDIT-001`: AU-2/CC8.1 audit event attribution for
  `aiagent.interactive.started` holds while the wait is in flight.
- [x] `go build ./...`, `go vet ./...` clean
- [x] `golangci-lint run` clean on changed packages
- [x] Full `internal/kubernautagent/...` unit suite green
- [x] Full `test/integration/kubernautagent/mcp/...` suite green, including the
      `IT-KA-1425-001` hang fix