### PR TITLE
docs(must-gather): document --extra-namespace flag in README

### DIFF
--- a/cmd/must-gather/README.md
+++ b/cmd/must-gather/README.md
@@ -77,7 +77,7 @@ kubectl run kubernaut-must-gather \
 | `--namespace=NS` | `kubernaut-system` | Kubernaut Helm release namespace (CRDs, service pods, DataStorage API) |
 | `--workflow-namespace=NS` | `kubernaut-workflows` | Tekton PipelineRun execution namespace |
 | `--operator-namespace=NS` | `kubernaut-operator-system` | Optional: namespace of the separate [kubernaut-operator](https://github.com/jordigilh/kubernaut-operator) component. Its controller-manager logs are collected only if the namespace actually exists on the cluster -- most installs are Helm-chart-only and won't have it, which is not an error. |
-| `--extra-namespace=NS` | (none) | Additional namespace to collect pod logs from (repeatable). For mesh/gateway infra deployed outside the release/workflow/operator namespaces -- e.g. Kuadrant's `mcp-system`/`gateway-system`/`istio-system`, or Envoy AI Gateway's `envoy-gateway-system`/`envoy-ai-gateway-system`. Each namespace is optional and silently skipped if absent. |
+| `--extra-namespace=NS` | (none) | Additional namespace to collect pod logs from (repeatable). For mesh/gateway infra deployed outside the release/workflow/operator namespaces -- e.g. Kuadrant's `mcp-system`/`gateway-system`/`istio-system`, or Envoy AI Gateway's `envoy-gateway-system`/`envoy-ai-gateway-system`. Same "optional, skip if absent" behavior as `--operator-namespace`: safe to always pass the full set of known mesh/gateway namespaces regardless of which one (if any) is actually installed -- must-gather checks each with `kubectl get namespace` and silently skips whichever don't exist, no need to detect which stack is deployed beforehand. |
 | `--help`, `-h` | - | Show usage information |
 
 ### Examples
@@ -101,8 +101,12 @@ kubectl run kubernaut-must-gather \
 # kubernaut-operator installed into a non-default namespace
 /usr/bin/gather --operator-namespace=my-kubernaut-operator
 
-# Collect pod logs from additional mesh/gateway infra namespaces (repeatable)
-/usr/bin/gather --extra-namespace=istio-system --extra-namespace=mcp-system
+# Collect pod logs from additional mesh/gateway infra namespaces (repeatable).
+# Safe to pass every known namespace up front -- whichever aren't actually
+# deployed on this cluster are silently skipped, no need to check first.
+/usr/bin/gather \
+  --extra-namespace=mcp-system --extra-namespace=gateway-system --extra-namespace=istio-system \
+  --extra-namespace=envoy-gateway-system --extra-namespace=envoy-ai-gateway-system
 ```
 
 ---

--- a/cmd/must-gather/README.md
+++ b/cmd/must-gather/README.md
@@ -77,6 +77,7 @@ kubectl run kubernaut-must-gather \
 | `--namespace=NS` | `kubernaut-system` | Kubernaut Helm release namespace (CRDs, service pods, DataStorage API) |
 | `--workflow-namespace=NS` | `kubernaut-workflows` | Tekton PipelineRun execution namespace |
 | `--operator-namespace=NS` | `kubernaut-operator-system` | Optional: namespace of the separate [kubernaut-operator](https://github.com/jordigilh/kubernaut-operator) component. Its controller-manager logs are collected only if the namespace actually exists on the cluster -- most installs are Helm-chart-only and won't have it, which is not an error. |
+| `--extra-namespace=NS` | (none) | Additional namespace to collect pod logs from (repeatable). For mesh/gateway infra deployed outside the release/workflow/operator namespaces -- e.g. Kuadrant's `mcp-system`/`gateway-system`/`istio-system`, or Envoy AI Gateway's `envoy-gateway-system`/`envoy-ai-gateway-system`. Each namespace is optional and silently skipped if absent. |
 | `--help`, `-h` | - | Show usage information |
 
 ### Examples
@@ -99,6 +100,9 @@ kubectl run kubernaut-must-gather \
 
 # kubernaut-operator installed into a non-default namespace
 /usr/bin/gather --operator-namespace=my-kubernaut-operator
+
+# Collect pod logs from additional mesh/gateway infra namespaces (repeatable)
+/usr/bin/gather --extra-namespace=istio-system --extra-namespace=mcp-system
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Related to #2194 (already closed manually): the README's flags table and examples didn't mention `--extra-namespace`, even though it was implemented, bats-tested, and rolled out to the `fleet`/`fleetmetadatacache`/`eaigw` E2E suites in #2036/#2197. This was the last unmet item on #2194's acceptance criteria checklist.

## Test plan

- Docs-only change; no functional code touched.