### PR TITLE
fix(signalprocessing,authwebhook): SP least-privilege RBAC + AgentSession existence gate (#2243, #2244)

### DIFF
--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -1744,7 +1744,7 @@ components:
           type: string
           minLength: 1
           maxLength: 50
-          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend, security]
+          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend, security, agentsession]
           description: |
             Domain-level event category (ADR-034 v1.8, Issue #306).
             Per convention: event_category identifies the business domain of the event.
@@ -1763,6 +1763,7 @@ components:
             - actiontype: ActionType taxonomy lifecycle events (Issue #300)
             - apifrontend: API Frontend service — triage, session, delegation, and user decision events (Issue #1021)
             - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not tied to a single business domain (GAP-09, Issue #1505)
+            - agentsession: AgentSession CRD admission events (RemediationRequest existence gate, Issue #2244)
           example: gateway
         event_action:
           type: string
@@ -1903,6 +1904,7 @@ components:
             - $ref: '#/components/schemas/ActionTypeCatalogReenabledPayload'
             - $ref: '#/components/schemas/ActionTypeCatalogDisableDeniedPayload'
             - $ref: '#/components/schemas/ActionTypeWebhookAuditPayload'
+            - $ref: '#/components/schemas/AgentSessionWebhookAuditPayload'
             - $ref: '#/components/schemas/ApifrontendTriageStartedPayload'
             - $ref: '#/components/schemas/ApifrontendTriageCompletedPayload'
             - $ref: '#/components/schemas/ApifrontendRRCreatedPayload'
@@ -2052,6 +2054,8 @@ components:
               'actiontype.denied.create': '#/components/schemas/ActionTypeWebhookAuditPayload'
               'actiontype.denied.update': '#/components/schemas/ActionTypeWebhookAuditPayload'
               'actiontype.denied.delete': '#/components/schemas/ActionTypeWebhookAuditPayload'
+              'agentsession.admitted.create': '#/components/schemas/AgentSessionWebhookAuditPayload'
+              'agentsession.denied.create': '#/components/schemas/AgentSessionWebhookAuditPayload'
               'apifrontend.triage.started': '#/components/schemas/ApifrontendTriageStartedPayload'
               'apifrontend.triage.completed': '#/components/schemas/ApifrontendTriageCompletedPayload'
               'apifrontend.rr.created': '#/components/schemas/ApifrontendRRCreatedPayload'
@@ -6169,6 +6173,35 @@ components:
         denial_reason:
           type: string
         denial_operation:
+          type: string
+
+    AgentSessionWebhookAuditPayload:
+      type: object
+      description: "AW audit payload for AgentSession CRD admission events (RemediationRequest existence gate, Issue #2244, BR-AA-KA-065.13)"
+      required:
+        - event_type
+        - crd_name
+        - crd_namespace
+        - action
+      properties:
+        event_type:
+          type: string
+          enum:
+            - 'agentsession.admitted.create'
+            - 'agentsession.denied.create'
+        crd_name:
+          type: string
+          description: "K8s metadata.name"
+        crd_namespace:
+          type: string
+          description: "K8s namespace"
+        action:
+          type: string
+          enum: ['create', 'denied']
+        remediation_request_ref:
+          type: string
+          description: "Spec.RemediationRequestRef.Name being validated for existence"
+        denial_reason:
           type: string
 
     # ── Apifrontend Audit Payloads (Issue #1021) ──────────────────────────

--- a/charts/kubernaut/templates/authwebhook/webhooks.yaml
+++ b/charts/kubernaut/templates/authwebhook/webhooks.yaml
@@ -134,3 +134,23 @@ webhooks:
         scope: "Namespaced"
     sideEffects: NoneOnDryRun
     timeoutSeconds: 15
+  - name: agentsession.validate.kubernaut.ai
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: authwebhook
+        namespace: {{ .Release.Namespace }}
+        path: /validate-agentsession
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ .Release.Namespace }}
+    rules:
+      - apiGroups: ["kubernaut.ai"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE"]
+        resources: ["agentsessions"]
+        scope: "Namespaced"
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 15

--- a/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
+++ b/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
@@ -118,8 +118,13 @@ metadata:
   labels:
     {{- include "kubernaut.labels" . | nindent 4 }}
 rules:
+  # #2243 (BR-RBAC-020, FedRAMP AC-6): remediationrequests was previously
+  # granted here alongside signalprocessings, but SP never performs CRUD
+  # against the RemediationRequest CRD -- it only reads
+  # Spec.RemediationRequestRef.Name (a plain string field) for audit
+  # correlation. Removed as an unused, least-privilege-violating grant.
   - apiGroups: ["kubernaut.ai"]
-    resources: ["signalprocessings", "remediationrequests"]
+    resources: ["signalprocessings"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["kubernaut.ai"]
     resources: ["signalprocessings/status", "signalprocessings/finalizers"]

--- a/charts/kubernaut/tests/authwebhook_agentsession_webhook_test.yaml
+++ b/charts/kubernaut/tests/authwebhook_agentsession_webhook_test.yaml
@@ -1,0 +1,167 @@
+suite: "Issue #2244 (BR-AA-KA-065.13): AgentSession CREATE existence-gate ValidatingWebhookConfiguration entry"
+# charts/kubernaut/templates/authwebhook/webhooks.yaml gains a new
+# agentsession.validate.kubernaut.ai entry (AgentSessionHandler) alongside
+# the existing remediationworkflow/actiontype entries. This must intercept
+# CREATE only (AgentSessionSpec is CEL-immutable, so UPDATE/DELETE need no
+# gate) with failurePolicy: Fail, matching the RW/ActionType precedent
+# (DD-WEBHOOK-001 v1.5).
+templates:
+  - templates/authwebhook/webhooks.yaml
+set:
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+  global:
+    llmProfiles:
+      primary:
+        provider: openai
+        model: gpt-4
+        credentialsSecretName: llm-credentials-primary
+  kubernautAgent:
+    llmProfileRef: primary
+tests:
+  - it: "IT-HELM-2244-001: agentsession.validate.kubernaut.ai entry intercepts CREATE only"
+    documentSelector:
+      path: metadata.name
+      value: authwebhook-validating
+    asserts:
+      - isKind:
+          of: ValidatingWebhookConfiguration
+      - contains:
+          path: webhooks
+          content:
+            name: agentsession.validate.kubernaut.ai
+            admissionReviewVersions: ["v1"]
+            clientConfig:
+              service:
+                name: authwebhook
+                namespace: NAMESPACE
+                path: /validate-agentsession
+            failurePolicy: Fail
+            matchPolicy: Equivalent
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: NAMESPACE
+            rules:
+              - apiGroups: ["kubernaut.ai"]
+                apiVersions: ["v1alpha1"]
+                operations: ["CREATE"]
+                resources: ["agentsessions"]
+                scope: "Namespaced"
+            sideEffects: NoneOnDryRun
+            timeoutSeconds: 15
+
+  - it: "IT-HELM-2244-002: agentsession entry does NOT intercept UPDATE or DELETE (AgentSessionSpec is CEL-immutable)"
+    documentSelector:
+      path: metadata.name
+      value: authwebhook-validating
+    asserts:
+      - notContains:
+          path: webhooks
+          content:
+            name: agentsession.validate.kubernaut.ai
+            admissionReviewVersions: ["v1"]
+            clientConfig:
+              service:
+                name: authwebhook
+                namespace: NAMESPACE
+                path: /validate-agentsession
+            failurePolicy: Fail
+            matchPolicy: Equivalent
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: NAMESPACE
+            rules:
+              - apiGroups: ["kubernaut.ai"]
+                apiVersions: ["v1alpha1"]
+                operations: ["CREATE", "UPDATE", "DELETE"]
+                resources: ["agentsessions"]
+                scope: "Namespaced"
+            sideEffects: NoneOnDryRun
+            timeoutSeconds: 15
+
+  - it: "IT-HELM-2244-003: rendered namespace defaults to the release namespace when installed into a custom namespace"
+    release:
+      namespace: kubernaut-prod
+    documentSelector:
+      path: metadata.name
+      value: authwebhook-validating
+    asserts:
+      - contains:
+          path: webhooks
+          content:
+            name: agentsession.validate.kubernaut.ai
+            admissionReviewVersions: ["v1"]
+            clientConfig:
+              service:
+                name: authwebhook
+                namespace: kubernaut-prod
+                path: /validate-agentsession
+            failurePolicy: Fail
+            matchPolicy: Equivalent
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: kubernaut-prod
+            rules:
+              - apiGroups: ["kubernaut.ai"]
+                apiVersions: ["v1alpha1"]
+                operations: ["CREATE"]
+                resources: ["agentsessions"]
+                scope: "Namespaced"
+            sideEffects: NoneOnDryRun
+            timeoutSeconds: 15
+
+  - it: "IT-HELM-2244-004: RemediationWorkflow and ActionType entries are unaffected (regression guard)"
+    documentSelector:
+      path: metadata.name
+      value: authwebhook-validating
+    asserts:
+      - contains:
+          path: webhooks
+          content:
+            name: remediationworkflow.validate.kubernaut.ai
+            admissionReviewVersions: ["v1"]
+            clientConfig:
+              service:
+                name: authwebhook
+                namespace: NAMESPACE
+                path: /validate-remediationworkflow
+            failurePolicy: Fail
+            matchPolicy: Equivalent
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: NAMESPACE
+            rules:
+              - apiGroups: ["kubernaut.ai"]
+                apiVersions: ["v1alpha1"]
+                operations: ["CREATE", "UPDATE", "DELETE"]
+                resources: ["remediationworkflows"]
+                scope: "Namespaced"
+            sideEffects: NoneOnDryRun
+            timeoutSeconds: 15
+      - contains:
+          path: webhooks
+          content:
+            name: actiontype.validate.kubernaut.ai
+            admissionReviewVersions: ["v1"]
+            clientConfig:
+              service:
+                name: authwebhook
+                namespace: NAMESPACE
+                path: /validate-actiontype
+            failurePolicy: Fail
+            matchPolicy: Equivalent
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: NAMESPACE
+            rules:
+              - apiGroups: ["kubernaut.ai"]
+                apiVersions: ["v1alpha1"]
+                operations: ["CREATE", "UPDATE", "DELETE"]
+                resources: ["actiontypes"]
+                scope: "Namespaced"
+            sideEffects: NoneOnDryRun
+            timeoutSeconds: 15

--- a/charts/kubernaut/tests/signalprocessing_rbac_least_privilege_test.yaml
+++ b/charts/kubernaut/tests/signalprocessing_rbac_least_privilege_test.yaml
@@ -1,0 +1,59 @@
+suite: "Issue #2243: SP ClusterRole must not grant full-CRUD RemediationRequest RBAC (AC-6 least privilege)"
+# templates/signalprocessing/signalprocessing.yaml's ClusterRole grants full
+# CRUD (get/list/watch/create/update/patch/delete) on "remediationrequests"
+# alongside "signalprocessings" in the same rule. Static analysis of
+# internal/controller/signalprocessing/ and pkg/signalprocessing/ found zero
+# client.Get/List/Create/Update/Patch/Delete call sites against the
+# RemediationRequest CRD type -- SP only reads
+# Spec.RemediationRequestRef.Name (a plain string field on its own CRD,
+# populated by RO at creation) for audit correlation, never the RR object
+# itself. This is a dead, unused grant and a least-privilege (FedRAMP AC-6)
+# violation.
+templates:
+  - templates/signalprocessing/signalprocessing.yaml
+set:
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+tests:
+  - it: "IT-HELM-2243-001: SP ClusterRole does NOT grant any verbs on remediationrequests"
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["kubernaut.ai"]
+            resources: ["signalprocessings", "remediationrequests"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["kubernaut.ai"]
+            resources: ["remediationrequests"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: "IT-HELM-2243-002: SP ClusterRole retains full-CRUD on signalprocessings (regression guard -- own CRD access must be unaffected)"
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["kubernaut.ai"]
+            resources: ["signalprocessings"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: "IT-HELM-2243-003: no rule anywhere in SP's ClusterRole references the remediationrequests resource string at all"
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - notContains:
+          path: rules[0].resources
+          content: remediationrequests

--- a/cmd/authwebhook/main.go
+++ b/cmd/authwebhook/main.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	actiontypev1 "github.com/jordigilh/kubernaut/api/actiontype/v1alpha1"
+	agentsessionv1alpha1 "github.com/jordigilh/kubernaut/api/agentsession/v1alpha1"
 	notificationv1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
 	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	remediationworkflowv1 "github.com/jordigilh/kubernaut/api/remediationworkflow/v1alpha1"
@@ -47,6 +48,7 @@ func init() {
 	utilruntime.Must(notificationv1.AddToScheme(scheme))
 	utilruntime.Must(remediationworkflowv1.AddToScheme(scheme))
 	utilruntime.Must(actiontypev1.AddToScheme(scheme))
+	utilruntime.Must(agentsessionv1alpha1.AddToScheme(scheme))
 }
 
 // loadAuthWebhookConfig loads the YAML config (or defaults, ADR-030),
@@ -272,11 +274,12 @@ func registerAuthWebhookCRUDHandlers(mgr ctrl.Manager, auditStore audit.AuditSto
 	setupLog.Info("Registered NotificationRequest DELETE webhook handler with audit store")
 }
 
-// registerAuthWebhookWorkflowHandlers wires the RemediationWorkflow and
-// ActionType admission handlers (ADR-058, ADR-059), the RemediationWorkflow
-// finalizer reconciler (Issue #418), and the startup reconciler that syncs
-// existing CRDs with DataStorage on boot (Issue #548, #1246). Exits the
-// process on any failure, matching main()'s original fail-fast behavior.
+// registerAuthWebhookWorkflowHandlers wires the RemediationWorkflow,
+// ActionType (ADR-058, ADR-059), and AgentSession (Issue #2244) admission
+// handlers, the RemediationWorkflow finalizer reconciler (Issue #418), and
+// the startup reconciler that syncs existing CRDs with DataStorage on boot
+// (Issue #548, #1246). Exits the process on any failure, matching main()'s
+// original fail-fast behavior.
 func registerAuthWebhookWorkflowHandlers(mgr ctrl.Manager, cfg *awconfig.Config, auditStore audit.AuditStore) {
 	webhookServer := mgr.GetWebhookServer()
 
@@ -316,6 +319,12 @@ func registerAuthWebhookWorkflowHandlers(mgr ctrl.Manager, cfg *awconfig.Config,
 	atHandler := authwebhook.NewActionTypeHandler(auditStore, mgr.GetClient())
 	webhookServer.Register("/validate-actiontype", &webhook.Admission{Handler: atHandler})
 	setupLog.Info("Registered ActionType webhook handler with audit store")
+
+	// Issue #2244, BR-AA-KA-065.13: AgentSession CREATE existence gate
+	// (RemediationRequestRef must resolve to a real RemediationRequest).
+	asHandler := authwebhook.NewAgentSessionHandler(auditStore, mgr.GetClient())
+	webhookServer.Register("/validate-agentsession", &webhook.Admission{Handler: asHandler})
+	setupLog.Info("Registered AgentSession webhook handler with audit store")
 
 	// Issue #548: Startup reconciler syncs existing CRDs with DataStorage on boot.
 	// Issue #1246: Graceful degradation — individual RW failures don't crash the pod.

--- a/docs/architecture/decisions/DD-WEBHOOK-001-crd-webhook-requirements-matrix.md
+++ b/docs/architecture/decisions/DD-WEBHOOK-001-crd-webhook-requirements-matrix.md
@@ -7,6 +7,7 @@
 **Scope**: All Kubernetes CRDs in Kubernaut requiring user authentication
 
 **Version History**:
+- **v1.5** (August 22, 2026): Issue #2244 — Added `AgentSession` (CREATE-only) as 5th webhook handler. `AgentSessionHandler` gates CREATE on `Spec.RemediationRequestRef` resolving to a real `RemediationRequest` in the same namespace, denying otherwise (SI-10 input validation at the trust boundary, before KA's dispatcher observes the object). Existence-gate pattern mirrors `#1661`/`DD-WORKFLOW-018` and the existing `validateActionTypeExists` precedent in `remediationworkflow_handler.go`. `AgentSessionSpec` is CEL-immutable (`self == oldSelf`), so no UPDATE gate is needed. Zero new RBAC (reuses AW's existing `get/list/watch` grant on `remediationrequests`). `failurePolicy: Fail`, matching RW/ActionType's entries. New BR: `BR-AA-KA-065.13`.
 - **v1.4** (April 21, 2026): Issue #773 — RemediationWorkflow operations updated from CREATE/DELETE to CREATE/UPDATE/DELETE. UPDATE now triggers DS re-registration with content integrity enforcement (409 on same version + different content). Distinct `remediationworkflow.admitted.update` audit event type added (SOC2 CC8.1).
 - **v1.3** (March 4, 2026): Added RemediationWorkflow (CREATE/DELETE) as 4th webhook handler. Workflow registration now uses CRD + ValidatingWebhook (ADR-058), replacing REST-only approach. Corrects v1.1 note about workflow CRUD using HTTP middleware.
 - **v1.2** (January 6, 2026): **ARCHITECTURE UPDATE**: Single consolidated webhook deployment (`kubernaut-auth-webhook`) with multiple handlers. Updated implementation approach and timelines. Added references to comprehensive implementation and test plans.
@@ -57,6 +58,10 @@
 │  │    → CREATE: registers in DS, updates .status async      │ │
 │  │    → DELETE: disables in DS (best-effort)                │ │
 │  │                                                           │ │
+│  │  Route: /validate-agentsession                            │ │
+│  │    → AgentSessionHandler (#2244)                          │ │
+│  │    → CREATE: denies if RemediationRequestRef unresolvable│ │
+│  │                                                           │ │
 │  │  Shared: ExtractAuthenticatedUser(req.UserInfo)          │ │
 │  └──────────────────────────────────────────────────────────┘ │
 │                                                                 │
@@ -95,6 +100,7 @@ pkg/authwebhook/notificationrequest_handler.go        # NR-specific logic
 pkg/authwebhook/remediationworkflow_handler.go        # RW-specific logic (ADR-058)
 pkg/authwebhook/remediationworkflow_audit.go          # RW audit helpers
 pkg/authwebhook/ds_client.go                          # DS client adapter for RW handler
+pkg/authwebhook/agentsession_handler.go               # AS-specific logic (#2244)
 ```
 
 **Comprehensive Plans**:
@@ -182,7 +188,7 @@ env:
 
 ## 📊 **CRD Webhook Requirements Matrix**
 
-### **CRDs Requiring Webhooks** ✅ (4 Total)
+### **CRDs Requiring Webhooks** ✅ (5 Total)
 
 | CRD | Use Case | Status Fields Requiring Auth | SOC2 Control | Implementation Owner | Priority | Target Version |
 |-----|----------|------------------------------|--------------|----------------------|----------|----------------|
@@ -190,8 +196,11 @@ env:
 | **RemediationApprovalRequest** | Approval Decisions | `status.approvalRequest` | CC8.1 (Attribution) | RO Team | P0 | v1.0 |
 | **NotificationRequest** | Cancellation Attribution | `metadata.deletionTimestamp` (DELETE) | CC8.1 (Attribution) | Notification Team | P0 | v1.1 |
 | **RemediationWorkflow** | CRD-Based Registration/Disable/Re-Registration | `status.workflowId`, `status.catalogStatus` (CREATE/UPDATE/DELETE) | CC8.1 (Attribution) | Webhook Team | P0 | v1.0 |
+| **AgentSession** | RemediationRequest Existence Gate (CREATE-only) | N/A (no status write; pure Allow/Deny) | N/A — SI-10 (input validation) | Webhook Team | P1 | v1.5 |
 
 **Note**: RemediationWorkflow registration uses a ValidatingWebhookConfiguration that bridges CRD lifecycle to the DS workflow catalog (ADR-058, BR-WORKFLOW-006). The DS REST API for workflow registration is internal-only.
+
+**Note (v1.5)**: `AgentSession`'s webhook is not driven by the standard Criterion 1-4 decision tree (no manual intervention, no SOC2 attribution need — `AgentSession.Status` is exclusively KA-owned per DD-AA-KA-001). It exists instead as a **cross-resource existence gate**: `Spec.RemediationRequestRef` is set by the client at CREATE and is CEL-immutable thereafter, but nothing at the CRD-schema level can verify the referenced `RemediationRequest` actually exists (CEL/`x-kubernetes-validations` cannot look up a different object). The webhook is the only enforcement point capable of denying a dangling reference before AA's dispatcher ever observes it (SI-10). See Use Case 5 below.
 
 ### **CRDs NOT Requiring Webhooks** ❌
 
@@ -427,6 +436,39 @@ kubectl delete notificationrequest <nr-name> -n <namespace>
 
 ---
 
+### **Use Case 5: AgentSession → RemediationRequest Existence Gate** (v1.5)
+
+**Business Requirement**: `BR-AA-KA-065.13` (Issue [#2244](https://github.com/jordigilh/kubernaut/issues/2244))
+
+**Scenario**: `AgentSession` is created with `Spec.RemediationRequestRef` pointing at the `RemediationRequest` that triggered the investigation. Nothing at the CRD-schema level (CEL/`x-kubernetes-validations`) can verify a *different* object exists — only the object's own fields are evaluated. Without an admission-time check, a dangling reference (typo, stale fixture, race between RR deletion and AS creation) would reach KA's dispatcher undetected.
+
+**Why Webhook Required**:
+1. ✅ **Input Validation at the Trust Boundary (SI-10)**: the reference must be verified before KA ever observes the object, not downstream in application code.
+2. ❌ Does **not** meet Criteria 1-3 (no manual intervention, no SOC2 attribution, no approval workflow) — this is a pure existence-gate, not an attribution webhook. Included in this matrix because it is still an admission-time authenticated denial with an audit trail, following the same architectural pattern (and shared `pkg/authwebhook` plumbing) as the other four handlers.
+4. ✅ **Precedent**: identical existence-gate shape to `#1661`'s `validateActionTypeExists` (RemediationWorkflow → ActionType) and documented generally in [DD-WORKFLOW-018](./DD-WORKFLOW-018-etcd-single-source-of-truth.md).
+
+**Operations Intercepted**:
+- **CREATE only**: denies if `client.Get` on `Spec.RemediationRequestRef.{Name,Namespace}` returns `NotFound` or a lookup error.
+- **No UPDATE/DELETE gate**: `AgentSessionSpec` carries `+kubebuilder:validation:XValidation:rule="self == oldSelf"` (CEL-immutable) — the reference cannot change post-create, so there is nothing for an UPDATE gate to re-validate.
+
+**Status Fields**: none. `AgentSession.Status` is exclusively KA-owned (`DD-AA-KA-001`); the handler never writes `.status` and requires no async goroutine, unlike RW/ActionType's `.status`-writing handlers.
+
+**Audit Events** (synchronous, before the admission response returns):
+- `agentsession.admitted.create`: CREATE admitted (RR resolved)
+- `agentsession.denied.create`: CREATE denied (RR not found or lookup error)
+
+**RBAC**: zero new grants — reuses AW's existing `get/list/watch` on `remediationrequests` ([charts/kubernaut/templates/authwebhook/authwebhook.yaml](../../../charts/kubernaut/templates/authwebhook/authwebhook.yaml)).
+
+**Webhook Type**: **ValidatingWebhookConfiguration** (CREATE only), namespace-scoped (`.Release.Namespace`), `failurePolicy: Fail` (matches RW/ActionType's entries — see Changelog v1.5 rationale).
+
+**Implementation Owner**: Webhook Team
+
+**Timeline**: Implemented (v1.5, Issue #2244)
+
+**Reference**: [DD-WORKFLOW-018-etcd-single-source-of-truth.md](./DD-WORKFLOW-018-etcd-single-source-of-truth.md) (existence-gate pattern precedent)
+
+---
+
 ## 🚫 **Anti-Patterns - When NOT to Use Webhooks**
 
 ### **❌ Anti-Pattern 1: Controller-Only Status Updates**
@@ -594,6 +636,7 @@ Is this an approval workflow or override action?
 | **RemediationApprovalRequest** | ✅ YES | Webhook Team | Phase 3 (Day 3) | 1 day | Phase 1 complete |
 | **NotificationRequest** (v1.1) | ✅ YES | Webhook Team | Phase 4 (Day 4) | 1 day | Phase 1 complete |
 | **RemediationWorkflow** (v1.3) | ✅ YES | Webhook Team | Implemented (Issue #299) | Implemented | ADR-058, BR-WORKFLOW-006 |
+| **AgentSession** (v1.5) | ✅ YES | Webhook Team | Implemented (Issue #2244) | Implemented | #1661, DD-WORKFLOW-018, BR-AA-KA-065.13 |
 | **SignalProcessing** | ❌ NO | N/A | N/A | N/A | N/A (K8s enrichment automated) |
 | **AIAnalysis** | ❌ NO | N/A | N/A | N/A | N/A (AI investigation automated) |
 | **RemediationRequest** | ❌ NO | N/A | N/A | N/A | N/A (routing automated) |
@@ -786,6 +829,8 @@ This DD is successfully implemented when:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| **1.5** | **2026-08-22** | Issue #2244 — Added `AgentSession` as 5th webhook handler (ValidatingWebhookConfiguration, CREATE-only). `AgentSessionHandler` gates admission on `Spec.RemediationRequestRef` resolving to a real `RemediationRequest` in the same namespace (SI-10). Not an attribution webhook (no `.status` write; `AgentSession.Status` is exclusively KA-owned per DD-AA-KA-001) — included in this matrix as a cross-resource existence gate following the `#1661`/`DD-WORKFLOW-018` pattern. No UPDATE/DELETE gate needed: `AgentSessionSpec` is CEL-immutable (`self == oldSelf`). Zero new RBAC (reuses AW's existing `remediationrequests` read grant). `failurePolicy: Fail`, matching RW/ActionType. New BR: `BR-AA-KA-065.13`. Added Use Case 5, updated matrix (4→5), team responsibility matrix, and architecture diagram/file structure. |
+| **1.4** | **2026-04-21** | Issue #773 — RemediationWorkflow operations updated from CREATE/DELETE to CREATE/UPDATE/DELETE. UPDATE now triggers DS re-registration with content integrity enforcement (409 on same version + different content). Distinct `remediationworkflow.admitted.update` audit event type added (SOC2 CC8.1). |
 | **1.3** | **2026-03-04** | Added RemediationWorkflow as 4th webhook handler (ValidatingWebhookConfiguration for CREATE/DELETE). Workflow registration now uses CRD + AW bridge to DS (ADR-058, BR-WORKFLOW-006). Corrects v1.1 note: workflow operations now use CRD webhook, not HTTP middleware. Updated architecture diagram, file structure, matrix (3→4), team responsibility matrix, and timeline. |
 | 1.2 | 2026-01-06 | **ARCHITECTURE UPDATE**: Single consolidated webhook deployment (`kubernaut-auth-webhook`) with multiple handlers instead of 3 separate webhooks. Added consolidated architecture section with benefits (66% memory reduction, 3× faster deployments, guaranteed consistency). Updated team responsibility matrix for unified Webhook Team ownership. Updated implementation timeline to 5-6 days consolidated approach. Added comprehensive [implementation plan](../../development/SOC2/WEBHOOK_IMPLEMENTATION_PLAN.md) and [test plan](../../development/SOC2/WEBHOOK_TEST_PLAN.md) references. Updated all DD-AUTH-002 references to DD-AUTH-003 (sidecar pattern supersedes middleware). |
 | 1.1 | 2026-01-06 | Added NotificationRequest (DELETE attribution). Workflow CRUD uses externalized authorization via sidecar (DD-AUTH-003), not CRD webhook. |
@@ -796,7 +841,7 @@ This DD is successfully implemented when:
 ---
 
 **Document Status**: ✅ **AUTHORITATIVE**
-**Version**: 1.3
+**Version**: 1.5
 **Authority**: Decision criteria for all CRD webhook implementations
-**Next Review**: 2026-06-04 (3 months)
+**Next Review**: 2026-11-22 (3 months)
 

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -1744,7 +1744,7 @@ components:
           type: string
           minLength: 1
           maxLength: 50
-          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend, security]
+          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend, security, agentsession]
           description: |
             Domain-level event category (ADR-034 v1.8, Issue #306).
             Per convention: event_category identifies the business domain of the event.
@@ -1763,6 +1763,7 @@ components:
             - actiontype: ActionType taxonomy lifecycle events (Issue #300)
             - apifrontend: API Frontend service — triage, session, delegation, and user decision events (Issue #1021)
             - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not tied to a single business domain (GAP-09, Issue #1505)
+            - agentsession: AgentSession CRD admission events (RemediationRequest existence gate, Issue #2244)
           example: gateway
         event_action:
           type: string
@@ -1903,6 +1904,7 @@ components:
             - $ref: '#/components/schemas/ActionTypeCatalogReenabledPayload'
             - $ref: '#/components/schemas/ActionTypeCatalogDisableDeniedPayload'
             - $ref: '#/components/schemas/ActionTypeWebhookAuditPayload'
+            - $ref: '#/components/schemas/AgentSessionWebhookAuditPayload'
             - $ref: '#/components/schemas/ApifrontendTriageStartedPayload'
             - $ref: '#/components/schemas/ApifrontendTriageCompletedPayload'
             - $ref: '#/components/schemas/ApifrontendRRCreatedPayload'
@@ -2052,6 +2054,8 @@ components:
               'actiontype.denied.create': '#/components/schemas/ActionTypeWebhookAuditPayload'
               'actiontype.denied.update': '#/components/schemas/ActionTypeWebhookAuditPayload'
               'actiontype.denied.delete': '#/components/schemas/ActionTypeWebhookAuditPayload'
+              'agentsession.admitted.create': '#/components/schemas/AgentSessionWebhookAuditPayload'
+              'agentsession.denied.create': '#/components/schemas/AgentSessionWebhookAuditPayload'
               'apifrontend.triage.started': '#/components/schemas/ApifrontendTriageStartedPayload'
               'apifrontend.triage.completed': '#/components/schemas/ApifrontendTriageCompletedPayload'
               'apifrontend.rr.created': '#/components/schemas/ApifrontendRRCreatedPayload'
@@ -6169,6 +6173,35 @@ components:
         denial_reason:
           type: string
         denial_operation:
+          type: string
+
+    AgentSessionWebhookAuditPayload:
+      type: object
+      description: "AW audit payload for AgentSession CRD admission events (RemediationRequest existence gate, Issue #2244, BR-AA-KA-065.13)"
+      required:
+        - event_type
+        - crd_name
+        - crd_namespace
+        - action
+      properties:
+        event_type:
+          type: string
+          enum:
+            - 'agentsession.admitted.create'
+            - 'agentsession.denied.create'
+        crd_name:
+          type: string
+          description: "K8s metadata.name"
+        crd_namespace:
+          type: string
+          description: "K8s namespace"
+        action:
+          type: string
+          enum: ['create', 'denied']
+        remediation_request_ref:
+          type: string
+          description: "Spec.RemediationRequestRef.Name being validated for existence"
+        denial_reason:
           type: string
 
     # ── Apifrontend Audit Payloads (Issue #1021) ──────────────────────────

--- a/pkg/authwebhook/agentsession_handler.go
+++ b/pkg/authwebhook/agentsession_handler.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authwebhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	agentsessionv1alpha1 "github.com/jordigilh/kubernaut/api/agentsession/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/audit"
+	api "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	admissionv1 "k8s.io/api/admission/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AgentSessionHandler handles admission requests for AgentSession CRD CREATE
+// operations. Issue #2244, BR-AA-KA-065.13: a cross-resource existence gate
+// mirroring #1661's validateActionTypeExists pattern (DD-WORKFLOW-018) --
+// denies CREATE when Spec.RemediationRequestRef does not resolve to a real
+// RemediationRequest in the same namespace (SI-10: input validation at the
+// trust boundary, before KA's dispatcher ever observes the object).
+//
+// No UPDATE/DELETE gate is needed: AgentSessionSpec carries
+// +kubebuilder:validation:XValidation:rule="self == oldSelf" (CEL-immutable),
+// so RemediationRequestRef cannot change post-create.
+//
+// Unlike RemediationWorkflowHandler/ActionTypeHandler, this handler never
+// writes .status -- AgentSession.Status is exclusively KA-owned
+// (DD-AA-KA-001) -- so the audit-emit below is synchronous, before the
+// admission response returns, with no async goroutine.
+type AgentSessionHandler struct {
+	auditStore audit.AuditStore
+	k8sClient  client.Client
+}
+
+// NewAgentSessionHandler creates a handler for AgentSession admission.
+func NewAgentSessionHandler(auditStore audit.AuditStore, k8sClient client.Client) *AgentSessionHandler {
+	return &AgentSessionHandler{
+		auditStore: auditStore,
+		k8sClient:  k8sClient,
+	}
+}
+
+// Handle processes admission requests for AgentSession CRD. Only CREATE is
+// intercepted -- see the type doc comment for why UPDATE/DELETE need no gate.
+func (h *AgentSessionHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.Operation != admissionv1.Create {
+		return admission.Allowed("operation not intercepted")
+	}
+	return h.handleCreate(ctx, req)
+}
+
+// handleCreate denies CREATE when Spec.RemediationRequestRef does not
+// resolve to a real RemediationRequest in req.Namespace.
+func (h *AgentSessionHandler) handleCreate(ctx context.Context, req admission.Request) admission.Response {
+	logger := ctrl.Log.WithName("as-webhook").WithValues("operation", "CREATE", "name", req.Name, "namespace", req.Namespace)
+
+	as := &agentsessionv1alpha1.AgentSession{}
+	if err := json.Unmarshal(req.Object.Raw, as); err != nil {
+		logger.Error(err, "Failed to unmarshal AgentSession")
+		h.emitDeniedAudit(ctx, req, fmt.Sprintf("failed to unmarshal AgentSession: %v", err))
+		return admission.Denied(fmt.Sprintf("failed to unmarshal AgentSession: %v", err))
+	}
+
+	if err := h.validateRemediationRequestExists(ctx, as.Spec.RemediationRequestRef.Name, req.Namespace); err != nil {
+		logger.Error(err, "RemediationRequest existence check failed", "remediationRequestRef", as.Spec.RemediationRequestRef.Name)
+		h.emitDeniedAudit(ctx, req, err.Error())
+		return admission.Denied(err.Error())
+	}
+
+	logger.Info("AgentSession admitted", "remediationRequestRef", as.Spec.RemediationRequestRef.Name)
+	h.emitAdmitAudit(ctx, req, as.Spec.RemediationRequestRef.Name)
+
+	return admission.Allowed("agent session admitted")
+}
+
+// validateRemediationRequestExists checks that rrName resolves to a real
+// RemediationRequest in namespace via a direct Get -- RemediationRequestRef
+// is a plain ObjectRef{Name, Namespace}, so no field indexer is needed
+// (unlike ActionType's list-by-spec.name lookup).
+//
+// h.k8sClient is nil in unit tests that don't exercise this gate
+// (production always wires a real cache-backed client in
+// cmd/authwebhook/main.go); the check is skipped rather than denied in that
+// case, matching the existing best-effort precedent of
+// RemediationWorkflowHandler.validateActionTypeExists.
+func (h *AgentSessionHandler) validateRemediationRequestExists(ctx context.Context, rrName, namespace string) error {
+	if h.k8sClient == nil {
+		return nil
+	}
+
+	rr := &remediationv1.RemediationRequest{}
+	key := types.NamespacedName{Name: rrName, Namespace: namespace}
+	if err := h.k8sClient.Get(ctx, key, rr); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("remediationRequestRef %q does not exist in namespace %q", rrName, namespace)
+		}
+		return fmt.Errorf("remediation request lookup failed for %q: %w", rrName, err)
+	}
+	return nil
+}
+
+// emitAdmitAudit emits a success audit event for an admitted AgentSession CREATE.
+func (h *AgentSessionHandler) emitAdmitAudit(ctx context.Context, req admission.Request, rrName string) {
+	if h.auditStore == nil {
+		return
+	}
+
+	event := buildAuditEnvelope(req, WebhookAuditOpts{
+		EventType:    EventTypeASAdmittedCreate,
+		Category:     EventCategoryAgentSession,
+		Action:       "admitted",
+		Outcome:      api.AuditEventRequestEventOutcomeSuccess,
+		ResourceKind: "AgentSession",
+		ResourceID:   req.Name,
+	})
+
+	payload := api.AgentSessionWebhookAuditPayload{
+		EventType:    api.AgentSessionWebhookAuditPayloadEventTypeAgentsessionAdmittedCreate,
+		CrdName:      req.Name,
+		CrdNamespace: req.Namespace,
+		Action:       api.AgentSessionWebhookAuditPayloadActionCreate,
+	}
+	payload.RemediationRequestRef.SetTo(rrName)
+	event.EventData = api.NewAuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData(payload)
+
+	storeAuditBestEffort(ctx, h.auditStore, event, "as-webhook", EventTypeASAdmittedCreate)
+}
+
+// emitDeniedAudit emits a denied audit event when an AgentSession CREATE is rejected.
+func (h *AgentSessionHandler) emitDeniedAudit(ctx context.Context, req admission.Request, reason string) {
+	if h.auditStore == nil {
+		return
+	}
+
+	event := buildAuditEnvelope(req, WebhookAuditOpts{
+		EventType:    EventTypeASDeniedCreate,
+		Category:     EventCategoryAgentSession,
+		Action:       "denied",
+		Outcome:      api.AuditEventRequestEventOutcomeFailure,
+		ResourceKind: "AgentSession",
+		ResourceID:   req.Name,
+	})
+
+	payload := api.AgentSessionWebhookAuditPayload{
+		EventType:    api.AgentSessionWebhookAuditPayloadEventTypeAgentsessionDeniedCreate,
+		CrdName:      req.Name,
+		CrdNamespace: req.Namespace,
+		Action:       api.AgentSessionWebhookAuditPayloadActionDenied,
+	}
+	payload.DenialReason.SetTo(reason)
+	event.EventData = api.NewAuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData(payload)
+
+	storeAuditBestEffort(ctx, h.auditStore, event, "as-webhook", EventTypeASDeniedCreate)
+}

--- a/pkg/authwebhook/agentsession_handler_test.go
+++ b/pkg/authwebhook/agentsession_handler_test.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authwebhook_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	agentsessionv1alpha1 "github.com/jordigilh/kubernaut/api/agentsession/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/authwebhook"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	admissionv1 "k8s.io/api/admission/v1"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// ========================================
+// AgentSession Test Helpers (Issue #2244)
+// ========================================
+
+// buildAgentSession constructs a test fixture; name/namespace are fixed to
+// "session-1"/"kubernaut-system" since every call site in this file uses
+// the same values (unparam) -- only rrName varies across tests.
+func buildAgentSession(rrName string) *agentsessionv1alpha1.AgentSession {
+	const namespace = "kubernaut-system"
+	return &agentsessionv1alpha1.AgentSession{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubernaut.ai/v1alpha1",
+			Kind:       "AgentSession",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "session-1",
+			Namespace: namespace,
+			UID:       "as-uid-001",
+		},
+		Spec: agentsessionv1alpha1.AgentSessionSpec{
+			RemediationRequestRef: agentsessionv1alpha1.ObjectRef{
+				Name:      rrName,
+				Namespace: namespace,
+			},
+			IncidentID:    "aianalysis-001",
+			RemediationID: rrName,
+			SignalName:    "OOMKilled",
+			Severity:      "critical",
+		},
+	}
+}
+
+func buildRemediationRequestForAS(name, namespace string) *remediationv1.RemediationRequest {
+	return &remediationv1.RemediationRequest{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubernaut.ai/v1alpha1",
+			Kind:       "RemediationRequest",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       "rr-uid-001",
+		},
+		Spec: remediationv1.RemediationRequestSpec{
+			SignalFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			SignalName:        "OOMKilled",
+			Severity:          "critical",
+			TargetType:        "kubernetes",
+			TargetResource: remediationv1.ResourceIdentifier{
+				Kind:      "Pod",
+				Name:      "test-pod",
+				Namespace: namespace,
+			},
+			FiringTime:   metav1.Now(),
+			ReceivedTime: metav1.Now(),
+		},
+	}
+}
+
+func buildASCreateAdmissionRequest(as *agentsessionv1alpha1.AgentSession) admission.Request {
+	raw, _ := json.Marshal(as)
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID: "as-admission-create-001",
+			Kind: metav1.GroupVersionKind{
+				Group: "kubernaut.ai", Version: "v1alpha1", Kind: "AgentSession",
+			},
+			Name:      as.Name,
+			Namespace: as.Namespace,
+			Operation: admissionv1.Create,
+			UserInfo: authv1.UserInfo{
+				Username: testUserEmail,
+				UID:      testUserUID,
+				Groups:   []string{"system:masters"},
+			},
+			Object: runtime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+func buildASUpdateAdmissionRequest(oldAS, newAS *agentsessionv1alpha1.AgentSession) admission.Request {
+	oldRaw, _ := json.Marshal(oldAS)
+	newRaw, _ := json.Marshal(newAS)
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID: "as-admission-update-001",
+			Kind: metav1.GroupVersionKind{
+				Group: "kubernaut.ai", Version: "v1alpha1", Kind: "AgentSession",
+			},
+			Name:      newAS.Name,
+			Namespace: newAS.Namespace,
+			Operation: admissionv1.Update,
+			UserInfo: authv1.UserInfo{
+				Username: testUserEmail,
+				UID:      testUserUID,
+			},
+			Object:    runtime.RawExtension{Raw: newRaw},
+			OldObject: runtime.RawExtension{Raw: oldRaw},
+		},
+	}
+}
+
+func newASScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = agentsessionv1alpha1.AddToScheme(s)
+	_ = remediationv1.AddToScheme(s)
+	return s
+}
+
+// ========================================
+// Tests
+// ========================================
+
+var _ = Describe("AgentSession Admission Handler (#2244, BR-AA-KA-065.13)", func() {
+	var (
+		ctx       context.Context
+		mockAudit *MockAuditStoreRW
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockAudit = &MockAuditStoreRW{}
+	})
+
+	// ========================================
+	// UT-AS-2244-001: k8sClient nil skips the gate (best-effort precedent)
+	// ========================================
+	Describe("UT-AS-2244-001: k8sClient nil skips the existence gate", func() {
+		It("should return Allowed with zero k8s calls when h.k8sClient is nil (matches validateActionTypeExists precedent)", func() {
+			handler := authwebhook.NewAgentSessionHandler(mockAudit, nil)
+			as := buildAgentSession("rr-does-not-matter")
+
+			resp := handler.Handle(ctx, buildASCreateAdmissionRequest(as))
+
+			Expect(resp.Allowed).To(BeTrue(),
+				"CREATE should be Allowed when k8sClient is not configured (unit-test best-effort skip)")
+			Expect(mockAudit.StoredEvents).To(HaveLen(1))
+			Expect(mockAudit.StoredEvents[0].EventType).To(Equal(authwebhook.EventTypeASAdmittedCreate))
+		})
+	})
+
+	// ========================================
+	// UT-AS-2244-002: CREATE allowed when RemediationRequestRef resolves
+	// ========================================
+	Describe("UT-AS-2244-002: CREATE allowed when RemediationRequestRef resolves to a real RemediationRequest", func() {
+		It("should return Allowed and emit an admitted audit event", func() {
+			rr := buildRemediationRequestForAS("rr-001", "kubernaut-system")
+			as := buildAgentSession("rr-001")
+
+			fakeK8s := fake.NewClientBuilder().
+				WithScheme(newASScheme()).
+				WithObjects(rr).
+				Build()
+			handler := authwebhook.NewAgentSessionHandler(mockAudit, fakeK8s)
+
+			resp := handler.Handle(ctx, buildASCreateAdmissionRequest(as))
+
+			Expect(resp.Allowed).To(BeTrue(),
+				"CREATE should be Allowed when RemediationRequestRef resolves: %v", resp.Result)
+
+			Expect(mockAudit.StoredEvents).To(HaveLen(1))
+			event := mockAudit.StoredEvents[0]
+			Expect(event.EventType).To(Equal("agentsession.admitted.create"))
+			Expect(string(event.EventCategory)).To(Equal("agentsession"))
+			Expect(event.EventAction).To(Equal("admitted"))
+			Expect(string(event.EventOutcome)).To(Equal("success"))
+			Expect(event.ActorID.Value).To(Equal(testUserEmail))
+			Expect(event.ResourceType.Value).To(Equal("AgentSession"))
+			Expect(event.ResourceID.Value).To(Equal("session-1"))
+
+			payload, ok := event.EventData.GetAgentSessionWebhookAuditPayload()
+			Expect(ok).To(BeTrue(), "EventData should contain AgentSessionWebhookAuditPayload")
+			Expect(payload.CrdName).To(Equal("session-1"))
+			Expect(payload.CrdNamespace).To(Equal("kubernaut-system"))
+			Expect(payload.Action).To(Equal(ogenclient.AgentSessionWebhookAuditPayloadActionCreate))
+			Expect(payload.RemediationRequestRef.Value).To(Equal("rr-001"))
+		})
+	})
+
+	// ========================================
+	// UT-AS-2244-003: CREATE denied when RemediationRequestRef does not exist
+	// ========================================
+	Describe("UT-AS-2244-003: CREATE denied when RemediationRequestRef does not exist (SI-10)", func() {
+		It("should return Denied with a clear message and emit a denied audit event", func() {
+			as := buildAgentSession("rr-nonexistent")
+
+			fakeK8s := fake.NewClientBuilder().
+				WithScheme(newASScheme()).
+				Build()
+			handler := authwebhook.NewAgentSessionHandler(mockAudit, fakeK8s)
+
+			resp := handler.Handle(ctx, buildASCreateAdmissionRequest(as))
+
+			Expect(resp.Allowed).To(BeFalse(),
+				"CREATE should be Denied when RemediationRequestRef does not resolve")
+			Expect(resp.Result.Message).To(ContainSubstring("rr-nonexistent"))
+			Expect(resp.Result.Message).To(ContainSubstring("does not exist"))
+
+			Expect(mockAudit.StoredEvents).To(HaveLen(1))
+			event := mockAudit.StoredEvents[0]
+			Expect(event.EventType).To(Equal("agentsession.denied.create"))
+			Expect(string(event.EventOutcome)).To(Equal("failure"))
+			Expect(event.EventAction).To(Equal("denied"))
+
+			payload, ok := event.EventData.GetAgentSessionWebhookAuditPayload()
+			Expect(ok).To(BeTrue())
+			Expect(payload.Action).To(Equal(ogenclient.AgentSessionWebhookAuditPayloadActionDenied))
+			Expect(payload.DenialReason.Value).To(ContainSubstring("rr-nonexistent"))
+		})
+	})
+
+	// ========================================
+	// UT-AS-2244-004: CREATE denied when RemediationRequestRef points to a
+	// different namespace (RR lookup is scoped to req.Namespace)
+	// ========================================
+	Describe("UT-AS-2244-004: CREATE denied when the RR exists only in a different namespace", func() {
+		It("should return Denied because the existence check is scoped to the AgentSession's own namespace", func() {
+			rr := buildRemediationRequestForAS("rr-001", "other-namespace")
+			as := buildAgentSession("rr-001")
+
+			fakeK8s := fake.NewClientBuilder().
+				WithScheme(newASScheme()).
+				WithObjects(rr).
+				Build()
+			handler := authwebhook.NewAgentSessionHandler(mockAudit, fakeK8s)
+
+			resp := handler.Handle(ctx, buildASCreateAdmissionRequest(as))
+
+			Expect(resp.Allowed).To(BeFalse(),
+				"a RemediationRequest with the same name in a different namespace must not satisfy the gate")
+		})
+	})
+
+	// ========================================
+	// UT-AS-2244-005: CREATE denied (fail-closed) when the lookup itself errors
+	// ========================================
+	Describe("UT-AS-2244-005: CREATE denied when the RemediationRequest lookup errors (fail-closed)", func() {
+		It("should return Denied when Get returns a non-NotFound error", func() {
+			as := buildAgentSession("rr-001")
+			erroringK8s := fake.NewClientBuilder().
+				WithScheme(newASScheme()).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fmt.Errorf("simulated K8s API failure")
+					},
+				}).
+				Build()
+			handler := authwebhook.NewAgentSessionHandler(mockAudit, erroringK8s)
+
+			resp := handler.Handle(ctx, buildASCreateAdmissionRequest(as))
+
+			Expect(resp.Allowed).To(BeFalse(),
+				"CREATE should be Denied (fail-closed) when the existence lookup itself errors")
+			Expect(resp.Result.Message).To(ContainSubstring("lookup failed"))
+
+			Expect(mockAudit.StoredEvents).To(HaveLen(1))
+			Expect(mockAudit.StoredEvents[0].EventType).To(Equal(authwebhook.EventTypeASDeniedCreate))
+		})
+	})
+
+	// ========================================
+	// UT-AS-2244-006: UPDATE/DELETE are not intercepted (CEL-immutable spec)
+	// ========================================
+	Describe("UT-AS-2244-006: UPDATE and DELETE operations are not intercepted", func() {
+		It("should return Allowed for UPDATE without any k8s calls or audit events (spec is CEL-immutable)", func() {
+			handler := authwebhook.NewAgentSessionHandler(mockAudit, nil)
+			as := buildAgentSession("rr-001")
+
+			resp := handler.Handle(ctx, buildASUpdateAdmissionRequest(as, as))
+
+			Expect(resp.Allowed).To(BeTrue(),
+				"UPDATE should be Allowed unconditionally -- AgentSessionSpec is CEL-immutable, nothing to re-validate")
+			Expect(mockAudit.StoredEvents).To(BeEmpty(),
+				"No audit event should be emitted for an operation this handler does not gate")
+		})
+	})
+
+	// ========================================
+	// UT-AS-2244-007: CREATE denied when the object is unmarshalable
+	// ========================================
+	Describe("UT-AS-2244-007: CREATE denied when the AgentSession object cannot be unmarshaled", func() {
+		It("should return Denied and emit a denied audit event", func() {
+			handler := authwebhook.NewAgentSessionHandler(mockAudit, nil)
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UID: "as-admission-bad-001",
+					Kind: metav1.GroupVersionKind{
+						Group: "kubernaut.ai", Version: "v1alpha1", Kind: "AgentSession",
+					},
+					Name:      "session-bad",
+					Namespace: "kubernaut-system",
+					Operation: admissionv1.Create,
+					UserInfo: authv1.UserInfo{
+						Username: testUserEmail,
+						UID:      testUserUID,
+					},
+					Object: runtime.RawExtension{Raw: []byte("not-json")},
+				},
+			}
+
+			resp := handler.Handle(ctx, req)
+
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Message).To(ContainSubstring("failed to unmarshal"))
+			Expect(mockAudit.StoredEvents).To(HaveLen(1))
+			Expect(mockAudit.StoredEvents[0].EventType).To(Equal(authwebhook.EventTypeASDeniedCreate))
+		})
+	})
+})

--- a/pkg/authwebhook/types.go
+++ b/pkg/authwebhook/types.go
@@ -29,15 +29,21 @@ const (
 	EventTypeATDeniedCreate   = "actiontype.denied.create"
 	EventTypeATDeniedUpdate   = "actiontype.denied.update"
 	EventTypeATDeniedDelete   = "actiontype.denied.delete"
+
+	// Issue #2244, BR-AA-KA-065.13: AgentSession CRD admission event types
+	// (RemediationRequest existence gate, CREATE-only).
+	EventTypeASAdmittedCreate = "agentsession.admitted.create"
+	EventTypeASDeniedCreate   = "agentsession.denied.create"
 )
 
 // Event category constants per ADR-034 v1.8: event_category = business domain
 const (
-	EventCategoryActionType       = "actiontype"
-	EventCategoryWorkflow         = "workflow"
-	EventCategoryWorkflowExec     = "workflowexecution"
-	EventCategoryApproval         = "approval"
-	EventCategoryNotification     = "notification"
+	EventCategoryActionType   = "actiontype"
+	EventCategoryWorkflow     = "workflow"
+	EventCategoryWorkflowExec = "workflowexecution"
+	EventCategoryApproval     = "approval"
+	EventCategoryNotification = "notification"
+	EventCategoryAgentSession = "agentsession"
 )
 
 // AuthContext holds authenticated user information extracted from admission requests.

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -7728,6 +7728,263 @@ func (s *ActionTypeWebhookAuditPayloadEventType) UnmarshalJSON(data []byte) erro
 }
 
 // Encode implements json.Marshaler.
+func (s *AgentSessionWebhookAuditPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *AgentSessionWebhookAuditPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("crd_name")
+		e.Str(s.CrdName)
+	}
+	{
+		e.FieldStart("crd_namespace")
+		e.Str(s.CrdNamespace)
+	}
+	{
+		e.FieldStart("action")
+		s.Action.Encode(e)
+	}
+	{
+		if s.RemediationRequestRef.Set {
+			e.FieldStart("remediation_request_ref")
+			s.RemediationRequestRef.Encode(e)
+		}
+	}
+	{
+		if s.DenialReason.Set {
+			e.FieldStart("denial_reason")
+			s.DenialReason.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfAgentSessionWebhookAuditPayload = [6]string{
+	0: "event_type",
+	1: "crd_name",
+	2: "crd_namespace",
+	3: "action",
+	4: "remediation_request_ref",
+	5: "denial_reason",
+}
+
+// Decode decodes AgentSessionWebhookAuditPayload from json.
+func (s *AgentSessionWebhookAuditPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AgentSessionWebhookAuditPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "crd_name":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.CrdName = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"crd_name\"")
+			}
+		case "crd_namespace":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.CrdNamespace = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"crd_namespace\"")
+			}
+		case "action":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				if err := s.Action.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"action\"")
+			}
+		case "remediation_request_ref":
+			if err := func() error {
+				s.RemediationRequestRef.Reset()
+				if err := s.RemediationRequestRef.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"remediation_request_ref\"")
+			}
+		case "denial_reason":
+			if err := func() error {
+				s.DenialReason.Reset()
+				if err := s.DenialReason.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"denial_reason\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AgentSessionWebhookAuditPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00001111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfAgentSessionWebhookAuditPayload) {
+					name = jsonFieldsNameOfAgentSessionWebhookAuditPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AgentSessionWebhookAuditPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AgentSessionWebhookAuditPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AgentSessionWebhookAuditPayloadAction as json.
+func (s AgentSessionWebhookAuditPayloadAction) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AgentSessionWebhookAuditPayloadAction from json.
+func (s *AgentSessionWebhookAuditPayloadAction) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AgentSessionWebhookAuditPayloadAction to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AgentSessionWebhookAuditPayloadAction(v) {
+	case AgentSessionWebhookAuditPayloadActionCreate:
+		*s = AgentSessionWebhookAuditPayloadActionCreate
+	case AgentSessionWebhookAuditPayloadActionDenied:
+		*s = AgentSessionWebhookAuditPayloadActionDenied
+	default:
+		*s = AgentSessionWebhookAuditPayloadAction(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AgentSessionWebhookAuditPayloadAction) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AgentSessionWebhookAuditPayloadAction) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AgentSessionWebhookAuditPayloadEventType as json.
+func (s AgentSessionWebhookAuditPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AgentSessionWebhookAuditPayloadEventType from json.
+func (s *AgentSessionWebhookAuditPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AgentSessionWebhookAuditPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AgentSessionWebhookAuditPayloadEventType(v) {
+	case AgentSessionWebhookAuditPayloadEventTypeAgentsessionAdmittedCreate:
+		*s = AgentSessionWebhookAuditPayloadEventTypeAgentsessionAdmittedCreate
+	case AgentSessionWebhookAuditPayloadEventTypeAgentsessionDeniedCreate:
+		*s = AgentSessionWebhookAuditPayloadEventTypeAgentsessionDeniedCreate
+	default:
+		*s = AgentSessionWebhookAuditPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AgentSessionWebhookAuditPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AgentSessionWebhookAuditPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *ApifrontendA2ATaskCompletedPayload) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -15157,6 +15414,8 @@ func (s *AuditEventEventCategory) Decode(d *jx.Decoder) error {
 		*s = AuditEventEventCategoryApifrontend
 	case AuditEventEventCategorySecurity:
 		*s = AuditEventEventCategorySecurity
+	case AuditEventEventCategoryAgentsession:
+		*s = AuditEventEventCategoryAgentsession
 	default:
 		*s = AuditEventEventCategory(v)
 	}
@@ -17914,6 +18173,42 @@ func (s AuditEventEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case AuditEventEventDataAgentsessionAdmittedCreateAuditEventEventData, AuditEventEventDataAgentsessionDeniedCreateAuditEventEventData:
+		switch s.Type {
+		case AuditEventEventDataAgentsessionAdmittedCreateAuditEventEventData:
+			e.FieldStart("event_type")
+			e.Str("agentsession.admitted.create")
+		case AuditEventEventDataAgentsessionDeniedCreateAuditEventEventData:
+			e.FieldStart("event_type")
+			e.Str("agentsession.denied.create")
+		}
+		{
+			s := s.AgentSessionWebhookAuditPayload
+			{
+				e.FieldStart("crd_name")
+				e.Str(s.CrdName)
+			}
+			{
+				e.FieldStart("crd_namespace")
+				e.Str(s.CrdNamespace)
+			}
+			{
+				e.FieldStart("action")
+				s.Action.Encode(e)
+			}
+			{
+				if s.RemediationRequestRef.Set {
+					e.FieldStart("remediation_request_ref")
+					s.RemediationRequestRef.Encode(e)
+				}
+			}
+			{
+				if s.DenialReason.Set {
+					e.FieldStart("denial_reason")
+					s.DenialReason.Encode(e)
+				}
+			}
+		}
 	case ApifrontendTriageStartedPayloadAuditEventEventData:
 		e.FieldStart("event_type")
 		e.Str("apifrontend.triage.started")
@@ -19096,6 +19391,12 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 				case "actiontype.denied.update":
 					s.Type = AuditEventEventDataActiontypeDeniedUpdateAuditEventEventData
 					found = true
+				case "agentsession.admitted.create":
+					s.Type = AuditEventEventDataAgentsessionAdmittedCreateAuditEventEventData
+					found = true
+				case "agentsession.denied.create":
+					s.Type = AuditEventEventDataAgentsessionDeniedCreateAuditEventEventData
+					found = true
 				case "apifrontend.triage.started":
 					s.Type = ApifrontendTriageStartedPayloadAuditEventEventData
 					found = true
@@ -19446,6 +19747,10 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 		}
 	case AuditEventEventDataActiontypeAdmittedCreateAuditEventEventData, AuditEventEventDataActiontypeAdmittedDeleteAuditEventEventData, AuditEventEventDataActiontypeAdmittedUpdateAuditEventEventData, AuditEventEventDataActiontypeDeniedCreateAuditEventEventData, AuditEventEventDataActiontypeDeniedDeleteAuditEventEventData, AuditEventEventDataActiontypeDeniedUpdateAuditEventEventData:
 		if err := s.ActionTypeWebhookAuditPayload.Decode(d); err != nil {
+			return err
+		}
+	case AuditEventEventDataAgentsessionAdmittedCreateAuditEventEventData, AuditEventEventDataAgentsessionDeniedCreateAuditEventEventData:
+		if err := s.AgentSessionWebhookAuditPayload.Decode(d); err != nil {
 			return err
 		}
 	case ApifrontendTriageStartedPayloadAuditEventEventData:
@@ -20153,6 +20458,8 @@ func (s *AuditEventRequestEventCategory) Decode(d *jx.Decoder) error {
 		*s = AuditEventRequestEventCategoryApifrontend
 	case AuditEventRequestEventCategorySecurity:
 		*s = AuditEventRequestEventCategorySecurity
+	case AuditEventRequestEventCategoryAgentsession:
+		*s = AuditEventRequestEventCategoryAgentsession
 	default:
 		*s = AuditEventRequestEventCategory(v)
 	}
@@ -22910,6 +23217,42 @@ func (s AuditEventRequestEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case AuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData, AuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData:
+		switch s.Type {
+		case AuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData:
+			e.FieldStart("event_type")
+			e.Str("agentsession.admitted.create")
+		case AuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData:
+			e.FieldStart("event_type")
+			e.Str("agentsession.denied.create")
+		}
+		{
+			s := s.AgentSessionWebhookAuditPayload
+			{
+				e.FieldStart("crd_name")
+				e.Str(s.CrdName)
+			}
+			{
+				e.FieldStart("crd_namespace")
+				e.Str(s.CrdNamespace)
+			}
+			{
+				e.FieldStart("action")
+				s.Action.Encode(e)
+			}
+			{
+				if s.RemediationRequestRef.Set {
+					e.FieldStart("remediation_request_ref")
+					s.RemediationRequestRef.Encode(e)
+				}
+			}
+			{
+				if s.DenialReason.Set {
+					e.FieldStart("denial_reason")
+					s.DenialReason.Encode(e)
+				}
+			}
+		}
 	case ApifrontendTriageStartedPayloadAuditEventRequestEventData:
 		e.FieldStart("event_type")
 		e.Str("apifrontend.triage.started")
@@ -24092,6 +24435,12 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 				case "actiontype.denied.update":
 					s.Type = AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData
 					found = true
+				case "agentsession.admitted.create":
+					s.Type = AuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData
+					found = true
+				case "agentsession.denied.create":
+					s.Type = AuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData
+					found = true
 				case "apifrontend.triage.started":
 					s.Type = ApifrontendTriageStartedPayloadAuditEventRequestEventData
 					found = true
@@ -24442,6 +24791,10 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 		}
 	case AuditEventRequestEventDataActiontypeAdmittedCreateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeAdmittedDeleteAuditEventRequestEventData, AuditEventRequestEventDataActiontypeAdmittedUpdateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedCreateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedDeleteAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData:
 		if err := s.ActionTypeWebhookAuditPayload.Decode(d); err != nil {
+			return err
+		}
+	case AuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData, AuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData:
+		if err := s.AgentSessionWebhookAuditPayload.Decode(d); err != nil {
 			return err
 		}
 	case ApifrontendTriageStartedPayloadAuditEventRequestEventData:

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -3980,6 +3980,163 @@ func (s *ActionTypeWebhookAuditPayloadEventType) UnmarshalText(data []byte) erro
 	}
 }
 
+// AW audit payload for AgentSession CRD admission events (RemediationRequest existence gate, Issue
+// #2244, BR-AA-KA-065.13).
+// Ref: #/components/schemas/AgentSessionWebhookAuditPayload
+type AgentSessionWebhookAuditPayload struct {
+	EventType AgentSessionWebhookAuditPayloadEventType `json:"event_type"`
+	// K8s metadata.name.
+	CrdName string `json:"crd_name"`
+	// K8s namespace.
+	CrdNamespace string                                `json:"crd_namespace"`
+	Action       AgentSessionWebhookAuditPayloadAction `json:"action"`
+	// Spec.RemediationRequestRef.Name being validated for existence.
+	RemediationRequestRef OptString `json:"remediation_request_ref"`
+	DenialReason          OptString `json:"denial_reason"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *AgentSessionWebhookAuditPayload) GetEventType() AgentSessionWebhookAuditPayloadEventType {
+	return s.EventType
+}
+
+// GetCrdName returns the value of CrdName.
+func (s *AgentSessionWebhookAuditPayload) GetCrdName() string {
+	return s.CrdName
+}
+
+// GetCrdNamespace returns the value of CrdNamespace.
+func (s *AgentSessionWebhookAuditPayload) GetCrdNamespace() string {
+	return s.CrdNamespace
+}
+
+// GetAction returns the value of Action.
+func (s *AgentSessionWebhookAuditPayload) GetAction() AgentSessionWebhookAuditPayloadAction {
+	return s.Action
+}
+
+// GetRemediationRequestRef returns the value of RemediationRequestRef.
+func (s *AgentSessionWebhookAuditPayload) GetRemediationRequestRef() OptString {
+	return s.RemediationRequestRef
+}
+
+// GetDenialReason returns the value of DenialReason.
+func (s *AgentSessionWebhookAuditPayload) GetDenialReason() OptString {
+	return s.DenialReason
+}
+
+// SetEventType sets the value of EventType.
+func (s *AgentSessionWebhookAuditPayload) SetEventType(val AgentSessionWebhookAuditPayloadEventType) {
+	s.EventType = val
+}
+
+// SetCrdName sets the value of CrdName.
+func (s *AgentSessionWebhookAuditPayload) SetCrdName(val string) {
+	s.CrdName = val
+}
+
+// SetCrdNamespace sets the value of CrdNamespace.
+func (s *AgentSessionWebhookAuditPayload) SetCrdNamespace(val string) {
+	s.CrdNamespace = val
+}
+
+// SetAction sets the value of Action.
+func (s *AgentSessionWebhookAuditPayload) SetAction(val AgentSessionWebhookAuditPayloadAction) {
+	s.Action = val
+}
+
+// SetRemediationRequestRef sets the value of RemediationRequestRef.
+func (s *AgentSessionWebhookAuditPayload) SetRemediationRequestRef(val OptString) {
+	s.RemediationRequestRef = val
+}
+
+// SetDenialReason sets the value of DenialReason.
+func (s *AgentSessionWebhookAuditPayload) SetDenialReason(val OptString) {
+	s.DenialReason = val
+}
+
+type AgentSessionWebhookAuditPayloadAction string
+
+const (
+	AgentSessionWebhookAuditPayloadActionCreate AgentSessionWebhookAuditPayloadAction = "create"
+	AgentSessionWebhookAuditPayloadActionDenied AgentSessionWebhookAuditPayloadAction = "denied"
+)
+
+// AllValues returns all AgentSessionWebhookAuditPayloadAction values.
+func (AgentSessionWebhookAuditPayloadAction) AllValues() []AgentSessionWebhookAuditPayloadAction {
+	return []AgentSessionWebhookAuditPayloadAction{
+		AgentSessionWebhookAuditPayloadActionCreate,
+		AgentSessionWebhookAuditPayloadActionDenied,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AgentSessionWebhookAuditPayloadAction) MarshalText() ([]byte, error) {
+	switch s {
+	case AgentSessionWebhookAuditPayloadActionCreate:
+		return []byte(s), nil
+	case AgentSessionWebhookAuditPayloadActionDenied:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AgentSessionWebhookAuditPayloadAction) UnmarshalText(data []byte) error {
+	switch AgentSessionWebhookAuditPayloadAction(data) {
+	case AgentSessionWebhookAuditPayloadActionCreate:
+		*s = AgentSessionWebhookAuditPayloadActionCreate
+		return nil
+	case AgentSessionWebhookAuditPayloadActionDenied:
+		*s = AgentSessionWebhookAuditPayloadActionDenied
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+type AgentSessionWebhookAuditPayloadEventType string
+
+const (
+	AgentSessionWebhookAuditPayloadEventTypeAgentsessionAdmittedCreate AgentSessionWebhookAuditPayloadEventType = "agentsession.admitted.create"
+	AgentSessionWebhookAuditPayloadEventTypeAgentsessionDeniedCreate   AgentSessionWebhookAuditPayloadEventType = "agentsession.denied.create"
+)
+
+// AllValues returns all AgentSessionWebhookAuditPayloadEventType values.
+func (AgentSessionWebhookAuditPayloadEventType) AllValues() []AgentSessionWebhookAuditPayloadEventType {
+	return []AgentSessionWebhookAuditPayloadEventType{
+		AgentSessionWebhookAuditPayloadEventTypeAgentsessionAdmittedCreate,
+		AgentSessionWebhookAuditPayloadEventTypeAgentsessionDeniedCreate,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AgentSessionWebhookAuditPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case AgentSessionWebhookAuditPayloadEventTypeAgentsessionAdmittedCreate:
+		return []byte(s), nil
+	case AgentSessionWebhookAuditPayloadEventTypeAgentsessionDeniedCreate:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AgentSessionWebhookAuditPayloadEventType) UnmarshalText(data []byte) error {
+	switch AgentSessionWebhookAuditPayloadEventType(data) {
+	case AgentSessionWebhookAuditPayloadEventTypeAgentsessionAdmittedCreate:
+		*s = AgentSessionWebhookAuditPayloadEventTypeAgentsessionAdmittedCreate
+		return nil
+	case AgentSessionWebhookAuditPayloadEventTypeAgentsessionDeniedCreate:
+		*s = AgentSessionWebhookAuditPayloadEventTypeAgentsessionDeniedCreate
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
 // A2A task completed event payload (apifrontend.a2a.task_completed) — A2A task execution succeeded
 // (SOC2 CC7.2, Issue.
 // Ref: #/components/schemas/ApifrontendA2ATaskCompletedPayload
@@ -7732,7 +7889,8 @@ type AuditEvent struct {
 	// - apifrontend: API Frontend service — triage, session, delegation, and user decision events
 	// (Issue #1021)
 	// - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not
-	// tied to a single business domain (GAP-09, Issue #1505).
+	// tied to a single business domain (GAP-09, Issue #1505)
+	// - agentsession: AgentSession CRD admission events (RemediationRequest existence gate, Issue #2244).
 	EventCategory AuditEventEventCategory `json:"event_category"`
 	// Action performed (ADR-034).
 	EventAction string `json:"event_action"`
@@ -8107,7 +8265,8 @@ func (s *AuditEvent) SetLegalHoldPlacedAt(val OptNilDateTime) {
 // - apifrontend: API Frontend service — triage, session, delegation, and user decision events
 // (Issue #1021)
 // - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not
-// tied to a single business domain (GAP-09, Issue #1505).
+// tied to a single business domain (GAP-09, Issue #1505)
+// - agentsession: AgentSession CRD admission events (RemediationRequest existence gate, Issue #2244).
 type AuditEventEventCategory string
 
 const (
@@ -8124,6 +8283,7 @@ const (
 	AuditEventEventCategoryActiontype        AuditEventEventCategory = "actiontype"
 	AuditEventEventCategoryApifrontend       AuditEventEventCategory = "apifrontend"
 	AuditEventEventCategorySecurity          AuditEventEventCategory = "security"
+	AuditEventEventCategoryAgentsession      AuditEventEventCategory = "agentsession"
 )
 
 // AllValues returns all AuditEventEventCategory values.
@@ -8142,6 +8302,7 @@ func (AuditEventEventCategory) AllValues() []AuditEventEventCategory {
 		AuditEventEventCategoryActiontype,
 		AuditEventEventCategoryApifrontend,
 		AuditEventEventCategorySecurity,
+		AuditEventEventCategoryAgentsession,
 	}
 }
 
@@ -8173,6 +8334,8 @@ func (s AuditEventEventCategory) MarshalText() ([]byte, error) {
 	case AuditEventEventCategoryApifrontend:
 		return []byte(s), nil
 	case AuditEventEventCategorySecurity:
+		return []byte(s), nil
+	case AuditEventEventCategoryAgentsession:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -8220,6 +8383,9 @@ func (s *AuditEventEventCategory) UnmarshalText(data []byte) error {
 		return nil
 	case AuditEventEventCategorySecurity:
 		*s = AuditEventEventCategorySecurity
+		return nil
+	case AuditEventEventCategoryAgentsession:
+		*s = AuditEventEventCategoryAgentsession
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)
@@ -8292,6 +8458,7 @@ type AuditEventEventData struct {
 	ActionTypeCatalogReenabledPayload            ActionTypeCatalogReenabledPayload
 	ActionTypeCatalogDisableDeniedPayload        ActionTypeCatalogDisableDeniedPayload
 	ActionTypeWebhookAuditPayload                ActionTypeWebhookAuditPayload
+	AgentSessionWebhookAuditPayload              AgentSessionWebhookAuditPayload
 	ApifrontendTriageStartedPayload              ApifrontendTriageStartedPayload
 	ApifrontendTriageCompletedPayload            ApifrontendTriageCompletedPayload
 	ApifrontendRRCreatedPayload                  ApifrontendRRCreatedPayload
@@ -8439,6 +8606,8 @@ const (
 	AuditEventEventDataActiontypeDeniedCreateAuditEventEventData                     AuditEventEventDataType = "actiontype.denied.create"
 	AuditEventEventDataActiontypeDeniedDeleteAuditEventEventData                     AuditEventEventDataType = "actiontype.denied.delete"
 	AuditEventEventDataActiontypeDeniedUpdateAuditEventEventData                     AuditEventEventDataType = "actiontype.denied.update"
+	AuditEventEventDataAgentsessionAdmittedCreateAuditEventEventData                 AuditEventEventDataType = "agentsession.admitted.create"
+	AuditEventEventDataAgentsessionDeniedCreateAuditEventEventData                   AuditEventEventDataType = "agentsession.denied.create"
 	ApifrontendTriageStartedPayloadAuditEventEventData                               AuditEventEventDataType = "apifrontend.triage.started"
 	ApifrontendTriageCompletedPayloadAuditEventEventData                             AuditEventEventDataType = "apifrontend.triage.completed"
 	ApifrontendRRCreatedPayloadAuditEventEventData                                   AuditEventEventDataType = "apifrontend.rr.created"
@@ -8819,6 +8988,16 @@ func (s AuditEventEventData) IsActionTypeCatalogDisableDeniedPayload() bool {
 func (s AuditEventEventData) IsActionTypeWebhookAuditPayload() bool {
 	switch s.Type {
 	case AuditEventEventDataActiontypeAdmittedCreateAuditEventEventData, AuditEventEventDataActiontypeAdmittedDeleteAuditEventEventData, AuditEventEventDataActiontypeAdmittedUpdateAuditEventEventData, AuditEventEventDataActiontypeDeniedCreateAuditEventEventData, AuditEventEventDataActiontypeDeniedDeleteAuditEventEventData, AuditEventEventDataActiontypeDeniedUpdateAuditEventEventData:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsAgentSessionWebhookAuditPayload reports whether AuditEventEventData is AgentSessionWebhookAuditPayload.
+func (s AuditEventEventData) IsAgentSessionWebhookAuditPayload() bool {
+	switch s.Type {
+	case AuditEventEventDataAgentsessionAdmittedCreateAuditEventEventData, AuditEventEventDataAgentsessionDeniedCreateAuditEventEventData:
 		return true
 	default:
 		return false
@@ -10607,6 +10786,38 @@ func NewAuditEventEventDataActiontypeDeniedUpdateAuditEventEventData(v ActionTyp
 	return s
 }
 
+// SetAgentSessionWebhookAuditPayload sets AuditEventEventData to AgentSessionWebhookAuditPayload.
+// panics if `t` is not associated with AgentSessionWebhookAuditPayload
+func (s *AuditEventEventData) SetAgentSessionWebhookAuditPayload(t AuditEventEventDataType, v AgentSessionWebhookAuditPayload) {
+	s.Type = t
+	s.AgentSessionWebhookAuditPayload = v
+	if !s.IsAgentSessionWebhookAuditPayload() {
+		panic(fmt.Errorf("invariant: %v is not AgentSessionWebhookAuditPayload", t))
+	}
+}
+
+// GetAgentSessionWebhookAuditPayload returns AgentSessionWebhookAuditPayload and true boolean if AuditEventEventData is AgentSessionWebhookAuditPayload.
+func (s AuditEventEventData) GetAgentSessionWebhookAuditPayload() (v AgentSessionWebhookAuditPayload, ok bool) {
+	if !s.IsAgentSessionWebhookAuditPayload() {
+		return v, false
+	}
+	return s.AgentSessionWebhookAuditPayload, true
+}
+
+// NewAuditEventEventDataAgentsessionAdmittedCreateAuditEventEventData returns new AuditEventEventData from AgentSessionWebhookAuditPayload.
+func NewAuditEventEventDataAgentsessionAdmittedCreateAuditEventEventData(v AgentSessionWebhookAuditPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetAgentSessionWebhookAuditPayload(AuditEventEventDataAgentsessionAdmittedCreateAuditEventEventData, v)
+	return s
+}
+
+// NewAuditEventEventDataAgentsessionDeniedCreateAuditEventEventData returns new AuditEventEventData from AgentSessionWebhookAuditPayload.
+func NewAuditEventEventDataAgentsessionDeniedCreateAuditEventEventData(v AgentSessionWebhookAuditPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetAgentSessionWebhookAuditPayload(AuditEventEventDataAgentsessionDeniedCreateAuditEventEventData, v)
+	return s
+}
+
 // SetApifrontendTriageStartedPayload sets AuditEventEventData to ApifrontendTriageStartedPayload.
 func (s *AuditEventEventData) SetApifrontendTriageStartedPayload(v ApifrontendTriageStartedPayload) {
 	s.Type = ApifrontendTriageStartedPayloadAuditEventEventData
@@ -11396,7 +11607,8 @@ type AuditEventRequest struct {
 	// - apifrontend: API Frontend service — triage, session, delegation, and user decision events
 	// (Issue #1021)
 	// - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not
-	// tied to a single business domain (GAP-09, Issue #1505).
+	// tied to a single business domain (GAP-09, Issue #1505)
+	// - agentsession: AgentSession CRD admission events (RemediationRequest existence gate, Issue #2244).
 	EventCategory AuditEventRequestEventCategory `json:"event_category"`
 	// Action performed (ADR-034).
 	EventAction string `json:"event_action"`
@@ -11681,7 +11893,8 @@ func (s *AuditEventRequest) SetEventData(val AuditEventRequestEventData) {
 // - apifrontend: API Frontend service — triage, session, delegation, and user decision events
 // (Issue #1021)
 // - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not
-// tied to a single business domain (GAP-09, Issue #1505).
+// tied to a single business domain (GAP-09, Issue #1505)
+// - agentsession: AgentSession CRD admission events (RemediationRequest existence gate, Issue #2244).
 type AuditEventRequestEventCategory string
 
 const (
@@ -11698,6 +11911,7 @@ const (
 	AuditEventRequestEventCategoryActiontype        AuditEventRequestEventCategory = "actiontype"
 	AuditEventRequestEventCategoryApifrontend       AuditEventRequestEventCategory = "apifrontend"
 	AuditEventRequestEventCategorySecurity          AuditEventRequestEventCategory = "security"
+	AuditEventRequestEventCategoryAgentsession      AuditEventRequestEventCategory = "agentsession"
 )
 
 // AllValues returns all AuditEventRequestEventCategory values.
@@ -11716,6 +11930,7 @@ func (AuditEventRequestEventCategory) AllValues() []AuditEventRequestEventCatego
 		AuditEventRequestEventCategoryActiontype,
 		AuditEventRequestEventCategoryApifrontend,
 		AuditEventRequestEventCategorySecurity,
+		AuditEventRequestEventCategoryAgentsession,
 	}
 }
 
@@ -11747,6 +11962,8 @@ func (s AuditEventRequestEventCategory) MarshalText() ([]byte, error) {
 	case AuditEventRequestEventCategoryApifrontend:
 		return []byte(s), nil
 	case AuditEventRequestEventCategorySecurity:
+		return []byte(s), nil
+	case AuditEventRequestEventCategoryAgentsession:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -11794,6 +12011,9 @@ func (s *AuditEventRequestEventCategory) UnmarshalText(data []byte) error {
 		return nil
 	case AuditEventRequestEventCategorySecurity:
 		*s = AuditEventRequestEventCategorySecurity
+		return nil
+	case AuditEventRequestEventCategoryAgentsession:
+		*s = AuditEventRequestEventCategoryAgentsession
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)
@@ -11866,6 +12086,7 @@ type AuditEventRequestEventData struct {
 	ActionTypeCatalogReenabledPayload            ActionTypeCatalogReenabledPayload
 	ActionTypeCatalogDisableDeniedPayload        ActionTypeCatalogDisableDeniedPayload
 	ActionTypeWebhookAuditPayload                ActionTypeWebhookAuditPayload
+	AgentSessionWebhookAuditPayload              AgentSessionWebhookAuditPayload
 	ApifrontendTriageStartedPayload              ApifrontendTriageStartedPayload
 	ApifrontendTriageCompletedPayload            ApifrontendTriageCompletedPayload
 	ApifrontendRRCreatedPayload                  ApifrontendRRCreatedPayload
@@ -12013,6 +12234,8 @@ const (
 	AuditEventRequestEventDataActiontypeDeniedCreateAuditEventRequestEventData                     AuditEventRequestEventDataType = "actiontype.denied.create"
 	AuditEventRequestEventDataActiontypeDeniedDeleteAuditEventRequestEventData                     AuditEventRequestEventDataType = "actiontype.denied.delete"
 	AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData                     AuditEventRequestEventDataType = "actiontype.denied.update"
+	AuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData                 AuditEventRequestEventDataType = "agentsession.admitted.create"
+	AuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData                   AuditEventRequestEventDataType = "agentsession.denied.create"
 	ApifrontendTriageStartedPayloadAuditEventRequestEventData                                      AuditEventRequestEventDataType = "apifrontend.triage.started"
 	ApifrontendTriageCompletedPayloadAuditEventRequestEventData                                    AuditEventRequestEventDataType = "apifrontend.triage.completed"
 	ApifrontendRRCreatedPayloadAuditEventRequestEventData                                          AuditEventRequestEventDataType = "apifrontend.rr.created"
@@ -12393,6 +12616,16 @@ func (s AuditEventRequestEventData) IsActionTypeCatalogDisableDeniedPayload() bo
 func (s AuditEventRequestEventData) IsActionTypeWebhookAuditPayload() bool {
 	switch s.Type {
 	case AuditEventRequestEventDataActiontypeAdmittedCreateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeAdmittedDeleteAuditEventRequestEventData, AuditEventRequestEventDataActiontypeAdmittedUpdateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedCreateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedDeleteAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsAgentSessionWebhookAuditPayload reports whether AuditEventRequestEventData is AgentSessionWebhookAuditPayload.
+func (s AuditEventRequestEventData) IsAgentSessionWebhookAuditPayload() bool {
+	switch s.Type {
+	case AuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData, AuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData:
 		return true
 	default:
 		return false
@@ -14178,6 +14411,38 @@ func NewAuditEventRequestEventDataActiontypeDeniedDeleteAuditEventRequestEventDa
 func NewAuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData(v ActionTypeWebhookAuditPayload) AuditEventRequestEventData {
 	var s AuditEventRequestEventData
 	s.SetActionTypeWebhookAuditPayload(AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData, v)
+	return s
+}
+
+// SetAgentSessionWebhookAuditPayload sets AuditEventRequestEventData to AgentSessionWebhookAuditPayload.
+// panics if `t` is not associated with AgentSessionWebhookAuditPayload
+func (s *AuditEventRequestEventData) SetAgentSessionWebhookAuditPayload(t AuditEventRequestEventDataType, v AgentSessionWebhookAuditPayload) {
+	s.Type = t
+	s.AgentSessionWebhookAuditPayload = v
+	if !s.IsAgentSessionWebhookAuditPayload() {
+		panic(fmt.Errorf("invariant: %v is not AgentSessionWebhookAuditPayload", t))
+	}
+}
+
+// GetAgentSessionWebhookAuditPayload returns AgentSessionWebhookAuditPayload and true boolean if AuditEventRequestEventData is AgentSessionWebhookAuditPayload.
+func (s AuditEventRequestEventData) GetAgentSessionWebhookAuditPayload() (v AgentSessionWebhookAuditPayload, ok bool) {
+	if !s.IsAgentSessionWebhookAuditPayload() {
+		return v, false
+	}
+	return s.AgentSessionWebhookAuditPayload, true
+}
+
+// NewAuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData returns new AuditEventRequestEventData from AgentSessionWebhookAuditPayload.
+func NewAuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData(v AgentSessionWebhookAuditPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetAgentSessionWebhookAuditPayload(AuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData, v)
+	return s
+}
+
+// NewAuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData returns new AuditEventRequestEventData from AgentSessionWebhookAuditPayload.
+func NewAuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData(v AgentSessionWebhookAuditPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetAgentSessionWebhookAuditPayload(AuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData, v)
 	return s
 }
 

--- a/pkg/datastorage/ogen-client/oas_validators_gen.go
+++ b/pkg/datastorage/ogen-client/oas_validators_gen.go
@@ -1587,6 +1587,62 @@ func (s ActionTypeWebhookAuditPayloadEventType) Validate() error {
 	}
 }
 
+func (s *AgentSessionWebhookAuditPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.Action.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "action",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s AgentSessionWebhookAuditPayloadAction) Validate() error {
+	switch s {
+	case "create":
+		return nil
+	case "denied":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s AgentSessionWebhookAuditPayloadEventType) Validate() error {
+	switch s {
+	case "agentsession.admitted.create":
+		return nil
+	case "agentsession.denied.create":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
 func (s *ApifrontendA2ATaskCompletedPayload) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -3110,6 +3166,8 @@ func (s AuditEventEventCategory) Validate() error {
 		return nil
 	case "security":
 		return nil
+	case "agentsession":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
@@ -3382,6 +3440,11 @@ func (s AuditEventEventData) Validate() error {
 		return nil
 	case AuditEventEventDataActiontypeAdmittedCreateAuditEventEventData, AuditEventEventDataActiontypeAdmittedDeleteAuditEventEventData, AuditEventEventDataActiontypeAdmittedUpdateAuditEventEventData, AuditEventEventDataActiontypeDeniedCreateAuditEventEventData, AuditEventEventDataActiontypeDeniedDeleteAuditEventEventData, AuditEventEventDataActiontypeDeniedUpdateAuditEventEventData:
 		if err := s.ActionTypeWebhookAuditPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case AuditEventEventDataAgentsessionAdmittedCreateAuditEventEventData, AuditEventEventDataAgentsessionDeniedCreateAuditEventEventData:
+		if err := s.AgentSessionWebhookAuditPayload.Validate(); err != nil {
 			return err
 		}
 		return nil
@@ -3768,6 +3831,8 @@ func (s AuditEventRequestEventCategory) Validate() error {
 		return nil
 	case "security":
 		return nil
+	case "agentsession":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
@@ -4040,6 +4105,11 @@ func (s AuditEventRequestEventData) Validate() error {
 		return nil
 	case AuditEventRequestEventDataActiontypeAdmittedCreateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeAdmittedDeleteAuditEventRequestEventData, AuditEventRequestEventDataActiontypeAdmittedUpdateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedCreateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedDeleteAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData:
 		if err := s.ActionTypeWebhookAuditPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case AuditEventRequestEventDataAgentsessionAdmittedCreateAuditEventRequestEventData, AuditEventRequestEventDataAgentsessionDeniedCreateAuditEventRequestEventData:
+		if err := s.AgentSessionWebhookAuditPayload.Validate(); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -1744,7 +1744,7 @@ components:
           type: string
           minLength: 1
           maxLength: 50
-          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend, security]
+          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend, security, agentsession]
           description: |
             Domain-level event category (ADR-034 v1.8, Issue #306).
             Per convention: event_category identifies the business domain of the event.
@@ -1763,6 +1763,7 @@ components:
             - actiontype: ActionType taxonomy lifecycle events (Issue #300)
             - apifrontend: API Frontend service — triage, session, delegation, and user decision events (Issue #1021)
             - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not tied to a single business domain (GAP-09, Issue #1505)
+            - agentsession: AgentSession CRD admission events (RemediationRequest existence gate, Issue #2244)
           example: gateway
         event_action:
           type: string
@@ -1903,6 +1904,7 @@ components:
             - $ref: '#/components/schemas/ActionTypeCatalogReenabledPayload'
             - $ref: '#/components/schemas/ActionTypeCatalogDisableDeniedPayload'
             - $ref: '#/components/schemas/ActionTypeWebhookAuditPayload'
+            - $ref: '#/components/schemas/AgentSessionWebhookAuditPayload'
             - $ref: '#/components/schemas/ApifrontendTriageStartedPayload'
             - $ref: '#/components/schemas/ApifrontendTriageCompletedPayload'
             - $ref: '#/components/schemas/ApifrontendRRCreatedPayload'
@@ -2052,6 +2054,8 @@ components:
               'actiontype.denied.create': '#/components/schemas/ActionTypeWebhookAuditPayload'
               'actiontype.denied.update': '#/components/schemas/ActionTypeWebhookAuditPayload'
               'actiontype.denied.delete': '#/components/schemas/ActionTypeWebhookAuditPayload'
+              'agentsession.admitted.create': '#/components/schemas/AgentSessionWebhookAuditPayload'
+              'agentsession.denied.create': '#/components/schemas/AgentSessionWebhookAuditPayload'
               'apifrontend.triage.started': '#/components/schemas/ApifrontendTriageStartedPayload'
               'apifrontend.triage.completed': '#/components/schemas/ApifrontendTriageCompletedPayload'
               'apifrontend.rr.created': '#/components/schemas/ApifrontendRRCreatedPayload'
@@ -6169,6 +6173,35 @@ components:
         denial_reason:
           type: string
         denial_operation:
+          type: string
+
+    AgentSessionWebhookAuditPayload:
+      type: object
+      description: "AW audit payload for AgentSession CRD admission events (RemediationRequest existence gate, Issue #2244, BR-AA-KA-065.13)"
+      required:
+        - event_type
+        - crd_name
+        - crd_namespace
+        - action
+      properties:
+        event_type:
+          type: string
+          enum:
+            - 'agentsession.admitted.create'
+            - 'agentsession.denied.create'
+        crd_name:
+          type: string
+          description: "K8s metadata.name"
+        crd_namespace:
+          type: string
+          description: "K8s namespace"
+        action:
+          type: string
+          enum: ['create', 'denied']
+        remediation_request_ref:
+          type: string
+          description: "Spec.RemediationRequestRef.Name being validated for existence"
+        denial_reason:
           type: string
 
     # ── Apifrontend Audit Payloads (Issue #1021) ──────────────────────────

--- a/test/e2e/authwebhook/06_agentsession_gate_test.go
+++ b/test/e2e/authwebhook/06_agentsession_gate_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authwebhook
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	agentsessionv1alpha1 "github.com/jordigilh/kubernaut/api/agentsession/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	auditclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+)
+
+// ========================================
+// E2E-AS-2244-DENY (Issue #2244, BR-AA-KA-065.13)
+// ========================================
+//
+// Authority: BR-AA-KA-065.13, DD-WEBHOOK-001 v1.5, DD-WORKFLOW-018
+//
+// Proves AW's AgentSession->RemediationRequest existence gate end-to-end
+// against a real cluster: an AgentSession referencing a non-existent
+// RemediationRequest is rejected at admission (SI-10, input validation at
+// the trust boundary before KA's dispatcher ever observes the object),
+// never persists as a CRD, and the denial itself is fully auditable.
+// Mirrors #1661's E2E-AT-3XX-DENY pattern (05_actiontype_gate_and_format_test.go)
+// for the same existence-gate shape.
+
+// buildAgentSessionCRD constructs an AgentSession CRD object referencing
+// rrName in sharedNamespace (the AgentSession MUST be created in the same
+// namespace as the RemediationRequest it investigates).
+func buildAgentSessionCRD(crdName, rrName string) *agentsessionv1alpha1.AgentSession {
+	return &agentsessionv1alpha1.AgentSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crdName,
+			Namespace: sharedNamespace,
+		},
+		Spec: agentsessionv1alpha1.AgentSessionSpec{
+			RemediationRequestRef: agentsessionv1alpha1.ObjectRef{
+				Name:      rrName,
+				Namespace: sharedNamespace,
+			},
+			IncidentID:    fmt.Sprintf("e2e-aa-%s", uuid.New().String()[:8]),
+			RemediationID: rrName,
+			SignalName:    "OOMKilled",
+			Severity:      "critical",
+		},
+	}
+}
+
+// buildRemediationRequestCRD constructs a minimal, valid RemediationRequest
+// CRD object in sharedNamespace, for the allow-path counterpart of the
+// existence gate.
+func buildRemediationRequestCRD(crdName string) *remediationv1.RemediationRequest {
+	return &remediationv1.RemediationRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crdName,
+			Namespace: sharedNamespace,
+		},
+		Spec: remediationv1.RemediationRequestSpec{
+			SignalFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			SignalName:        "OOMKilled",
+			Severity:          "critical",
+			TargetType:        "kubernetes",
+			TargetResource: remediationv1.ResourceIdentifier{
+				Kind:      "Pod",
+				Name:      "e2e-agentsession-test-pod",
+				Namespace: sharedNamespace,
+			},
+			FiringTime:   metav1.Now(),
+			ReceivedTime: metav1.Now(),
+		},
+	}
+}
+
+var _ = Describe("E2E: AW AgentSession Existence Gate (#2244, BR-AA-KA-065.13)", Serial, Label("e2e", "agentsession-gate"), func() {
+	var crdCleanup []string
+
+	AfterEach(func() {
+		for _, name := range crdCleanup {
+			as := &agentsessionv1alpha1.AgentSession{}
+			key := types.NamespacedName{Name: name, Namespace: sharedNamespace}
+			if err := k8sClient.Get(ctx, key, as); err == nil {
+				_ = k8sClient.Delete(ctx, as)
+			}
+		}
+		crdCleanup = nil
+	})
+
+	// ========================================
+	// E2E-AS-2244-DENY: AgentSession referencing a non-existent
+	// RemediationRequest is denied and never persists.
+	// ========================================
+	It("E2E-AS-2244-DENY: AgentSession referencing a non-existent RemediationRequest is denied and never persisted", func() {
+		crdName := fmt.Sprintf("e2e-as-deny-%s", uuid.New().String()[:8])
+		nonExistentRR := fmt.Sprintf("e2e-nonexistent-rr-%s", uuid.New().String()[:8])
+
+		By("Attempting to create an AgentSession referencing a non-existent RemediationRequest")
+		as := buildAgentSessionCRD(crdName, nonExistentRR)
+
+		err := k8sClient.Create(ctx, as)
+		Expect(err).To(HaveOccurred(), "CREATE should be Denied by the webhook (AW's AgentSession existence gate)")
+		Expect(err.Error()).To(ContainSubstring("does not exist"),
+			"Denial reason should match AgentSessionHandler.validateRemediationRequestExists wording")
+		Expect(err.Error()).To(ContainSubstring(nonExistentRR))
+
+		By("Verifying the AgentSession never persisted in the cluster (denied CREATE)")
+		getErr := k8sClient.Get(ctx, types.NamespacedName{Name: crdName, Namespace: sharedNamespace}, &agentsessionv1alpha1.AgentSession{})
+		Expect(getErr).To(HaveOccurred(), "Denied CREATE should mean the CRD was never persisted")
+
+		By("Verifying the agentsession.denied.create audit event is recorded (BR-AUDIT-005)")
+		authAuditClient := createAuthenticatedAuditClient()
+		Expect(authAuditClient).ToNot(BeNil(), "DD-AUTH-014 authenticated audit client must be available in E2E")
+
+		var deniedPayload auditclient.AgentSessionWebhookAuditPayload
+		Eventually(func() bool {
+			events, qErr := authAuditClient.QueryAuditEvents(ctx, auditclient.QueryAuditEventsParams{
+				EventType:   auditclient.NewOptString("agentsession.denied.create"),
+				DetailKey:   auditclient.NewOptString("crd_name"),
+				DetailValue: auditclient.NewOptString(crdName),
+			})
+			if qErr != nil {
+				return false
+			}
+			for _, evt := range events.Data {
+				payload, ok := evt.EventData.GetAgentSessionWebhookAuditPayload()
+				if ok && payload.CrdName == crdName {
+					deniedPayload = payload
+					return true
+				}
+			}
+			return false
+		}, 15*time.Second, 1*time.Second).Should(BeTrue(),
+			"Audit trail should contain an agentsession.denied.create event for this CRD")
+
+		Expect(deniedPayload.CrdNamespace).To(Equal(sharedNamespace))
+		Expect(deniedPayload.Action).To(Equal(auditclient.AgentSessionWebhookAuditPayloadActionDenied))
+		Expect(deniedPayload.DenialReason.IsSet()).To(BeTrue())
+		Expect(deniedPayload.DenialReason.Value).To(ContainSubstring(nonExistentRR))
+
+		GinkgoWriter.Printf("✅ AgentSession referencing non-existent RemediationRequest %q correctly denied, zero persistence, audit trail captured\n",
+			nonExistentRR)
+	})
+
+	// ========================================
+	// E2E-AS-2244-ALLOW: AgentSession referencing a real RemediationRequest
+	// is admitted and persists, with the admitted audit event recorded.
+	// ========================================
+	It("E2E-AS-2244-ALLOW: AgentSession referencing a real RemediationRequest is admitted and persisted", func() {
+		rrName := fmt.Sprintf("e2e-as-allow-rr-%s", uuid.New().String()[:8])
+		rr := buildRemediationRequestCRD(rrName)
+		Expect(k8sClient.Create(ctx, rr)).To(Succeed(), "RemediationRequest CRD creation should succeed")
+
+		crdName := fmt.Sprintf("e2e-as-allow-%s", uuid.New().String()[:8])
+		as := buildAgentSessionCRD(crdName, rrName)
+
+		By("Creating an AgentSession referencing a real RemediationRequest")
+		Expect(k8sClient.Create(ctx, as)).To(Succeed(), "CREATE should be Allowed when RemediationRequestRef resolves")
+		crdCleanup = append(crdCleanup, crdName)
+
+		By("Verifying the AgentSession persisted in the cluster")
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crdName, Namespace: sharedNamespace}, &agentsessionv1alpha1.AgentSession{})).To(Succeed())
+
+		By("Verifying the agentsession.admitted.create audit event is recorded (BR-AUDIT-005)")
+		authAuditClient := createAuthenticatedAuditClient()
+		Expect(authAuditClient).ToNot(BeNil(), "DD-AUTH-014 authenticated audit client must be available in E2E")
+
+		var admittedPayload auditclient.AgentSessionWebhookAuditPayload
+		Eventually(func() bool {
+			events, qErr := authAuditClient.QueryAuditEvents(ctx, auditclient.QueryAuditEventsParams{
+				EventType:   auditclient.NewOptString("agentsession.admitted.create"),
+				DetailKey:   auditclient.NewOptString("crd_name"),
+				DetailValue: auditclient.NewOptString(crdName),
+			})
+			if qErr != nil {
+				return false
+			}
+			for _, evt := range events.Data {
+				payload, ok := evt.EventData.GetAgentSessionWebhookAuditPayload()
+				if ok && payload.CrdName == crdName {
+					admittedPayload = payload
+					return true
+				}
+			}
+			return false
+		}, 15*time.Second, 1*time.Second).Should(BeTrue(),
+			"Audit trail should contain an agentsession.admitted.create event for this CRD")
+
+		Expect(admittedPayload.Action).To(Equal(auditclient.AgentSessionWebhookAuditPayloadActionCreate))
+		Expect(admittedPayload.RemediationRequestRef.Value).To(Equal(rrName))
+
+		GinkgoWriter.Printf("✅ AgentSession referencing real RemediationRequest %q correctly admitted and persisted\n", rrName)
+	})
+})

--- a/test/e2e/authwebhook/authwebhook_e2e_suite_test.go
+++ b/test/e2e/authwebhook/authwebhook_e2e_suite_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	actiontypev1 "github.com/jordigilh/kubernaut/api/actiontype/v1alpha1"
+	agentsessionv1alpha1 "github.com/jordigilh/kubernaut/api/agentsession/v1alpha1"
 	notificationv1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
 	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	remediationworkflowv1 "github.com/jordigilh/kubernaut/api/remediationworkflow/v1alpha1"
@@ -270,6 +271,7 @@ var _ = SynchronizedBeforeSuite(
 		Expect(remediationv1.AddToScheme(scheme.Scheme)).To(Succeed())
 		Expect(notificationv1.AddToScheme(scheme.Scheme)).To(Succeed())
 		Expect(remediationworkflowv1.AddToScheme(scheme.Scheme)).To(Succeed())
+		Expect(agentsessionv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 		k8sClient, err = client.New(restConfig, client.Options{Scheme: scheme.Scheme})
 		Expect(err).ToNot(HaveOccurred())

--- a/test/infrastructure/authwebhook_e2e.go
+++ b/test/infrastructure/authwebhook_e2e.go
@@ -637,6 +637,27 @@ webhooks:
     scope: "Namespaced"
   sideEffects: NoneOnDryRun
   timeoutSeconds: 15
+- name: agentsession.validate.kubernaut.ai
+  admissionReviewVersions: ["v1"]
+  clientConfig:
+    service:
+      name: authwebhook
+      namespace: %[1]s
+      path: /validate-agentsession
+    caBundle: ""
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: %[1]s
+  rules:
+  - apiGroups: ["kubernaut.ai"]
+    apiVersions: ["v1alpha1"]
+    operations: ["CREATE"]
+    resources: ["agentsessions"]
+    scope: "Namespaced"
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 15
 `, namespace, imageTag, pullPolicy, dataStorageURL, dataStorageHealthURL)
 }
 
