### PR TITLE
fix(chart): close 6 values.schema.json config-knob gaps (#2216-#2221)

### DIFF
--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -135,6 +135,7 @@ datastorage:
             existingSecret: ""
             secretKey: hmacKey
         database:
+            connMaxIdleTime: 10m
             connMaxLifetime: 1h
             maxIdleConns: 20
             maxOpenConns: 100

--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -50,6 +50,12 @@ apifrontend:
         mcp:
             enabled: true
             sessionIdleTimeout: 30m
+            toolTimeout: 30s
+            toolTimeouts:
+                kubernaut_await_session: 3m
+                kubernaut_discover_workflows: 60s
+                kubernaut_investigate: 15m
+                kubernaut_watch: 15m
         rateLimit:
             ipRequestsPerSec: 10000
             maxConcurrentSessions: 50

--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -434,6 +434,11 @@ remediationorchestrator:
         enabled: true
     replicas: 1
 signalprocessing:
+    config:
+        classifier:
+            hotReloadInterval: 30s
+        enrichment:
+            cacheTtl: 5m
     fleet:
         namespace: ""
         oauth2:

--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -49,7 +49,7 @@ apifrontend:
             enabled: true
         mcp:
             enabled: true
-            sessionIdleTimeout: 5m
+            sessionIdleTimeout: 30m
         rateLimit:
             ipRequestsPerSec: 10000
             maxConcurrentSessions: 50

--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -215,6 +215,7 @@ gateway:
         middleware:
             trustedProxyCIDRs: []
         server:
+            idleTimeout: 120s
             k8sRequestTimeout: 15s
             maxConcurrentRequests: 100
             readTimeout: 30s

--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -160,6 +160,7 @@ datastorage:
                 requestsPerSecond: 50
             readTimeout: 30s
             signerCertDir: /etc/certs
+            writeTimeout: 30s
     dbExistingSecret: ""
     logging:
         level: INFO

--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -94,6 +94,15 @@ session:
 mcp:
   enabled: {{ $v.config.mcp.enabled }}
   sessionIdleTimeout: {{ $v.config.mcp.sessionIdleTimeout | quote }}
+  # Issue #2221: toolTimeout/toolTimeouts were wired into the MCP bridge
+  # (cmd/apifrontend/mcp_a2a_handlers.go) with real config.DefaultConfig()
+  # defaults, but never exposed via the chart at all.
+  toolTimeout: {{ $v.config.mcp.toolTimeout | quote }}
+  toolTimeouts:
+    kubernaut_investigate: {{ $v.config.mcp.toolTimeouts.kubernaut_investigate | quote }}
+    kubernaut_await_session: {{ $v.config.mcp.toolTimeouts.kubernaut_await_session | quote }}
+    kubernaut_watch: {{ $v.config.mcp.toolTimeouts.kubernaut_watch | quote }}
+    kubernaut_discover_workflows: {{ $v.config.mcp.toolTimeouts.kubernaut_discover_workflows | quote }}
 # DD-PLATFORM-006 DA14 (PR9): was `| default true` -- same bug as mcp.enabled
 # above.
 interactive:

--- a/charts/kubernaut/templates/datastorage/datastorage.yaml
+++ b/charts/kubernaut/templates/datastorage/datastorage.yaml
@@ -16,8 +16,8 @@ server:
   host: "0.0.0.0"
   healthPort: 8081
   metricsPort: 9090
-  readTimeout: 30s
-  writeTimeout: 30s
+  readTimeout: {{ $v.config.server.readTimeout }}
+  writeTimeout: {{ $v.config.server.writeTimeout }}
   # #1048 Phase 4 / SC-5: Maximum request body size in bytes (default: 5242880 = 5 MiB)
   maxBodySize: {{ $v.config.server.maxBodySize | quote }}
   # SEC-H3 / AC-4: CORS allowed origins (default: [] = reject all cross-origin)

--- a/charts/kubernaut/templates/datastorage/datastorage.yaml
+++ b/charts/kubernaut/templates/datastorage/datastorage.yaml
@@ -43,7 +43,7 @@ database:
   maxOpenConns: {{ $v.config.database.maxOpenConns }}
   maxIdleConns: {{ $v.config.database.maxIdleConns }}
   connMaxLifetime: {{ $v.config.database.connMaxLifetime }}
-  connMaxIdleTime: 10m
+  connMaxIdleTime: {{ $v.config.database.connMaxIdleTime }}
   secretsFile: "/etc/datastorage/secrets/db-secrets.yaml"
   usernameKey: "username"
   passwordKey: "password"

--- a/charts/kubernaut/templates/gateway/gateway.yaml
+++ b/charts/kubernaut/templates/gateway/gateway.yaml
@@ -33,7 +33,7 @@ server:
   maxConcurrentRequests: {{ $v.config.server.maxConcurrentRequests }}
   readTimeout: {{ $v.config.server.readTimeout }}
   writeTimeout: {{ $v.config.server.writeTimeout }}
-  idleTimeout: 120s
+  idleTimeout: {{ $v.config.server.idleTimeout }}
   k8sRequestTimeout: {{ $v.config.server.k8sRequestTimeout }}
 cors:
   allowedOrigins:

--- a/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
+++ b/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
@@ -62,12 +62,12 @@ controller:
   leaderElection: false
   leaderElectionId: "signalprocessing.kubernaut.ai"
 enrichment:
-  cacheTtl: "5m"
+  cacheTtl: {{ $v.config.enrichment.cacheTtl | quote }}
   timeout: "10s"
 classifier:
   regoConfigMapName: "signalprocessing-policy"
   regoConfigMapKey: "policy.rego"
-  hotReloadInterval: "30s"
+  hotReloadInterval: {{ $v.config.classifier.hotReloadInterval | quote }}
 datastorage:
   url: "{{ include "kubernaut.datastorage.url" . }}"
   healthUrl: "{{ include "kubernaut.datastorage.healthUrl" . }}"

--- a/charts/kubernaut/tests/apifrontend_mcp_session_idle_timeout_default_test.yaml
+++ b/charts/kubernaut/tests/apifrontend_mcp_session_idle_timeout_default_test.yaml
@@ -1,0 +1,64 @@
+suite: "Issue #2220: apifrontend.config.mcp.sessionIdleTimeout default was 5m, inconsistent with the 30m the Go-side cmd/ fallback silently applied whenever the field was unset"
+# Before this fix: values.schema.json defaulted mcp.sessionIdleTimeout to
+# "5m", but cmd/apifrontend/mcp_a2a_handlers.go:56-59 had its own
+# independent `if mcpSessionTimeout == 0 { mcpSessionTimeout = 30 * time.Minute }`
+# fallback -- so a bare `helm install` (schema default 5m, rendered into the
+# ConfigMap and loaded into Cfg.MCP.SessionIdleTimeout) actually produced a
+# real 5m session timeout in production (non-zero, so the Go fallback never
+# fired), NOT the 30m an operator reading the Go source might expect. Fixed
+# by consolidating to a single source of truth: schema default bumped to
+# 30m, and Go's own config.DefaultConfig() now sets the same 30m explicitly
+# (see pkg/apifrontend/config/config_test.go), with the now-redundant cmd/
+# fallback removed.
+templates:
+  - templates/apifrontend/apifrontend.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  global:
+    llmProfiles:
+      primary:
+        provider: openai
+        model: gpt-4
+        credentialsSecretName: llm-credentials-primary
+  kubernautAgent:
+    llmProfileRef: primary
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+  apifrontend:
+    config:
+      auth:
+        issuerURL: "https://sso.example.com/realms/kubernaut"
+tests:
+  - it: "default install (no mcp.sessionIdleTimeout override) renders sessionIdleTimeout: \"30m\", matching Go's config.DefaultConfig() exactly"
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'sessionIdleTimeout: "30m"'
+
+  - it: "an explicit mcp.sessionIdleTimeout override still wins over the schema default"
+    set:
+      apifrontend:
+        config:
+          mcp:
+            sessionIdleTimeout: "15m"
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'sessionIdleTimeout: "15m"'
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: 'sessionIdleTimeout: "30m"'

--- a/charts/kubernaut/tests/apifrontend_mcp_tool_timeouts_schema_test.yaml
+++ b/charts/kubernaut/tests/apifrontend_mcp_tool_timeouts_schema_test.yaml
@@ -1,0 +1,109 @@
+suite: "Issue #2221: mcp.toolTimeout / mcp.toolTimeouts never exposed via schema or template"
+# AF's MCPConfig.ToolTimeout / ToolTimeouts (pkg/apifrontend/config/config.go)
+# are both actively wired into the MCP bridge
+# (cmd/apifrontend/mcp_a2a_handlers.go:44-45) and have real built-in
+# defaults in config.DefaultConfig() (ToolTimeout: 30s; ToolTimeouts: a
+# 4-entry per-tool map), but values.schema.json had no mcp.toolTimeout /
+# mcp.toolTimeouts entries at all, and the template's mcp: block only
+# rendered enabled/sessionIdleTimeout. A chart-only install had no way to
+# override per-tool MCP timeouts, and the rendered ConfigMap never made
+# these Go-level defaults visible/auditable.
+#
+# toolTimeouts is modeled as 4 named schema properties (not an arbitrary
+# additionalProperties map) specifically so each of the 4 known tool names
+# carries its own materializable per-key default (hack/gen-helm-defaults
+# intentionally never materializes defaults for arbitrary-key map schemas
+# -- see its buildDefaultsTree/walkDefaults doc comments) and so a partial
+# override of one tool's timeout cannot silently wipe out the other 3
+# defaults.
+templates:
+  - templates/apifrontend/apifrontend.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  global:
+    llmProfiles:
+      primary:
+        provider: openai
+        model: gpt-4
+        credentialsSecretName: llm-credentials-primary
+  kubernautAgent:
+    llmProfileRef: primary
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+  apifrontend:
+    config:
+      auth:
+        issuerURL: "https://sso.example.com/realms/kubernaut"
+tests:
+  - it: "default install renders mcp.toolTimeout and all 4 mcp.toolTimeouts entries, matching config.DefaultConfig() exactly"
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'toolTimeout: "30s"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'kubernaut_investigate: "15m"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'kubernaut_await_session: "3m"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'kubernaut_watch: "15m"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'kubernaut_discover_workflows: "60s"'
+
+  - it: "an explicit mcp.toolTimeout override renders through"
+    set:
+      apifrontend:
+        config:
+          mcp:
+            toolTimeout: "45s"
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'toolTimeout: "45s"'
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: 'toolTimeout: "30s"'
+
+  - it: "PARTIAL-OVERRIDE PROOF: overriding only kubernaut_investigate's timeout leaves the other 3 tool defaults intact (named-property fields, not a wholesale-replaced arbitrary map)"
+    set:
+      apifrontend:
+        config:
+          mcp:
+            toolTimeouts:
+              kubernaut_investigate: "20m"
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'kubernaut_investigate: "20m"'
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: 'kubernaut_investigate: "15m"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'kubernaut_await_session: "3m"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'kubernaut_watch: "15m"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'kubernaut_discover_workflows: "60s"'

--- a/charts/kubernaut/tests/datastorage_conn_max_idle_time_schema_test.yaml
+++ b/charts/kubernaut/tests/datastorage_conn_max_idle_time_schema_test.yaml
@@ -1,0 +1,42 @@
+suite: "Issue #2218: DataStorage database.connMaxIdleTime hardcoded while its 3 struct siblings are schema-driven"
+# templates/datastorage/datastorage.yaml's database block: maxOpenConns,
+# maxIdleConns, connMaxLifetime are all schema-driven via
+# datastorage.config.database.*; connMaxIdleTime alone was a bare "10m"
+# literal. pkg/datastorage/config DatabaseConfig.ConnMaxIdleTime is a real,
+# actively-read field (pkg/datastorage/server/server_construction.go wires
+# it into sql.DB.SetConnMaxIdleTime), so this was a genuine override gap.
+templates:
+  - templates/datastorage/datastorage.yaml
+set:
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+tests:
+  - it: "default install (no database.connMaxIdleTime override) renders connMaxIdleTime: 10m, matching the Go default exactly"
+    documentSelector:
+      path: metadata.name
+      value: datastorage-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'connMaxIdleTime: 10m'
+
+  - it: "an explicit database.connMaxIdleTime override renders through instead of being silently discarded"
+    set:
+      datastorage:
+        config:
+          database:
+            connMaxIdleTime: "20m"
+    documentSelector:
+      path: metadata.name
+      value: datastorage-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'connMaxIdleTime: 20m'
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: 'connMaxIdleTime: 10m'

--- a/charts/kubernaut/tests/datastorage_readwrite_timeout_override_bug_test.yaml
+++ b/charts/kubernaut/tests/datastorage_readwrite_timeout_override_bug_test.yaml
@@ -1,0 +1,64 @@
+suite: "Issue #2219: DataStorage server.readTimeout schema override is silently ignored; writeTimeout has no schema field at all"
+# values.schema.json already declared datastorage.config.server.readTimeout
+# as a configurable goDuration (default 30s), so `--set
+# datastorage.config.server.readTimeout=60s` validated cleanly against the
+# schema -- but templates/datastorage/datastorage.yaml:19-20 rendered both
+# readTimeout and writeTimeout as bare literals, never referencing
+# .Values/$v, so the override was silently discarded. writeTimeout
+# additionally had no schema field at all despite being an exact peer of
+# readTimeout.
+templates:
+  - templates/datastorage/datastorage.yaml
+set:
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+tests:
+  - it: "default install renders readTimeout: 30s and writeTimeout: 30s, matching the Go defaults exactly"
+    documentSelector:
+      path: metadata.name
+      value: datastorage-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'readTimeout: 30s'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'writeTimeout: 30s'
+
+  - it: "REGRESSION GUARD (was the live bug): an explicit server.readTimeout override actually renders through, instead of being silently discarded"
+    set:
+      datastorage:
+        config:
+          server:
+            readTimeout: "60s"
+    documentSelector:
+      path: metadata.name
+      value: datastorage-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'readTimeout: 60s'
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: 'readTimeout: 30s'
+
+  - it: "an explicit server.writeTimeout override renders through (new schema field, exact peer of readTimeout)"
+    set:
+      datastorage:
+        config:
+          server:
+            writeTimeout: "45s"
+    documentSelector:
+      path: metadata.name
+      value: datastorage-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'writeTimeout: 45s'
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: 'writeTimeout: 30s'

--- a/charts/kubernaut/tests/gateway_server_idle_timeout_schema_test.yaml
+++ b/charts/kubernaut/tests/gateway_server_idle_timeout_schema_test.yaml
@@ -1,0 +1,43 @@
+suite: "Issue #2217: Gateway server.idleTimeout hardcoded while its 3 struct siblings (maxConcurrentRequests/readTimeout/writeTimeout) are schema-driven"
+# templates/gateway/gateway.yaml's server block: maxConcurrentRequests,
+# readTimeout, writeTimeout are all schema-driven via
+# gateway.config.server.*; idleTimeout alone was a bare "120s" literal.
+# pkg/gateway/config/config.go ServerConfig.IdleTimeout is a real, actively
+# -read field (pkg/gateway/server_constructors.go wires it into
+# http.Server.IdleTimeout), so this was a genuine override gap, not dead
+# config.
+templates:
+  - templates/gateway/gateway.yaml
+set:
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+tests:
+  - it: "default install (no server.idleTimeout override) renders idleTimeout: 120s, matching the Go default exactly (ServerConfig.IdleTimeout default = 120 * time.Second)"
+    documentSelector:
+      path: metadata.name
+      value: gateway-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'idleTimeout: 120s'
+
+  - it: "an explicit server.idleTimeout override renders through instead of being silently discarded"
+    set:
+      gateway:
+        config:
+          server:
+            idleTimeout: "60s"
+    documentSelector:
+      path: metadata.name
+      value: gateway-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'idleTimeout: 60s'
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: 'idleTimeout: 120s'

--- a/charts/kubernaut/tests/signalprocessing_enrichment_classifier_schema_test.yaml
+++ b/charts/kubernaut/tests/signalprocessing_enrichment_classifier_schema_test.yaml
@@ -1,0 +1,70 @@
+suite: "Issue #2216: signalprocessing enrichment.cacheTtl / classifier.hotReloadInterval hardcoded, no schema field"
+# templates/signalprocessing/signalprocessing.yaml hardcoded enrichment.cacheTtl
+# ("5m") and classifier.hotReloadInterval ("30s") as bare literals with no
+# corresponding values.schema.json entry, so neither could be overridden via
+# `helm install --set`. Both are real, actively-read Go config fields
+# (pkg/signalprocessing/config/config.go EnrichmentConfig.CacheTTL /
+# ClassifierConfig.HotReloadInterval, wired in cmd/signalprocessing/main.go) --
+# unlike #2215 (aianalysis agent.*), which turned out to be dead config
+# already removed by #2204.
+templates:
+  - templates/signalprocessing/signalprocessing.yaml
+set:
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+tests:
+  - it: "default install (no enrichment.cacheTtl override) renders cacheTtl: \"5m\", matching the Go default exactly (EnrichmentConfig.CacheTTL default = 5 * time.Minute)"
+    documentSelector:
+      path: metadata.name
+      value: signalprocessing-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'cacheTtl: "5m"'
+
+  - it: "default install (no classifier.hotReloadInterval override) renders hotReloadInterval: \"30s\", matching the Go default exactly (ClassifierConfig.HotReloadInterval default = 30 * time.Second)"
+    documentSelector:
+      path: metadata.name
+      value: signalprocessing-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'hotReloadInterval: "30s"'
+
+  - it: "an explicit enrichment.cacheTtl override renders through instead of being silently discarded"
+    set:
+      signalprocessing:
+        config:
+          enrichment:
+            cacheTtl: "10m"
+    documentSelector:
+      path: metadata.name
+      value: signalprocessing-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'cacheTtl: "10m"'
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: 'cacheTtl: "5m"'
+
+  - it: "an explicit classifier.hotReloadInterval override renders through instead of being silently discarded"
+    set:
+      signalprocessing:
+        config:
+          classifier:
+            hotReloadInterval: "45s"
+    documentSelector:
+      path: metadata.name
+      value: signalprocessing-config
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'hotReloadInterval: "45s"'
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: 'hotReloadInterval: "30s"'

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -1183,6 +1183,15 @@
                   "default": "30s",
                   "description": "Server read timeout"
                 },
