### PR TITLE
chore(deps): pin google.golang.org/adk (v1 line) to <v1.6.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,11 @@ updates:
       # fixes it. Remove this ignore rule once a fixed release is out.
       - dependency-name: "google.golang.org/adk/v2"
         versions: [">= 2.1.0"]
+      # Same google/adk-go#1356 regression, v1 module line (no "/v2" suffix
+      # -- only an indirect dep on main today, but pinned here too for
+      # symmetry with release/v1.5's direct dep on this module below).
+      - dependency-name: "google.golang.org/adk"
+        versions: [">= 1.6.0"]
     groups:
       all-go-deps:
         patterns:
@@ -105,6 +110,13 @@ updates:
       # fixes it. Remove this ignore rule once a fixed release is out.
       - dependency-name: "google.golang.org/adk/v2"
         versions: [">= 2.1.0"]
+      # release/v1.5 predates the v2 module migration and still depends
+      # directly on the v1 line, which carries the same google/adk-go#1356
+      # regression starting v1.6.0 (confirmed clean on v1.5.1 -- see
+      # google/adk-go#1354's repro). Caught when PR #2179 tried to bump
+      # straight into the regressed version.
+      - dependency-name: "google.golang.org/adk"
+        versions: [">= 1.6.0"]
     groups:
       all-go-deps:
         patterns:


### PR DESCRIPTION
## Summary

- Extends the pin from #2236 to also cover the **v1** module line (`google.golang.org/adk`, no `/v2` suffix), on both the `main` and `release/v1.5` gomod update blocks.

## Why

#2236 only ignored `google.golang.org/adk/v2 >= 2.1.0`. It missed that `release/v1.5` (pre-v2-module-migration) still depends **directly** on the v1 line at `v1.5.1`. PR #2179 (release/v1.5's grouped go-deps bump) tried to bump it straight to `v1.6.0` -- which is the exact version [google/adk-go#1354](https://github.com/google/adk-go/issues/1354) confirms is regressed (v1.5.1 clean, v1.6.0 leaking `temp:` state keys). Same root cause as #2236, [google/adk-go#1356](https://github.com/google/adk-go/pull/1356).

`main` only carries this as an indirect dependency today, but the ignore rule is added there too for symmetry/safety.

## Test plan

- [x] Validated `.github/dependabot.yml` is syntactically valid YAML.
- [ ] Once merged, recreate PR #2179 (`@dependabot recreate`) and confirm the new PR no longer proposes `v1.6.0`.