@@ -755,9 +776,9 @@ func patchWebhookConfigurations(ctx context.Context, kubeconfigPath string, writ
 		_, _ = fmt.Fprintf(writer, "   ✅ Patched %s\n", webhookName)
 	}
 
-	// Patch ValidatingWebhookConfiguration (3 webhooks: notificationrequest + remediationworkflow + actiontype)
+	// Patch ValidatingWebhookConfiguration (4 webhooks: notificationrequest + remediationworkflow + actiontype + agentsession, #2244)
 	_, _ = fmt.Fprintln(writer, "   🔧 Patching ValidatingWebhookConfiguration webhooks...")
-	validatingWebhookNames := []string{"notificationrequest.validate.kubernaut.ai", "remediationworkflow.validate.kubernaut.ai", "actiontype.validate.kubernaut.ai"}
+	validatingWebhookNames := []string{"notificationrequest.validate.kubernaut.ai", "remediationworkflow.validate.kubernaut.ai", "actiontype.validate.kubernaut.ai", "agentsession.validate.kubernaut.ai"}
 	for i, vwName := range validatingWebhookNames {
 		patchCmd := exec.CommandContext(ctx, "kubectl", "patch", "validatingwebhookconfiguration", "authwebhook-validating",
 			"--kubeconfig", kubeconfigPath,

--- a/test/integration/authwebhook/agentsession_test.go
+++ b/test/integration/authwebhook/agentsession_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authwebhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	agentsessionv1alpha1 "github.com/jordigilh/kubernaut/api/agentsession/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/authwebhook"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	admissionv1 "k8s.io/api/admission/v1"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Issue #2244, BR-AA-KA-065.13: IT coverage for AgentSessionHandler's
+// CREATE-only RemediationRequest existence gate, proving the production
+// wiring path (real envtest apiserver Get, real Manager-backed k8sClient,
+// real audit store round-trip to DS Postgres) -- not just the fake-client
+// UT coverage in pkg/authwebhook/agentsession_handler_test.go.
+var _ = Describe("#2244 AgentSession Admission Existence Gate (BR-AA-KA-065.13)", Label("integration", "authwebhook", "agentsession"), func() {
+
+	var asHandler *authwebhook.AgentSessionHandler
+
+	BeforeEach(func() {
+		asHandler = authwebhook.NewAgentSessionHandler(auditStore, k8sManager.GetClient())
+	})
+
+	flushAndQuery := func(correlationID, eventType string) []ogenclient.AuditEvent {
+		flushCtx, flushCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer flushCancel()
+		Expect(auditStore.Flush(flushCtx)).To(Succeed(), "Audit store flush should succeed")
+
+		var events []ogenclient.AuditEvent
+		Eventually(func() bool {
+			found, qErr := queryAuditEvents(dsClient, correlationID, &eventType)
+			if qErr != nil {
+				return false
+			}
+			events = found
+			return len(events) > 0
+		}, 15*time.Second, 1*time.Second).Should(BeTrue(),
+			fmt.Sprintf("Expected %s audit event with correlation_id=%s", eventType, correlationID))
+		return events
+	}
+
+	uniqueID := func(prefix string) string {
+		return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+	}
+
+	buildRR := func(name string) *remediationv1.RemediationRequest {
+		return &remediationv1.RemediationRequest{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "kubernaut.ai/v1alpha1",
+				Kind:       "RemediationRequest",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: defaultFixture,
+			},
+			Spec: remediationv1.RemediationRequestSpec{
+				SignalFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				SignalName:        "OOMKilled",
+				Severity:          "critical",
+				TargetType:        "kubernetes",
+				TargetResource: remediationv1.ResourceIdentifier{
+					Kind:      "Pod",
+					Name:      "it-agentsession-test-pod",
+					Namespace: defaultFixture,
+				},
+				FiringTime:   metav1.Now(),
+				ReceivedTime: metav1.Now(),
+			},
+		}
+	}
+
+	buildAS := func(name, rrName string) *agentsessionv1alpha1.AgentSession {
+		return &agentsessionv1alpha1.AgentSession{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "kubernaut.ai/v1alpha1",
+				Kind:       "AgentSession",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: defaultFixture,
+			},
+			Spec: agentsessionv1alpha1.AgentSessionSpec{
+				RemediationRequestRef: agentsessionv1alpha1.ObjectRef{
+					Name:      rrName,
+					Namespace: defaultFixture,
+				},
+				IncidentID:    uniqueID("it-aa"),
+				RemediationID: rrName,
+				SignalName:    "OOMKilled",
+				Severity:      "critical",
+			},
+		}
+	}
+
+	asCreateAdmissionRequest := func(as *agentsessionv1alpha1.AgentSession, uid string) admission.Request {
+		raw, err := json.Marshal(as)
+		Expect(err).ToNot(HaveOccurred())
+		return admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UID: types.UID(uid),
+				Kind: metav1.GroupVersionKind{
+					Group: "kubernaut.ai", Version: "v1alpha1", Kind: "AgentSession",
+				},
+				Name:      as.Name,
+				Namespace: as.Namespace,
+				Operation: admissionv1.Create,
+				UserInfo: authv1.UserInfo{
+					Username: "it-agentsession-user@kubernaut.ai",
+					UID:      "it-agentsession-uid",
+					Groups:   []string{"system:masters"},
+				},
+				Object: runtime.RawExtension{Raw: raw},
+			},
+		}
+	}
+
+	It("IT-AS-2244-001: CREATE is allowed and admitted audit persisted when RemediationRequestRef resolves to a real RR in etcd", func() {
+		rrName := uniqueID("it-rr-exists")
+		rr := buildRR(rrName)
+		Expect(k8sClient.Create(ctx, rr)).To(Succeed(), "RemediationRequest CRD creation should succeed")
+
+		uid := uniqueID("as-create-allowed")
+		as := buildAS(uniqueID("it-as-allowed"), rrName)
+
+		resp := asHandler.Handle(ctx, asCreateAdmissionRequest(as, uid))
+		Expect(resp.Allowed).To(BeTrue(), "AgentSession CREATE should be allowed when RemediationRequestRef resolves via real apiserver Get: %v", resp.Result)
+
+		events := flushAndQuery(uid, authwebhook.EventTypeASAdmittedCreate)
+		Expect(events).To(HaveLen(1))
+		Expect(events[0].CorrelationID).To(Equal(uid))
+		validateEventMetadata(events[0], "agentsession")
+
+		payload, ok := events[0].EventData.GetAgentSessionWebhookAuditPayload()
+		Expect(ok).To(BeTrue(), "event_data should decode as AgentSessionWebhookAuditPayload")
+		Expect(payload.CrdName).To(Equal(as.Name))
+		Expect(payload.CrdNamespace).To(Equal(defaultFixture))
+		Expect(payload.Action).To(Equal(ogenclient.AgentSessionWebhookAuditPayloadActionCreate))
+		Expect(payload.RemediationRequestRef.Value).To(Equal(rrName))
+	})
+
+	It("IT-AS-2244-002: CREATE is denied and denied audit persisted when RemediationRequestRef does not exist in etcd (SI-10)", func() {
+		uid := uniqueID("as-create-denied")
+		as := buildAS(uniqueID("it-as-denied"), uniqueID("rr-never-created"))
+
+		resp := asHandler.Handle(ctx, asCreateAdmissionRequest(as, uid))
+		Expect(resp.Allowed).To(BeFalse(), "AgentSession CREATE should be denied when RemediationRequestRef does not resolve via real apiserver Get")
+		Expect(resp.Result.Message).To(ContainSubstring("does not exist"))
+
+		events := flushAndQuery(uid, authwebhook.EventTypeASDeniedCreate)
+		Expect(events).To(HaveLen(1))
+		Expect(events[0].CorrelationID).To(Equal(uid))
+		validateEventMetadata(events[0], "agentsession")
+
+		payload, ok := events[0].EventData.GetAgentSessionWebhookAuditPayload()
+		Expect(ok).To(BeTrue())
+		Expect(payload.Action).To(Equal(ogenclient.AgentSessionWebhookAuditPayloadActionDenied))
+		Expect(payload.DenialReason.IsSet()).To(BeTrue())
+	})
+
+	It("IT-AS-2244-003: CREATE is denied when the RR exists only in a different namespace (namespace-scoped lookup)", func() {
+		rrName := uniqueID("it-rr-wrong-ns")
+		otherNS := "kube-system" // pre-existing built-in namespace, avoids an extra Namespace-creation round trip
+		rr := buildRR(rrName)
+		rr.Namespace = otherNS
+		Expect(k8sClient.Create(ctx, rr)).To(Succeed(), "RemediationRequest CRD creation in other namespace should succeed")
+
+		uid := uniqueID("as-create-wrong-ns")
+		as := buildAS(uniqueID("it-as-wrong-ns"), rrName)
+
+		resp := asHandler.Handle(ctx, asCreateAdmissionRequest(as, uid))
+		Expect(resp.Allowed).To(BeFalse(),
+			"a RemediationRequest with a matching name in a different namespace must not satisfy the gate")
+
+		events := flushAndQuery(uid, authwebhook.EventTypeASDeniedCreate)
+		Expect(events).To(HaveLen(1))
+	})
+
+	It("IT-AS-2244-004: UPDATE is not intercepted (AgentSessionSpec is CEL-immutable, nothing to re-validate)", func() {
+		rrName := uniqueID("it-rr-update")
+		rr := buildRR(rrName)
+		Expect(k8sClient.Create(ctx, rr)).To(Succeed())
+
+		as := buildAS(uniqueID("it-as-update"), rrName)
+		asJSON, err := json.Marshal(as)
+		Expect(err).ToNot(HaveOccurred())
+
+		uid := uniqueID("as-update-not-gated")
+		resp := asHandler.Handle(ctx, admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				UID: types.UID(uid),
+				Kind: metav1.GroupVersionKind{
+					Group: "kubernaut.ai", Version: "v1alpha1", Kind: "AgentSession",
+				},
+				Name:      as.Name,
+				Namespace: as.Namespace,
+				Operation: admissionv1.Update,
+				UserInfo: authv1.UserInfo{
+					Username: "it-agentsession-user@kubernaut.ai",
+					UID:      "it-agentsession-uid",
+				},
+				Object:    runtime.RawExtension{Raw: asJSON},
+				OldObject: runtime.RawExtension{Raw: asJSON},
+			},
+		})
+
+		Expect(resp.Allowed).To(BeTrue(), "UPDATE should be allowed unconditionally")
+
+		// #2244: no audit event is emitted for an operation this handler
+		// does not gate -- give the (nonexistent) event a bounded window to
+		// *not* appear rather than asserting on an empty slice immediately,
+		// since a false negative here would silently hide an audit-flood
+		// regression.
+		Consistently(func() ([]ogenclient.AuditEvent, error) {
+			return queryAuditEvents(dsClient, uid, nil)
+		}, 3*time.Second, 500*time.Millisecond).Should(BeEmpty(),
+			"UPDATE must not emit any audit event")
+	})
+
+})