+                "writeTimeout": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/goDuration"
+                    }
+                  ],
+                  "default": "30s",
+                  "description": "Issue #2219: exact peer of readTimeout, previously missing entirely. Server write timeout"
+                },
                 "corsAllowedOrigins": {
                   "type": "array",
                   "items": {

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -2899,6 +2899,54 @@
                   ],
                   "default": "30m",
                   "description": "Issue #2220: was 5m, inconsistent with the 30m the Go-side cmd/apifrontend fallback silently applied whenever this was unset. Consolidated to a single 30m default, now also set explicitly in config.DefaultConfig()."
+                },
+                "toolTimeout": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/goDuration"
+                    }
+                  ],
+                  "default": "30s",
+                  "description": "Issue #2221: default per-tool MCP call timeout, previously never exposed via Helm despite being wired into the MCP bridge (cmd/apifrontend/mcp_a2a_handlers.go)."
+                },
+                "toolTimeouts": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Issue #2221: per-tool MCP call timeout overrides (map[string]time.Duration in Go), previously never exposed via Helm. Modeled as named properties (one per known MCP tool) rather than an arbitrary-key map, so each carries its own materialized default and a partial override of one tool never discards the other 3 defaults.",
+                  "properties": {
+                    "kubernaut_investigate": {
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/goDuration"
+                        }
+                      ],
+                      "default": "15m"
+                    },
+                    "kubernaut_await_session": {
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/goDuration"
+                        }
+                      ],
+                      "default": "3m"
+                    },
+                    "kubernaut_watch": {
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/goDuration"
+                        }
+                      ],
+                      "default": "15m"
+                    },
+                    "kubernaut_discover_workflows": {
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/goDuration"
+                        }
+                      ],
+                      "default": "60s"
+                    }
+                  }
                 }
               }
             },

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -1245,6 +1245,15 @@
                   ],
                   "default": "1h",
                   "description": "Maximum connection lifetime"
