### PR TITLE
fix(remediationorchestrator): migrate to shared-envtest + fix BR-ORCH-031 guard gap (#2213)

### DIFF
--- a/docs/architecture/decisions/DD-TEST-010-controller-per-process-architecture.md
+++ b/docs/architecture/decisions/DD-TEST-010-controller-per-process-architecture.md
@@ -510,8 +510,8 @@ go test -race ./test/integration/[service]/...
 | Service | Current Pattern | Migration Status | Priority | Estimated Effort |
 |---------|----------------|------------------|----------|-----------------|
 | **WorkflowExecution** | ✅ Multi-Controller | N/A (reference) | - | 0h (complete) |
-| **AIAnalysis** | ❌ Single-Controller | 🔄 In Progress | P0 | 4-6h |
-| **RemediationOrchestrator** | ❌ Single-Controller | 📋 Planned | P1 | 4-6h |
+| **AIAnalysis** | ❌ Single-Controller | ✅ Migrated (Amendment 1) | P0 | 4-6h |
+| **RemediationOrchestrator** | ✅ Shared-Envtest (Amendment 1) | ✅ Migrated (Amendment 1) | P1 | 4-6h |
 | **SignalProcessing** | ❌ Single-Controller | 📋 Planned | P1 | 4-6h |
 | **Notification** | ❌ Single-Controller | 📋 Planned | P1 | 4-6h |
 | **Gateway** | N/A (no controller) | N/A | - | 0h |
@@ -598,4 +598,54 @@ watchers/namespace assumptions to audit, same as AA's controller cache + KA disp
 explicitly out of scope here; tracked in
 [issue #2213](https://github.com/jordigilh/kubernaut/issues/2213) rather than applied
 mechanically.
+
+### `remediationorchestrator` migrated (2026-08-21, issue #2213)
+
+**Preflight**: `remediationorchestrator`'s pre-migration `suite_test.go` had a *simpler* starting
+point than `aianalysis`'s -- no per-process sidecar container to re-namespace (RO has no equivalent
+of AA's KA dispatcher), and its manager cache already used precise `Cache.ByObject` namespace
+scoping. It ran *two* envtest instances (one for DD-AUTH-014's DataStorage auth bootstrap, one for
+the controller itself); the migration collapsed these to the single shared one Phase 1 already
+started for DataStorage auth, following the exact Phase 1/Phase 2 kubeconfig-serialization pattern
+established for `aianalysis` above (`ROControllerNamespace` const → per-process var, computed as
+`kubernaut-system-p<N>` in Phase 2). A Serena-backed `find_referencing_symbols` audit of all 33
+test files referencing `ROControllerNamespace` confirmed no cross-namespace assumptions (manager
+cache scoping + apiReader server-side filtering make bare `k8sClient.List`/`k8sManager.GetAPIReader()`
+calls namespace-safe under the new per-process-namespace model).
+
+**Validated on `helios08` at `TEST_PROCS=4`**: 141/141 specs green, reproducible across repeated
+runs, after fixing two classes of pre-existing issues the shared-envtest's added apiserver latency
+reliably exposed (neither is a defect in the migration's own `suite_test.go` changes):
+
+1. **Five latent test-synchronization races** (test-only fixes, no production code): three bare
+   `Expect()`s immediately following an `Eventually` on a *sibling* resource, not the field being
+   asserted on next (`override_flow_test.go`, `lifecycle_test.go`, `characterization_integration_test.go`);
+   one forward-reference-before-create ordering bug (`dedup_propagation_integration_test.go`,
+   `IT-RO-190-002`, reordered to create the referent first, mirroring the already-correct
+   `IT-RO-190-001`/`IT-RO-190-003` patterns in the same file -- and, on first attempt, a related
+   Create()-strips-status-subresource mistake in that same reorder, fixed by re-setting `Phase`
+   before the follow-up `Status().Update()`, exactly like those sibling tests already do).
+2. **One genuine production bug**, found (not just exposed) by this migration: `transitionPhase`'s
+   optimistic-concurrency conflict-retry guard (`internal/controller/remediationorchestrator/terminal_transitions.go`)
+   only re-validated `OverallPhase == oldPhase` on retry, not that `WorkflowExecutionRef` (set by an
+   earlier, separate write) was still present. A retry landing after a concurrent
+   status-update-failure recovery (which clears `WorkflowExecutionRef` and reverts `OverallPhase`
+   together -- `IT-RO-189-005`'s scenario, and per its own doc comment, `BR-ORCH-031`'s real-world
+   motivating case) could pass that guard and commit `OverallPhase=Executing` on top of the
+   now-missing ref, which `executing_handler.go` then treated as a permanent, non-retryable
+   "corrupted state" failure -- no timeout could have fixed this, since it doesn't resolve with more
+   waiting. Fixed by also requiring `WorkflowExecutionRef != nil` before committing
+   Advance-to-Executing (requeues instead, giving the Analyzing handler's Get-before-Create
+   idempotency another chance); reproduced deterministically in `UT-AT-013`/`UT-AT-014`
+   (`apply_transition_test.go`), no timing race needed to trigger it.
+
+**Lesson for future migrations under this issue**: budget time for exactly this kind of
+discovery. Shared-envtest's added latency is not just "the same tests, slower" -- it's a more
+sensitive detector for latent assumptions (both test-level ordering assumptions and, in this case,
+a real optimistic-concurrency guard gap) that a fully-isolated-per-process control plane was
+masking by construction (less contention == fewer opportunities for the retry window in question to
+be hit). Do not assume a suite that passes at `TEST_PROCS=1` in isolation is unaffected; validate at
+`TEST_PROCS=4` (matching CI) before declaring a per-service migration done, and treat unexplained
+failures under contention as a signal to keep root-causing rather than reach for a longer timeout
+first.
 

--- a/internal/controller/remediationorchestrator/apply_transition_test.go
+++ b/internal/controller/remediationorchestrator/apply_transition_test.go
@@ -279,6 +279,60 @@ var _ = Describe("Issue #666: ApplyTransition (BR-ORCH-025)", func() {
 	})
 
 	// ========================================
+	// BR-ORCH-031 / Issue #189, #2213: transitionPhase must not commit
+	// Advance-to-Executing without a WorkflowExecutionRef. Root-caused during
+	// the DD-TEST-010 Amendment 1 migration (issue #2213): IT-RO-189-005
+	// simulates a status-update-failure recovery by clearing
+	// WorkflowExecutionRef while reverting OverallPhase back to Analyzing.
+	// transitionPhase's conflict-retry guard only re-validates
+	// OverallPhase == oldPhase, so a retry that observes this reverted (but
+	// self-consistent: ref=nil + phase=Analyzing) state still passes the
+	// guard and commits OverallPhase=Executing on top of the now-missing
+	// ref — producing the "corrupted state: no WorkflowExecutionRef"
+	// terminal failure in executing_handler.go. This is reproducible
+	// deterministically without any timing race: the guard never checked
+	// the ref at all, so a single Advance(Executing) call against an RR
+	// with WorkflowExecutionRef==nil is enough to trigger it.
+	// ========================================
+	Describe("BR-ORCH-031: Advance-to-Executing requires WorkflowExecutionRef", func() {
+
+		It("UT-AT-013: does not commit Executing when WorkflowExecutionRef is missing", func() {
+			rr := newRemediationRequest("test-exec-no-ref", defaultFixture, remediationv1.PhaseAnalyzing)
+			rr.Status.StartTime = ptrMetaTime(time.Now())
+			// WorkflowExecutionRef intentionally left nil — simulates the
+			// IT-RO-189-005 status-update-failure recovery state.
+			c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&remediationv1.RemediationRequest{}).WithObjects(rr).Build()
+			r := newCharReconciler(c, c, scheme, &MockRoutingEngine{})
+
+			intent := phase.Advance(phase.Executing, "WFE created")
+			result, err := r.ApplyTransition(ctx, rr, intent)
+			Expect(err).ToNot(HaveOccurred(), "missing precondition should requeue, not error out")
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0), "should requeue to allow the Analyzing handler to recover the ref")
+			Expect(string(rr.Status.OverallPhase)).To(Equal(string(remediationv1.PhaseAnalyzing)),
+				"must not commit Executing without WorkflowExecutionRef set")
+		})
+
+		It("UT-AT-014: commits Executing normally once WorkflowExecutionRef is set", func() {
+			rr := newRemediationRequest("test-exec-with-ref", defaultFixture, remediationv1.PhaseAnalyzing)
+			rr.Status.StartTime = ptrMetaTime(time.Now())
+			rr.Status.EnsurePhaseProgress().WorkflowExecutionRef = &corev1.ObjectReference{
+				APIVersion: "workflowexecution.kubernaut.ai/v1alpha1",
+				Kind:       "WorkflowExecution",
+				Name:       "we-test-exec-with-ref",
+				Namespace:  defaultFixture,
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&remediationv1.RemediationRequest{}).WithObjects(rr).Build()
+			r := newCharReconciler(c, c, scheme, &MockRoutingEngine{})
+
+			intent := phase.Advance(phase.Executing, "WFE created")
+			result, err := r.ApplyTransition(ctx, rr, intent)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+			Expect(string(rr.Status.OverallPhase)).To(Equal(string(remediationv1.PhaseExecuting)))
+		})
+	})
+
+	// ========================================
 	// ToBlockingCondition mapping
 	// ========================================
 	Describe("ToBlockingCondition mapping", func() {

--- a/internal/controller/remediationorchestrator/terminal_transitions.go
+++ b/internal/controller/remediationorchestrator/terminal_transitions.go
@@ -258,6 +258,21 @@ func (r *Reconciler) transitionPhase(ctx context.Context, rr *remediationv1.Reme
 			return fmt.Errorf("%w: expected %s, got %s", errPhaseConflict,
 				oldPhase, rr.Status.OverallPhase)
 		}
+		// BR-ORCH-031 / Issue #189, #2213: Advance-to-Executing depends on
+		// WorkflowExecutionRef having already been persisted by an earlier,
+		// separate write (CreateWFEAndTransition). The OverallPhase guard
+		// above does not cover this: a conflict-triggered retry re-fetches
+		// fresh state and can observe WorkflowExecutionRef cleared by a
+		// concurrent status-update-failure recovery (IT-RO-189-005) even
+		// though OverallPhase still matches oldPhase (that recovery reverts
+		// both fields together). Without this check, committing Executing
+		// here corrupts the RR into a state executing_handler.go treats as
+		// a permanent, non-retryable failure. Requeueing instead gives the
+		// Analyzing handler's idempotent Get-before-Create another chance
+		// to restore the ref before Executing is committed.
+		if newPhase == phase.Executing && rr.Status.EnsurePhaseProgress().WorkflowExecutionRef == nil {
+			return fmt.Errorf("%w: WorkflowExecutionRef missing for phase %s", errPhaseConflict, newPhase)
+		}
 		r.applyPhaseTransitionFields(rr, newPhase)
 		return nil
 	})