--- a/test/integration/authwebhook/suite_test.go
+++ b/test/integration/authwebhook/suite_test.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	actiontypev1 "github.com/jordigilh/kubernaut/api/actiontype/v1alpha1"
+	agentsessionv1alpha1 "github.com/jordigilh/kubernaut/api/agentsession/v1alpha1"
 	notificationv1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
 	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	remediationworkflowv1 "github.com/jordigilh/kubernaut/api/remediationworkflow/v1alpha1"
@@ -252,6 +253,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 	err = remediationworkflowv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
+	err = agentsessionv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	By("Creating controller-runtime Manager (follows production pattern)")
 	// Pattern: cmd/authwebhook/main.go (same Manager setup as production)
@@ -341,6 +344,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).ToNot(HaveOccurred())
 	webhookServer.Register("/mutate-remediationrequest", &webhook.Admission{Handler: rrHandler})
 	GinkgoWriter.Println("   ✅ Registered RemediationRequest webhook handler")
+
+	// Register AgentSession CREATE existence-gate validator (Issue #2244, BR-AA-KA-065.13)
+	asHandler := authwebhook.NewAgentSessionHandler(auditStore, k8sManager.GetClient())
+	webhookServer.Register("/validate-agentsession", &webhook.Admission{Handler: asHandler})
+	GinkgoWriter.Println("   ✅ Registered AgentSession webhook handler")
 
 	// Register NotificationRequest DELETE validator (DD-WEBHOOK-003: Complete audit events)
 	nrValidator := authwebhook.NewNotificationRequestValidator(auditStore)


