### PR TITLE
chore(deps): pin google.golang.org/adk/v2 to v2.0.x pending upstream fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "sigs.k8s.io/*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # google/adk-go#1356 (impacts v2.1.0+): pin to v2.0.x until upstream
+      # fixes it. Remove this ignore rule once a fixed release is out.
+      - dependency-name: "google.golang.org/adk/v2"
+        versions: [">= 2.1.0"]
     groups:
       all-go-deps:
         patterns:
@@ -97,6 +101,10 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "sigs.k8s.io/*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # google/adk-go#1356 (impacts v2.1.0+): pin to v2.0.x until upstream
+      # fixes it. Remove this ignore rule once a fixed release is out.
+      - dependency-name: "google.golang.org/adk/v2"
+        versions: [">= 2.1.0"]
     groups:
       all-go-deps:
         patterns:


### PR DESCRIPTION
## Summary

- Adds a Dependabot `ignore` rule for `google.golang.org/adk/v2` on both the `main` and `release/v1.5` gomod update blocks, blocking version-update PRs for `>= 2.1.0`.
- Patch releases within `v2.0.x` remain eligible for automated updates.

## Why

[google/adk-go#1356](https://github.com/google/adk-go/pull/1356) documents a regression that also affects `v2.1.0+`. #2230 (Dependabot's `all-go-deps` group bump) already picked up `v2.2.0` and is currently failing `Unit Tests (apifrontend)` in CI, corroborating the upstream issue.

This pin is temporary -- remove the `ignore` entry once upstream ships a fix (tracked informally; author is watching the upstream PR).

## Test plan

- [x] Validated `.github/dependabot.yml` is syntactically valid YAML.
- [x] Verified the rule is scoped to `google.golang.org/adk/v2` only (not the unrelated `google.golang.org/adk` v1 indirect dep or `Alcova-AI/adk-anthropic-go`).
- [ ] Dependabot will pick up this config on its next scheduled run; no CI signal for config-only changes to `.github/dependabot.yml` itself.