--- a/test/integration/remediationorchestrator/characterization_integration_test.go
+++ b/test/integration/remediationorchestrator/characterization_integration_test.go
@@ -133,6 +133,17 @@ var _ = Describe("Issue #666: Characterization Integration Tests for RO Phase Ha
 		Expect(fetched.Status.EnsureCompletionStatus().FailurePhase).To(HaveValue(Equal(remediationv1.FailurePhaseAIAnalysis)),
 			"FailurePhase should be AIAnalysis")
 
+		By("Waiting for the one-time RetentionExpiryTime backfill (#265) to settle before the idempotency check")
+		// Issue #265: a separate, asynchronous reconcile backfills RetentionExpiryTime
+		// shortly after the Failed transition. Capturing firstResourceVersion before
+		// this lands would race against a legitimate (not idempotency-violating) write.
+		Eventually(func() *metav1.Time {
+			_ = k8sManager.GetAPIReader().Get(ctx, types.NamespacedName{
+				Name: rrName, Namespace: ROControllerNamespace,
+			}, fetched)
+			return fetched.Status.RetentionExpiryTime
+		}, timeout, interval).ShouldNot(BeNil(), "RetentionExpiryTime backfill should complete")
+
 		By("Verifying idempotency: second reconcile does not change Failed RR state")
 		firstResourceVersion := fetched.ResourceVersion
 		// ✅ APPROVED EXCEPTION: Intentional delay to allow controller reconcile loop

--- a/test/integration/remediationorchestrator/dedup_propagation_integration_test.go
+++ b/test/integration/remediationorchestrator/dedup_propagation_integration_test.go
@@ -222,6 +222,13 @@ var _ = Describe("Issue #190: Dedup Result Propagation Integration", Label("inte
 			},
 		}
 		Expect(k8sClient.Create(ctx, originalWFE)).To(Succeed())
+		// Create() on a status-subresource CRD strips .status from the API
+		// server's response and repopulates the local object with it, so
+		// Phase must be re-set here (mirrors IT-RO-190-001's Create+re-set
+		// pattern above) -- otherwise this persists Phase="", which
+		// handleDedupResultPropagation's default case treats as
+		// "still in progress" forever, hanging this test.
+		originalWFE.Status.Phase = workflowexecutionv1.PhaseFailed
 		originalWFE.Status.FailureReason = "OOM killed"
 		Expect(k8sClient.Status().Update(ctx, originalWFE)).To(Succeed())
 

--- a/test/integration/remediationorchestrator/dedup_propagation_integration_test.go
+++ b/test/integration/remediationorchestrator/dedup_propagation_integration_test.go
@@ -191,28 +191,15 @@ var _ = Describe("Issue #190: Dedup Result Propagation Integration", Label("inte
 	It("IT-RO-190-002: RR inherits Failed from original WFE with FailurePhaseDeduplicated", func() {
 		rr := driveToExecuting(ns, "rr-dedup-002")
 
-		By("Marking the WFE as Failed/Deduplicated")
-		weName := fmt.Sprintf("we-%s", rr.Name)
-		we := &workflowexecutionv1.WorkflowExecution{}
-		Eventually(func() error {
-			return k8sManager.GetAPIReader().Get(ctx, types.NamespacedName{Name: weName, Namespace: ROControllerNamespace}, we)
-		}, timeout, interval).Should(Succeed())
-
 		originalWFEName := "original-wfe-it-002"
-		we.Status.Phase = workflowexecutionv1.PhaseFailed
-		we.Status.FailureDetails = &workflowexecutionv1.FailureDetails{
-			Reason:   workflowexecutionv1.FailureReasonDeduplicated,
-			FailedAt: metav1.Now(),
-		}
-		we.Status.DeduplicatedBy = originalWFEName
-		Expect(k8sClient.Status().Update(ctx, we)).To(Succeed())
-
-		By("Waiting for DeduplicatedByWE to be set on the RR")
-		Eventually(func() string {
-			_ = k8sManager.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(rr), rr)
-			return rr.Status.EnsureRoutingStatus().DeduplicatedByWE
-		}, timeout, interval).Should(Equal(originalWFEName))
-
+		// DD-TEST-010 Amendment 1 fix: create the original WFE (already Failed) BEFORE
+		// setting DeduplicatedBy on the current WE, mirroring IT-RO-190-001's pattern
+		// ("avoids RO NotFound -> Failed race"). RO's handleDedupResultPropagation
+		// treats a NotFound on the DeduplicatedBy-referenced WFE as a terminal dangling
+		// reference (correct for IT-RO-190-003's genuine-deletion case) with no retry,
+		// so setting a forward reference to a not-yet-created object here was a latent
+		// test race: it depended on the test's own follow-up Create() call always
+		// outrunning the controller's self-triggered reconcile of its own status write.
 		By("Creating the original WFE as Failed")
 		originalWFE := &workflowexecutionv1.WorkflowExecution{
 			ObjectMeta: metav1.ObjectMeta{
@@ -237,6 +224,27 @@ var _ = Describe("Issue #190: Dedup Result Propagation Integration", Label("inte
 		Expect(k8sClient.Create(ctx, originalWFE)).To(Succeed())
 		originalWFE.Status.FailureReason = "OOM killed"
 		Expect(k8sClient.Status().Update(ctx, originalWFE)).To(Succeed())
+
+		By("Marking the WFE as Failed/Deduplicated")
+		weName := fmt.Sprintf("we-%s", rr.Name)
+		we := &workflowexecutionv1.WorkflowExecution{}
+		Eventually(func() error {
+			return k8sManager.GetAPIReader().Get(ctx, types.NamespacedName{Name: weName, Namespace: ROControllerNamespace}, we)
+		}, timeout, interval).Should(Succeed())
+
+		we.Status.Phase = workflowexecutionv1.PhaseFailed
+		we.Status.FailureDetails = &workflowexecutionv1.FailureDetails{
+			Reason:   workflowexecutionv1.FailureReasonDeduplicated,
+			FailedAt: metav1.Now(),
+		}
+		we.Status.DeduplicatedBy = originalWFEName
+		Expect(k8sClient.Status().Update(ctx, we)).To(Succeed())
+
+		By("Waiting for DeduplicatedByWE to be set on the RR")
+		Eventually(func() string {
+			_ = k8sManager.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(rr), rr)
+			return rr.Status.EnsureRoutingStatus().DeduplicatedByWE
+		}, timeout, interval).Should(Equal(originalWFEName))
 
 		By("Verifying RR inherits Failed with FailurePhaseDeduplicated")
 		Eventually(func() remediationv1.RemediationPhase {

--- a/test/integration/remediationorchestrator/lifecycle_test.go
+++ b/test/integration/remediationorchestrator/lifecycle_test.go
@@ -255,8 +255,13 @@ var _ = Describe("AIAnalysis ManualReview Flow", Label("integration", "manual-re
 
 			By("Verifying RR status updated")
 			rr := &remediationv1.RemediationRequest{}
-			Expect(k8sManager.GetAPIReader().Get(ctx, types.NamespacedName{Name: rrName, Namespace: ROControllerNamespace}, rr)).To(Succeed())
-			Expect(rr.Status.OverallPhase).To(Equal(remediationv1.PhaseFailed))
+			// NR creation and the RR.Status.OverallPhase=Failed write happen as separate
+			// steps; a bare Expect right after the NR Eventually above can observe the RR
+			// before that write lands (mirrors the override_flow_test.go:315 fix).
+			Eventually(func() remediationv1.RemediationPhase {
+				_ = k8sManager.GetAPIReader().Get(ctx, types.NamespacedName{Name: rrName, Namespace: ROControllerNamespace}, rr)
+				return rr.Status.OverallPhase
+			}, timeout, interval).Should(Equal(remediationv1.PhaseFailed))
 			Expect(rr.Status.EnsureCompletionStatus().Outcome).To(Equal("ManualReviewRequired"))
 
 			GinkgoWriter.Printf("✅ BR-ORCH-036: ManualReview notification created for WorkflowResolutionFailed\n")

--- a/test/integration/remediationorchestrator/locking_integration_test.go
+++ b/test/integration/remediationorchestrator/locking_integration_test.go
@@ -471,19 +471,21 @@ var _ = Describe("RO Distributed Locking (Issue #189, BR-ORCH-025)", func() {
 			}, timeout, interval).Should(Succeed())
 
 			// Wait for reconciler to retry and recover via Get-before-Create.
-			// DD-TEST-010 Amendment 1: this recovery legitimately involves an
-			// optimistic-concurrency conflict-and-retry cycle (the reverted status
-			// write above races the controller's own in-flight update); verified in
-			// isolation (--procs=1) this completes well within the suite's normal
-			// 120s timeout, but under 4-way shared-envtest contention (#2213) it can
-			// need more headroom to finish its retry loop. Dedicated longer timeout
-			// here (not a global bump) keeps other suites' timeouts meaningful.
+			// Root cause (found while migrating this suite under #2213): this
+			// revert races the controller's own in-flight Advance-to-Executing
+			// retry, which could previously commit OverallPhase=Executing on
+			// top of the now-nil ref (transitionPhase's conflict-retry guard
+			// only re-validated OverallPhase, not WorkflowExecutionRef) —
+			// producing a PERMANENT terminal failure in executing_handler.go
+			// that no timeout would recover from. Fixed in terminal_transitions.go
+			// (BR-ORCH-031 guard, UT-AT-013/014); the standard timeout here is
+			// sufficient again since recovery is now a normal, fast retry loop.
 			Eventually(func() bool {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rr), rr); err != nil {
 					return false
 				}
 				return rr.Status.EnsurePhaseProgress().WorkflowExecutionRef != nil
-			}, 4*timeout, interval).Should(BeTrue(), "WFE ref should be restored via idempotent create")
+			}, timeout, interval).Should(BeTrue(), "WFE ref should be restored via idempotent create")
 
 			// Verify the same WFE was reused (not a new one)
 			Expect(rr.Status.EnsurePhaseProgress().WorkflowExecutionRef.Name).To(Equal(wfeName),

--- a/test/integration/remediationorchestrator/locking_integration_test.go
+++ b/test/integration/remediationorchestrator/locking_integration_test.go
@@ -470,13 +470,20 @@ var _ = Describe("RO Distributed Locking (Issue #189, BR-ORCH-025)", func() {
 				return k8sClient.Status().Update(ctx, rr)
 			}, timeout, interval).Should(Succeed())
 
-			// Wait for reconciler to retry and recover via Get-before-Create
+			// Wait for reconciler to retry and recover via Get-before-Create.
+			// DD-TEST-010 Amendment 1: this recovery legitimately involves an
+			// optimistic-concurrency conflict-and-retry cycle (the reverted status
+			// write above races the controller's own in-flight update); verified in
+			// isolation (--procs=1) this completes well within the suite's normal
+			// 120s timeout, but under 4-way shared-envtest contention (#2213) it can
+			// need more headroom to finish its retry loop. Dedicated longer timeout
+			// here (not a global bump) keeps other suites' timeouts meaningful.
 			Eventually(func() bool {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rr), rr); err != nil {
 					return false
 				}
 				return rr.Status.EnsurePhaseProgress().WorkflowExecutionRef != nil
-			}, timeout, interval).Should(BeTrue(), "WFE ref should be restored via idempotent create")
+			}, 4*timeout, interval).Should(BeTrue(), "WFE ref should be restored via idempotent create")
 
 			// Verify the same WFE was reused (not a new one)
 			Expect(rr.Status.EnsurePhaseProgress().WorkflowExecutionRef.Name).To(Equal(wfeName),

--- a/test/integration/remediationorchestrator/override_flow_test.go
+++ b/test/integration/remediationorchestrator/override_flow_test.go
@@ -311,8 +311,13 @@ var _ = Describe("BR-ORCH-030: Operator Override Integration (#594)", Label("int
 
 			By("Verifying OperatorOverride event was emitted on RR")
 			rr := &remediationv1.RemediationRequest{}
-			Expect(k8sManager.GetAPIReader().Get(ctx, types.NamespacedName{Name: rrName, Namespace: ROControllerNamespace}, rr)).To(Succeed())
-			Expect(string(rr.Status.OverallPhase)).To(Equal("Executing"))
+			// WE creation and the RR.Status.OverallPhase="Executing" write happen as
+			// separate steps of the same reconcile; a bare Expect right after the WE
+			// Eventually above can observe the RR microseconds before that write lands.
+			Eventually(func() string {
+				_ = k8sManager.GetAPIReader().Get(ctx, types.NamespacedName{Name: rrName, Namespace: ROControllerNamespace}, rr)
+				return string(rr.Status.OverallPhase)
+			}, timeout, interval).Should(Equal("Executing"))
 		})
 	})
 })

--- a/test/integration/remediationorchestrator/suite_test.go
+++ b/test/integration/remediationorchestrator/suite_test.go
@@ -33,6 +33,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -51,6 +52,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -99,21 +101,25 @@ const (
 	// roRedisPort is the Redis/Valkey port for RO integration tests.
 	// Reused by FMC scope cache in fleet tests (same instance, disjoint key prefixes).
 	roRedisPort = 16381
-
-	// ROControllerNamespace is where RO creates and watches all CRDs (ADR-057).
-	// Must match Cache.ByObject in suite setup - tests create RR in this namespace.
-	ROControllerNamespace = "kubernaut-system"
 )
 
 // Package-level variables for test environment
 var (
 	ctx        context.Context
 	cancel     context.CancelFunc
-	testEnv    *envtest.Environment
 	cfg        *rest.Config
 	k8sClient  client.Client
 	k8sManager ctrl.Manager
 	auditStore audit.AuditStore
+
+	// ROControllerNamespace is where THIS PROCESS creates and watches all CRDs (ADR-057).
+	// DD-TEST-010 Amendment 1 (issue #2213): computed per-process in Phase 2 as
+	// "kubernaut-system-p<N>" now that all processes share a single envtest API
+	// server instead of one embedded control plane each. Isolation between
+	// parallel processes comes from this namespace boundary (plus the manager's
+	// namespace-scoped cache below) instead of a separate-cluster boundary.
+	// Must match Cache.ByObject in suite setup - tests create RR in this namespace.
+	ROControllerNamespace string
 
 	// DD-AUTH-014: Authenticated DataStorage clients (audit + OpenAPI with ServiceAccount tokens)
 	dsClients *integration.AuthenticatedDataStorageClients
@@ -129,9 +135,10 @@ func TestRemediationOrchestratorIntegration(t *testing.T) {
 }
 
 // SynchronizedBeforeSuite runs ONCE globally before all parallel processes start
-// DD-TEST-010 Pattern: Multi-Controller (per-process controller isolation)
-// Phase 1: Infrastructure ONLY (shared across all processes)
-// Phase 2: Per-process controller setup (isolated envtest + controller instances)
+// DD-TEST-010 Amendment 1 Pattern: shared envtest + namespace-scoped per-process controllers.
+// Phase 1: Infrastructure setup, INCLUDING the one shared envtest (process 1 only)
+// Phase 2: Per-process controller setup (own manager + reconciler, own namespace,
+// all connected to the SAME shared envtest API server started in Phase 1)
 var _ = SynchronizedBeforeSuite(func() []byte {
 	// ======================================================================
 	// PHASE 1: INFRASTRUCTURE SETUP (ONCE - GLOBAL)
@@ -158,9 +165,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	var err error
 
-	// DD-AUTH-014: Start shared envtest for DataStorage auth
-	// This is different from per-process envtest pattern because DataStorage
-	// container (started in Phase 1) needs to access envtest API server
+	// DD-AUTH-014 + DD-TEST-010 Amendment 1: Start the ONE envtest for the whole
+	// suite. Originally started here only for DataStorage auth (Phase 2 used to
+	// bootstrap its own separate per-process envtest for the controller); now
+	// every Phase 2 process reconnects to this same instance (see kubeconfig
+	// serialization below), so this is the sole control plane for the suite.
 	By("Starting shared envtest for DataStorage authentication (DD-AUTH-014)")
 
 	// DD-AUTH-014: Force envtest to bind to IPv4 by pre-setting SecureServing.Address
@@ -228,19 +237,42 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	GinkgoWriter.Println("✅ Phase 1 complete - infrastructure ready for all processes")
 	GinkgoWriter.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
-	// DD-AUTH-014: Serialize token for Phase 2 DataStorage client
-	return []byte(authConfig.Token)
+	// DD-TEST-010 Amendment 1 (issue #2213): serialize the shared envtest's
+	// kubeconfig to a file so every Phase 2 process can reconstruct the exact
+	// same *rest.Config -- Phase 2 no longer starts its own envtest.Environment
+	// (see the Phase 2 function below). This collapses N embedded control
+	// planes (etcd + kube-apiserver per process) down to 1, eliminating the
+	// resource contention that caused intermittent "connection refused"
+	// failures under CPU load (root-caused for aianalysis in PR #2189).
+	By("Serializing shared envtest kubeconfig for Phase 2")
+	kubeconfigPath, err := infrastructure.WriteEnvtestKubeconfigToFile(sharedCfg, "remediationorchestrator-shared")
+	Expect(err).ToNot(HaveOccurred(), "shared envtest kubeconfig must serialize for Phase 2")
+
+	// DD-AUTH-014 + DD-TEST-010: Phase 1 -> Phase 2 data passing (token + kubeconfig path)
+	type phase1Data struct {
+		Token          string `json:"token"`
+		KubeconfigPath string `json:"kubeconfig_path"`
+	}
+	payload, err := json.Marshal(phase1Data{
+		Token:          authConfig.Token,
+		KubeconfigPath: kubeconfigPath,
+	})
+	Expect(err).ToNot(HaveOccurred(), "Phase 1 data must serialize for Phase 2")
+	return payload
 }, func(data []byte) {
 	// ======================================================================
-	// PHASE 2: PER-PROCESS CONTROLLER SETUP (ISOLATED)
+	// PHASE 2: PER-PROCESS CONTROLLER SETUP (NAMESPACE-ISOLATED)
 	// ======================================================================
 	// Runs on ALL parallel processes (including process 1)
 	// Each process gets its own:
-	// - envtest (isolated K8s API server for controller)
-	// - k8sManager (isolated controller instance)
-	// - Controller reconciler (isolated event handlers)
+	// - k8sManager (own controller instance, cache scoped to this process's namespace)
+	// - Controller reconciler (own event handlers)
+	// All processes reconstruct a client to the SAME shared envtest API server
+	// Phase 1 started (via its serialized kubeconfig) -- there is no per-process
+	// envtest anymore. Isolation comes from ROControllerNamespace (computed
+	// below) instead of a separate cluster per process.
 	//
-	// DD-TEST-010: Multi-Controller Pattern for Parallel Test Execution
+	// DD-TEST-010 Amendment 1 (issue #2213): Shared-Envtest + Namespace-Scoping
 	// DD-AUTH-014: DataStorage client uses real ServiceAccount token (from Phase 1)
 	// Authority: docs/architecture/decisions/DD-TEST-010-controller-per-process-architecture.md
 	// ======================================================================
@@ -251,8 +283,14 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	GinkgoWriter.Println("PHASE 2: Per-Process Controller Setup (DD-TEST-010 + DD-AUTH-014)")
 	GinkgoWriter.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
-	// DD-AUTH-014: Deserialize ServiceAccount token from Phase 1
-	token := string(data)
+	// DD-AUTH-014 + DD-TEST-010: Deserialize token and shared envtest kubeconfig path from Phase 1
+	type phase1Data struct {
+		Token          string `json:"token"`
+		KubeconfigPath string `json:"kubeconfig_path"`
+	}
+	var p1 phase1Data
+	Expect(json.Unmarshal(data, &p1)).To(Succeed(), "Phase 1 data must deserialize successfully")
+	token := p1.Token
 	GinkgoWriter.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
 	GinkgoWriter.Printf("DD-AUTH-014 DEBUG: ServiceAccount Token Received\n")
 	GinkgoWriter.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
@@ -260,6 +298,15 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	GinkgoWriter.Printf("  Token Prefix: %s...\n", token[:min(50, len(token))])
 	GinkgoWriter.Printf("  Token Suffix: ...%s\n", token[max(len(token)-20, 0):])
 	GinkgoWriter.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
+
+	// DD-TEST-010 Amendment 1 (issue #2213): every process now shares the ONE
+	// envtest apiserver Phase 1 started, so process isolation must come from a
+	// namespace boundary instead of a cluster boundary. ROControllerNamespace
+	// is this process's own namespace, referenced unmodified by every existing
+	// test file (Cache.ByObject below, and 33 dependent _test.go files).
+	processNum := GinkgoParallelProcess()
+	ROControllerNamespace = fmt.Sprintf("kubernaut-system-p%d", processNum)
+	GinkgoWriter.Printf("✅ [Process %d] Own namespace: %s (shared envtest)\n", processNum, ROControllerNamespace)
 
 	// Create per-process context for controller lifecycle
 	ctx, cancel = context.WithCancel(context.Background())
@@ -294,15 +341,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = remediationworkflowv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	By("Bootstrapping per-process envtest with ALL CRDs")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-	}
-	// KUBEBUILDER_ASSETS is set by Makefile via setup-envtest dependency
-
-	cfg, err = testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
+	By(fmt.Sprintf("[Process %d] Reconstructing shared envtest connection", processNum))
+	// DD-TEST-010 Amendment 1: reconstruct cfg from the ONE envtest Phase 1
+	// started (via its serialized kubeconfig) instead of starting a separate
+	// per-process envtest.Environment.
+	cfg, err = clientcmd.BuildConfigFromFlags("", p1.KubeconfigPath)
+	Expect(err).NotTo(HaveOccurred(), "shared envtest kubeconfig must be loadable")
 	Expect(cfg).NotTo(BeNil())
 
 	By("Creating controller-runtime client")
@@ -311,26 +355,28 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(k8sClient).NotTo(BeNil())
 
 	By("Creating required namespaces")
-	// Create kubernaut-system namespace for controller
+	// Create this process's own controller namespace (unique per process; no
+	// AlreadyExists tolerance needed since no other process uses this name).
 	systemNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubernaut-system",
+			Name:   ROControllerNamespace,
+			Labels: map[string]string{"kubernaut.ai/managed": "true"},
 		},
 	}
-	err = k8sClient.Create(ctx, systemNs)
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		Expect(err).NotTo(HaveOccurred())
-	}
+	Expect(k8sClient.Create(ctx, systemNs)).To(Succeed())
 
