### PR TITLE
fix(e2e/apifrontend): wait for initial Prometheus rollout before restarting it

### DIFF
--- a/test/infrastructure/apifrontend_prometheus_e2e.go
+++ b/test/infrastructure/apifrontend_prometheus_e2e.go
@@ -93,11 +93,21 @@ func DeployPrometheusForSeverityTriage(ctx context.Context, namespace, kubeconfi
 // ReplicaSet is fully available, so a subsequent `kubectl rollout restart`
 // (SeedTriageAlertRules) always starts from a single stable ReplicaSet
 // instead of racing with it (see DeployPrometheusForSeverityTriage RCA above).
+//
+// 120s (not SeedTriageAlertRules's 60s) because, unlike that restart, this is
+// the FIRST rollout: PrometheusImage ("prom/prometheus:latest") is pulled
+// live from Docker Hub here, not preloaded into Kind like the app images
+// (apifrontend/datastorage/mock-llm/kubernautagent) or already cached
+// node-side like SeedTriageAlertRules's restart of the same image. Docker
+// Hub is more prone to registry throttling on shared GH-hosted-runner egress
+// IPs than the ghcr.io pulls elsewhere in this package -- DeployDex's
+// equivalent first-rollout wait for its own external ghcr.io image uses
+// 120s for the same reason (test/infrastructure/dex_e2e.go).
 func waitForPrometheusRollout(ctx context.Context, namespace, kubeconfigPath string, writer io.Writer) error {
 	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath, //nolint:gosec // G204: test infra
 		"rollout", "status", "deployment/prometheus",
 		"-n", namespace,
-		"--timeout=60s")
+		"--timeout=120s")
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 	if err := cmd.Run(); err != nil {

--- a/test/infrastructure/apifrontend_prometheus_e2e.go
+++ b/test/infrastructure/apifrontend_prometheus_e2e.go
@@ -47,6 +47,27 @@ import (
 // This delegates to kubernaut's canonical DeployPrometheus (DD-TEST-001 v2.8)
 // and then patches the rules ConfigMap with AF's triage fixtures.
 //
+// CI RCA (#2182, run 32063443903, job 95495177776): DeployPrometheus's initial
+// `kubectl apply` used to be followed immediately by SeedTriageAlertRules's
+// `kubectl rollout restart`, with no wait for the first rollout to settle.
+// Restarting a Deployment before its first ReplicaSet ever reaches Ready lets
+// Kubernetes' RollingUpdate surge/unavailable budget (both round up to 1 for
+// replicas:1) scale the old AND new ReplicaSet to 1 concurrently -- two
+// Prometheus pods, each with its own empty non-PVC TSDB, briefly answering
+// the same prometheus-svc NodePort. kube-proxy load-balances each new
+// connection independently, so the OTLP metric injections that ground
+// "HighCPU" (test/e2e/apifrontend/e2e_suite_test.go) could land with a
+// genuine 200 OK on the pod about to be torn down -- silently discarding the
+// sample -- while every subsequent rule-state poll only ever reaches the
+// surviving pod, which never received it. That poll then times out after
+// 120s ("HighCPU alert must reach firing state within 120s"), failing
+// SynchronizedBeforeSuite and aborting the whole 204-spec suite before any
+// test runs. Waiting for the initial rollout to be fully Ready before
+// SeedTriageAlertRules restarts it removes the race: only one ReplicaSet is
+// ever "current" when the restart begins, so the rolling update tears down
+// the sole old pod before/as the new one becomes ready, never running both
+// concurrently.
+//
 // Ref: Prometheus OTLP receiver -- https://prometheus.io/docs/guides/opentelemetry/
 func DeployPrometheusForSeverityTriage(ctx context.Context, namespace, kubeconfigPath string, writer io.Writer) error {
 	_, _ = fmt.Fprintln(writer, "Deploying Prometheus for severity triage testing...")
@@ -55,12 +76,33 @@ func DeployPrometheusForSeverityTriage(ctx context.Context, namespace, kubeconfi
 		return fmt.Errorf("deploy Prometheus: %w", err)
 	}
 
+	if err := waitForPrometheusRollout(ctx, namespace, kubeconfigPath, writer); err != nil {
+		return fmt.Errorf("initial Prometheus rollout not ready: %w", err)
+	}
+
 	_, _ = fmt.Fprintln(writer, "Seeding AF severity triage alert rules...")
 
 	if err := SeedTriageAlertRules(ctx, namespace, kubeconfigPath, writer); err != nil {
 		return fmt.Errorf("seed triage alert rules: %w", err)
 	}
 
+	return nil
+}
+
+// waitForPrometheusRollout blocks until the Prometheus Deployment's initial
+// ReplicaSet is fully available, so a subsequent `kubectl rollout restart`
+// (SeedTriageAlertRules) always starts from a single stable ReplicaSet
+// instead of racing with it (see DeployPrometheusForSeverityTriage RCA above).
+func waitForPrometheusRollout(ctx context.Context, namespace, kubeconfigPath string, writer io.Writer) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath, //nolint:gosec // G204: test infra
+		"rollout", "status", "deployment/prometheus",
+		"-n", namespace,
+		"--timeout=60s")
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("prometheus not ready after initial deploy: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #2182. `E2E (apifrontend)` intermittently fails at `SynchronizedBeforeSuite` with `HighCPU alert must reach firing state within 120s`, aborting the whole 204-spec suite before any test runs.

- `DeployPrometheusForSeverityTriage` applied the Prometheus Deployment and then, with no wait, immediately restarted it (`kubectl rollout restart`) to seed AF's triage alert rules ConfigMap.
- Restarting before the first rollout ever reached Ready let Kubernetes' rolling-update surge/unavailable budget (both round to 1 for `replicas: 1`) scale the old and new ReplicaSet to 1 **concurrently** -- confirmed in a failing run's must-gather `events.txt` (two ReplicaSets scaled up at the same timestamp, one killed ~6-8s later).
- Two Prometheus pods, each with its own empty non-PVC TSDB, briefly answered the same NodePort Service. The OTLP metric injection that grounds `HighCPU` could land a genuine `200 OK` on the pod about to be torn down (silently losing the sample), while every later rule-state poll only reached the surviving pod, which never received it -- hence the 120s timeout.
- This is a variant of a previously-fixed bug class (`de02c7603`, which added retries for connection *errors* from stale NodePort routing) that no retry-on-error logic can catch, since the request genuinely succeeds -- just on the wrong, soon-dead pod.

## Fix

Wait for the initial Prometheus rollout to be fully `Ready` (`kubectl rollout status --timeout=60s`) before `SeedTriageAlertRules` restarts it, so only one ReplicaSet is ever "current" when the restart begins.

## Test plan

- [x] `go build ./test/infrastructure/...`
- [x] `golangci-lint run ./test/infrastructure/...` (0 issues)
- [ ] `E2E (apifrontend)` CI job passes on this PR (best available verification -- this is CI test-infrastructure orchestration code with no unit-testable business logic; the fix's efficacy is proven by the CI run itself no longer racing two ReplicaSets)

Full RCA: see #2182.