+                },
+                "connMaxIdleTime": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/goDuration"
+                    }
+                  ],
+                  "default": "10m",
+                  "description": "Issue #2218: was a bare template literal while its 3 struct siblings (maxOpenConns/maxIdleConns/connMaxLifetime) were already schema-driven. Maximum connection idle time"
                 }
               }
             },

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -992,6 +992,15 @@
                   ],
                   "default": "30s"
                 },
+                "idleTimeout": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/goDuration"
+                    }
+                  ],
+                  "default": "120s",
+                  "description": "Issue #2217: was a bare template literal while its 3 struct siblings (maxConcurrentRequests/readTimeout/writeTimeout) were already schema-driven"
+                },
                 "k8sRequestTimeout": {
                   "allOf": [
                     {

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -1569,6 +1569,43 @@
         },
         "tolerations": {
           "$ref": "#/definitions/tolerations"
+        },
+        "config": {
+          "type": "object",
+          "description": "Issue #2216: enrichment.cacheTtl/classifier.hotReloadInterval were hardcoded chart literals with no schema exposure, despite being real, actively-read Go config fields (pkg/signalprocessing/config/config.go).",
+          "additionalProperties": false,
+          "properties": {
+            "enrichment": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cacheTtl": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/goDuration"
+                    }
+                  ],
+                  "default": "5m",
+                  "description": "Enrichment cache lifetime (EnrichmentConfig.CacheTTL)"
+                }
+              }
+            },
+            "classifier": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "hotReloadInterval": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/goDuration"
+                    }
+                  ],
+                  "default": "30s",
+                  "description": "Rego classification policy hot-reload poll interval (ClassifierConfig.HotReloadInterval)"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -2897,7 +2897,8 @@
                       "$ref": "#/definitions/goDuration"
                     }
                   ],