-	// Create default namespace for tests
+	// Create default namespace for tests (shared across processes; envtest
+	// creates this automatically, but tolerate AlreadyExists defensively).
 	defaultNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
 		},
 	}
-	_ = k8sClient.Create(ctx, defaultNs) // May already exist
+	if err := k8sClient.Create(ctx, defaultNs); err != nil && !apierrors.IsAlreadyExists(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
 
-	GinkgoWriter.Println("✅ Namespaces created: kubernaut-system, default")
+	GinkgoWriter.Printf("✅ Namespaces created: %s, default\n", ROControllerNamespace)
 
 	// ADR-057: Align integration test with production - RO watches only controller namespace.
 	// Without this, the test manager would watch all namespaces while production restricts to
@@ -567,14 +613,16 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 // SynchronizedAfterSuite ensures proper cleanup in parallel execution
-// DD-TEST-010: Per-process cleanup (Phase 1) + shared infrastructure cleanup (Phase 2)
+// DD-TEST-010 Amendment 1: Per-process controller cleanup (Phase 1) + shared
+// envtest/infrastructure cleanup, once, on the last process (Phase 2)
 var _ = SynchronizedAfterSuite(func() {
 	// ======================================================================
 	// PHASE 1: PER-PROCESS CLEANUP (RUNS ON ALL PROCESSES)
 	// ======================================================================
-	// Each parallel process cleans up its own controller and envtest instance
+	// Each parallel process stops its own controller manager. The shared
+	// envtest itself is stopped once below (Phase 2, last process only).
 	//
-	// DD-TEST-010: Multi-Controller Pattern Cleanup
+	// DD-TEST-010 Amendment 1: Shared-Envtest + Namespace-Scoping Cleanup
 	// ======================================================================
 	By("Tearing down per-process test environment")
 
@@ -583,15 +631,11 @@ var _ = SynchronizedAfterSuite(func() {
 		cancel()
 	}
 
-	// Stop per-process envtest
-	if testEnv != nil {
-		err := testEnv.Stop()
-		if err != nil {
-			GinkgoWriter.Printf("⚠️  Warning: Failed to stop envtest: %v\n", err)
-		} else {
-			GinkgoWriter.Println("✅ Per-process envtest stopped")
-		}
-	}
+	// DD-TEST-010 Amendment 1: there is no per-process envtest.Environment to
+	// stop anymore -- every process shares the ONE envtest Phase 1 started,
+	// torn down once via sharedTestEnv.Stop() (DeferCleanup, Phase 1 closure).
+	// This process's own namespace (ROControllerNamespace) is left in place;
+	// it disappears along with the whole shared apiserver when that happens.
 
 	// Close per-process audit store
 	if auditStore != nil {


### PR DESCRIPTION
## Summary

- Migrates the `remediationorchestrator` integration suite to DD-TEST-010
  Amendment 1 (shared-envtest + per-process namespace-scoping instead of
  N-envtests-per-process), per [#2213](https://github.com/jordigilh/kubernaut/issues/2213).
- Fixes 5 latent test-synchronization races that shared-envtest's added
  apiserver contention reliably exposed under `TEST_PROCS=4` (test-only,
  no production code): bare `Expect()`s immediately after an `Eventually`
  on a sibling resource, and a forward-reference-before-create ordering bug.
- Fixes a **real production bug** found (not just exposed) during this
  migration, tracked in [#2224](https://github.com/jordigilh/kubernaut/issues/2224):
  `transitionPhase`'s optimistic-concurrency conflict-retry guard only
  re-validated `OverallPhase == oldPhase`, not that `WorkflowExecutionRef`
  (set by an earlier, separate write) was still present. A retry landing
  after a concurrent status-update-failure recovery (clears the ref +
  reverts phase together — `BR-ORCH-031`'s real-world motivating scenario)
  could pass that guard and commit `OverallPhase=Executing` on top of the
  missing ref, which `executing_handler.go` then treated as a **permanent,
  non-retryable** "corrupted state" failure — no amount of waiting could
  have fixed it. Added the missing precondition check; reproduced
  deterministically in new `UT-AT-013`/`UT-AT-014` unit tests (no timing
  race needed to trigger it).
- Documents all of the above in `DD-TEST-010`, including a lesson for the
  remaining ~10 suites tracked under #2213: validate under real
  `TEST_PROCS=4` contention, not just isolation, before declaring a
  per-service migration done.

Fixes #2224

## Commits

1. `test(integration/remediationorchestrator)`: migrate `suite_test.go` to shared-envtest + per-process namespace
2. `fix(test/integration/remediationorchestrator)`: fix 5 latent test races exposed by the migration
3. `fix(remediationorchestrator)`: guard Advance-to-Executing against a missing `WorkflowExecutionRef` (`BR-ORCH-031`)
4. `fix(test/integration/remediationorchestrator)`: re-set `Phase` before `Status().Update()` in `IT-RO-190-002`
5. `docs(DD-TEST-010)`: record `remediationorchestrator` migrated under Amendment 1

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run` clean on changed packages
- [x] Unit suite (`internal/controller/remediationorchestrator`) green, including new `UT-AT-013`/`UT-AT-014` (RED confirmed against pre-fix code, GREEN after)
- [x] Integration suite validated on `helios08` at `TEST_PROCS=4` (matches CI parallelism): **141/141 specs green**, reproducible across repeated runs
- [x] No stray `etcd`/`kube-apiserver` processes left behind after teardown