### PR DESCRIPTION
## Summary

- **#2243** (`fix(signalprocessing)`): removes an unused, least-privilege-violating RBAC grant. SP's ClusterRole granted full CRUD on `remediationrequests` alongside `signalprocessings` in the same rule, but SP never performs CRUD against the RemediationRequest CRD -- it only reads `Spec.RemediationRequestRef.Name` (a plain string field on its own CRD) for audit correlation. BR-RBAC-020 / FedRAMP AC-6.
- **#2244** (`feat(authwebhook)`): adds a CREATE-only admission webhook for the `AgentSession` CRD that denies creation when `Spec.RemediationRequestRef` does not resolve to a real `RemediationRequest` in the same namespace (SI-10: input validation at the trust boundary, before KA's dispatcher ever observes the object). Mirrors #1661's `validateActionTypeExists` existence-gate pattern (DD-WORKFLOW-018). No UPDATE/DELETE gate is needed since `AgentSessionSpec` is CEL-immutable. `failurePolicy: Fail`, matching the RemediationWorkflow/ActionType precedent (DD-WEBHOOK-001 v1.5, Use Case 5). BR-AA-KA-065.13.

## Test plan

All tiers run against real infrastructure (Podman/Kind) on a remote host, not just compiled/vetted:

- [x] `go build ./...` / `go vet ./...` -- clean
- [x] `golangci-lint run` -- 0 issues
- [x] Helm unittest (`make test-helm`) -- 576/576 passed, including new `signalprocessing_rbac_least_privilege_test.yaml` and `authwebhook_agentsession_webhook_test.yaml` suites
- [x] `make test-integration-authwebhook` (envtest + Podman-backed Postgres/Redis/DataStorage) -- 37/37 passed
- [x] `make test-e2e-authwebhook` (Kind cluster + Docker-built images) -- 25/25 passed, including `E2E-AS-2244-DENY` and `E2E-AS-2244-ALLOW`

Two real bugs were caught and fixed by the real-infra runs (not visible with fake/mock clients):
1. A 62-vs-64-char `SignalFingerprint` test fixture that only failed under the real CRD's CEL/OpenAPI pattern validation.
2. A missing `agentsession` value in the `event_category` OpenAPI enum, which was silently dropping audit events for the new webhook (best-effort, non-blocking store, so it failed quietly until checked).