-                  "default": "5m"
+                  "default": "30m",
+                  "description": "Issue #2220: was 5m, inconsistent with the 30m the Go-side cmd/apifrontend fallback silently applied whenever this was unset. Consolidated to a single 30m default, now also set explicitly in config.DefaultConfig()."
                 }
               }
             },

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -818,7 +818,13 @@ apifrontend:
     # PLATFORM-006 DA14) -- omitted here; set false explicitly to disable.
     # mcp:
     #   enabled: true
-    #   sessionIdleTimeout: "5m"
+    #   sessionIdleTimeout: "30m"
+    #   toolTimeout: "30s"
+    #   toolTimeouts:
+    #     kubernaut_investigate: "15m"
+    #     kubernaut_await_session: "3m"
+    #     kubernaut_watch: "15m"
+    #     kubernaut_discover_workflows: "60s"
     # -- A2A/MCP session-dependent tool registration (kubernaut_investigate,
     # discover_workflows, select_workflow, message, complete, cancel, status,
     # reconnect, await_session -- see pkg/apifrontend/tools/tool_categories.go).

--- a/cmd/apifrontend/main_wiring_test.go
+++ b/cmd/apifrontend/main_wiring_test.go
@@ -642,6 +642,11 @@ func TestBuildMCPHandler_ReturnsHandlerAndReadyChecker(t *testing.T) {
 
 	d := testHandlerDeps(func(d *handlerDeps) {
 		d.Cfg.MCP.Enabled = true
+		// Issue #2220: cmd/apifrontend no longer falls back to 30m when this
+		// is zero (config.DefaultConfig() is now the single source of truth
+		// for that default) -- set it explicitly here so this fixture
+		// doesn't silently pass a 0 SessionTimeout into NewMCPHandler.
+		d.Cfg.MCP.SessionIdleTimeout = 30 * time.Minute
 		d.Backends.KAClient = ka.NewClient(ka.Config{BaseURL: kaBackend.URL})
 		d.Backends.DSResilientTransport = resilience.NewCircuitBreakerTransport(
 			http.DefaultTransport,

--- a/cmd/apifrontend/mcp_a2a_handlers.go
+++ b/cmd/apifrontend/mcp_a2a_handlers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/model"
@@ -53,17 +52,13 @@ func buildMCPHandler(d *handlerDeps) (http.Handler, func() bool, error) {
 		ScopeChecker:          d.Backends.ScopeChecker,
 	}
 
-	mcpSessionTimeout := d.Cfg.MCP.SessionIdleTimeout
-	if mcpSessionTimeout == 0 {
-		mcpSessionTimeout = 30 * time.Minute
-	}
 	h, err := handler.NewMCPHandler(handler.MCPConfig{
 		ServerName:     "kubernaut-apifrontend",
 		ServerVersion:  version.Version,
 		Enabled:        d.Cfg.MCP.Enabled,
 		Bridge:         bridgeCfg,
 		Auditor:        d.Auditor,
-		SessionTimeout: mcpSessionTimeout,
+		SessionTimeout: d.Cfg.MCP.SessionIdleTimeout,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -541,6 +541,8 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | Parameter | Type | Description | Default | Required |
 |-----------|------|--------------|---------|----------|
 | `affinity` | object | Kubernetes affinity rules | `` | No |
+| `config.classifier.hotReloadInterval` | string | Rego classification policy hot-reload poll interval (ClassifierConfig.HotReloadInterval) | `"30s"` | No |
+| `config.enrichment.cacheTtl` | string | Enrichment cache lifetime (EnrichmentConfig.CacheTTL) | `"5m"` | No |
 | `containerSecurityContext` | object | Kubernetes securityContext (pod or container level) | `` | No |
 | `fleet.namespace` | string | Restricts the ClusterRegistry CRD watch; empty watches all namespaces | `""` | No |
 | `fleet.oauth2.credentialsSecretRef` | string | K8s Secret with keys: client-id, client-secret. Overrides global.fleet.oauth2.credentialsSecretRef for this service only. | `""` | No |

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -53,7 +53,7 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `config.interactive.bridgeInactivityTimeout` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"180s"` | No |
 | `config.interactive.enabled` | boolean |  | `true` | No |
 | `config.mcp.enabled` | boolean |  | `true` | No |
-| `config.mcp.sessionIdleTimeout` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"5m"` | No |
+| `config.mcp.sessionIdleTimeout` | string | Issue #2220: was 5m, inconsistent with the 30m the Go-side cmd/apifrontend fallback silently applied whenever this was unset. Consolidated to a single 30m default, now also set explicitly in config.DefaultConfig(). | `"30m"` | No |
 | `config.rateLimit.ipRequestsPerSec` | integer |  | `10000` | No |
 | `config.rateLimit.maxConcurrentSessions` | integer |  | `50` | No |
 | `config.rateLimit.toolCallsPerMinute` | integer |  | `600` | No |

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -271,6 +271,7 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `config.cors.maxAge` | integer | Preflight cache duration in seconds. | `300` | No |
 | `config.deduplication.cooldownPeriod` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"5m"` | No |
 | `config.middleware.trustedProxyCIDRs` | array of string | Issue #673 L-1: CIDRs whose proxy headers are trusted | `[]` | No |
+| `config.server.idleTimeout` | string | Issue #2217: was a bare template literal while its 3 struct siblings (maxConcurrentRequests/readTimeout/writeTimeout) were already schema-driven | `"120s"` | No |
 | `config.server.k8sRequestTimeout` | string | Per-handler K8s API timeout (BR-GATEWAY-102) | `"15s"` | No |
 | `config.server.maxConcurrentRequests` | integer |  | `100` | No |
 | `config.server.readTimeout` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"30s"` | No |

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -180,6 +180,7 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `config.server.rateLimit.requestsPerSecond` | number | Sustained per-IP requests/second | `50` | No |
 | `config.server.readTimeout` | string | Server read timeout | `"30s"` | No |
 | `config.server.signerCertDir` | string | #1048 Phase 5 / AU-9: Directory containing signing cert (tls.crt, tls.key) | `"/etc/certs"` | No |
+| `config.server.writeTimeout` | string | Issue #2219: exact peer of readTimeout, previously missing entirely. Server write timeout | `"30s"` | No |
 | `containerSecurityContext` | object | Kubernetes securityContext (pod or container level) | `` | No |
 | `dbExistingSecret` | string | DEPRECATED: db-secrets.yaml is now in postgresql-secret. Set only for BYO PostgreSQL with a separate DataStorage secret. | `""` | No |
 | `logging.level` | string | Log level (Issue #875) | `"INFO"` | No |

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -159,6 +159,7 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `autoscaling.minReplicas` | integer |  | `1` | No |
 | `config.auditHashKey.existingSecret` | string | Pre-created Secret name; defaults to datastorage-audit-hmac-key when unset | `""` | No |
 | `config.auditHashKey.secretKey` | string | Key name within the secret's audit-hmac-key.yaml file | `"hmacKey"` | No |
+| `config.database.connMaxIdleTime` | string | Issue #2218: was a bare template literal while its 3 struct siblings (maxOpenConns/maxIdleConns/connMaxLifetime) were already schema-driven. Maximum connection idle time | `"10m"` | No |
 | `config.database.connMaxLifetime` | string | Maximum connection lifetime | `"1h"` | No |
 | `config.database.maxIdleConns` | integer | Maximum idle database connections | `20` | No |
 | `config.database.maxOpenConns` | integer | Maximum open database connections | `100` | No |

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -54,6 +54,11 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `config.interactive.enabled` | boolean |  | `true` | No |
 | `config.mcp.enabled` | boolean |  | `true` | No |
 | `config.mcp.sessionIdleTimeout` | string | Issue #2220: was 5m, inconsistent with the 30m the Go-side cmd/apifrontend fallback silently applied whenever this was unset. Consolidated to a single 30m default, now also set explicitly in config.DefaultConfig(). | `"30m"` | No |
+| `config.mcp.toolTimeout` | string | Issue #2221: default per-tool MCP call timeout, previously never exposed via Helm despite being wired into the MCP bridge (cmd/apifrontend/mcp_a2a_handlers.go). | `"30s"` | No |
+| `config.mcp.toolTimeouts.kubernaut_await_session` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"3m"` | No |
+| `config.mcp.toolTimeouts.kubernaut_discover_workflows` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"60s"` | No |
+| `config.mcp.toolTimeouts.kubernaut_investigate` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"15m"` | No |
+| `config.mcp.toolTimeouts.kubernaut_watch` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"15m"` | No |
 | `config.rateLimit.ipRequestsPerSec` | integer |  | `10000` | No |
 | `config.rateLimit.maxConcurrentSessions` | integer |  | `50` | No |
 | `config.rateLimit.toolCallsPerMinute` | integer |  | `600` | No |

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -292,8 +292,9 @@ func DefaultConfig() *Config {
 			},
 		},
 		MCP: MCPConfig{
-			Enabled:     false,
-			ToolTimeout: 30 * time.Second,
+			Enabled:            false,
+			SessionIdleTimeout: 30 * time.Minute,
+			ToolTimeout:        30 * time.Second,
 			ToolTimeouts: map[string]time.Duration{
 				"kubernaut_investigate":        15 * time.Minute,
 				"kubernaut_await_session":      3 * time.Minute,

--- a/pkg/apifrontend/config/config_test.go
+++ b/pkg/apifrontend/config/config_test.go
@@ -636,6 +636,11 @@ var _ = Describe("TC-P2C-03: DefaultConfig field assertions", func() {
 		Expect(cfg.Resilience.DS.CBFailureThreshold).To(BeNumerically(">", 0))
 		Expect(cfg.Resilience.K8s.CBFailureThreshold).To(BeNumerically(">", 0))
 	})
+
+	It("TC-P2C-03d: Issue #2220 DefaultConfig sets MCP.SessionIdleTimeout to 30m explicitly (single source of truth, no longer relying on the removed cmd/apifrontend zero-value fallback)", func() {
+		cfg := config.DefaultConfig()
+		Expect(cfg.MCP.SessionIdleTimeout).To(Equal(30 * time.Minute))
+	})
 })
 
 var _ = Describe("Tier 5b: Configurable Ports (Issue #1339)", func() {


### PR DESCRIPTION
## Summary

Closes a batch of chart/values.schema.json config-knob gaps found during a cross-service consistency audit for `kubernaut-operator#173`. Each issue is its own commit, RED→GREEN via a dedicated `helm-unittest` suite.

- #2216: signalprocessing `enrichment.cacheTtl` / `classifier.hotReloadInterval` were bare template literals despite being actively-read Go config fields (defaults `5m`/`30s` preserved).
- #2217: gateway `server.idleTimeout` was a bare literal while its 3 struct siblings were schema-driven (default `120s` preserved).
- #2218: datastorage `database.connMaxIdleTime` was a bare literal while its 3 struct siblings were schema-driven (default `10m` preserved).
- #2219: datastorage `server.readTimeout` was schema-declared but the override was **silently discarded** by the template (real bug, not just a missing knob); `writeTimeout` had no schema field at all despite being an exact peer. Both fixed; defaults preserved (`30s`/`30s`).
- #2220: apifrontend `mcp.sessionIdleTimeout` schema default was `5m`, inconsistent with the `30m` the Go-side `cmd/apifrontend` fallback silently applied whenever the field was unset — so a bare install actually got a real 5m timeout, not the 30m an operator reading the Go source would expect. Consolidated to a single 30m source of truth: schema bumped to `30m`, `config.DefaultConfig()` now sets it explicitly, and the now-redundant `cmd/apifrontend` fallback removed.
- #2221: apifrontend `mcp.toolTimeout` / `mcp.toolTimeouts` were wired into the MCP bridge with real Go-side defaults but never exposed via the chart at all. `toolTimeouts` is modeled as 4 named schema properties (not an arbitrary map) so each of the 4 known tool defaults materializes correctly and a partial override of one tool can never wipe out the other 3 (proven empirically by the new test).

**#2215 was investigated and found obsolete** — its premise (hardcoded `aianalysis.agent.timeout`/`sessionPollInterval`) was removed as dead code by #2204 the day before #2215 was filed. Commented on the issue recommending closure; not included in this PR.

Each fix follows RED→GREEN: a new `helm-unittest` suite proving the gap/bug first (asserting the exact Go-side default and, where relevant, an explicit regression-guard proving an override that was previously silently discarded now renders through), then the minimal schema/template/Go change to make it pass. Full `helm unittest` suite (563 tests, 68 suites) is green throughout, `go build ./...` and `golangci-lint` are clean.

## Commits

1. `afb2ea316` fix(chart): expose signalprocessing enrichment.cacheTtl / classifier.hotReloadInterval (#2216)
2. `f030e7897` fix(chart): expose gateway server.idleTimeout in values.schema.json (#2217)
3. `b9e2a3c2b` fix(chart): expose datastorage database.connMaxIdleTime in values.schema.json (#2218)
4. `f6b0308d2` fix(chart): datastorage server.readTimeout override was silently discarded; add writeTimeout schema field (#2219)
5. `c1740830e` fix(chart,apifrontend): consolidate mcp.sessionIdleTimeout default to 30m, single source of truth (#2220)
6. `2262c3db8` fix(chart): expose apifrontend mcp.toolTimeout / mcp.toolTimeouts in values.schema.json (#2221)
7. `1daa131de` refactor(chart): fix stale mcp.sessionIdleTimeout example default, document toolTimeout/toolTimeouts

## Test plan

- [x] New `helm-unittest` suite per issue, RED-confirmed against pre-fix state, GREEN after fix
- [x] Full `helm unittest charts/kubernaut/` suite green (68 suites / 563 tests)
- [x] `go build ./...` clean
- [x] `golangci-lint run` clean on all touched Go packages
- [x] `make generate-helm-defaults generate-helm-config-docs` re-run and committed after every schema change

Closes #2216, #2217, #2218, #2219, #2220, #2221