### PR TITLE
fix(apifrontend): create IS CRD before RR to close #2265 dispatch race

### DIFF
--- a/docs/architecture/decisions/DD-AA-KA-001-agentsession-crd-http-removal.md
+++ b/docs/architecture/decisions/DD-AA-KA-001-agentsession-crd-http-removal.md
@@ -616,6 +616,86 @@ several of these stalls beginning *before* E2E-AA-065's own burst window even st
 burst as the trigger. #2204 predates this PR, is unrelated to `AgentSessionReasonCapacityExceeded` retry
 logic, and its suggested fix (raise the affected specs' `Eventually` timeouts) is out of scope for this PR.
 
+### Gap 6 (2026-08-23, #2265): Gap 1's "freshest possible read" still raced AF's own separate IS-create call for the fresh-start path
+
+Gap 1 above resolved the fresh-start case by moving the IS-existence check to KA's actual dispatch
+decision point — "the freshest possible read, and the only read that matters, since dispatch is the
+one moment the decision is actually consumed." That reasoning is correct *given* the IS CRD exists
+by the time dispatch runs. It missed a second, independent ordering problem one layer up: AF's own
+`kubernaut_investigate`/`kubernaut_investigate_alert` MCP tools, for a genuinely new RR (no `rr_id`
+supplied — the human names a resource directly), created the RR *first* via `HandleCreateRR`, then
+issued a *separate* `SignalInteractive` call afterward to create the IS. Once the RR existed, nothing
+serialized "RO promotes it → AIAnalysis is created → AA creates `AgentSession` → KA's dispatcher runs
+`hasInvestigationSession()`" against "AF's own IS `Create` call actually lands" — under real
+cluster latency (informer relist/propagation delay, apiserver/etcd load) dispatch could win that race
+and read "no IS yet," permanently deciding `Status.Interactive=false` for a session the human had
+already asked to drive interactively (`Status.Interactive` is a write-once ack per Gap 1 above — KA
+never re-checks). Confirmed via must-gather RCA on a CI E2E flake
+([E2E-FP-1912-001](https://github.com/jordigilh/kubernaut/issues/2265)): the IS CRD's own
+`creationTimestamp` postdated the `AgentSession`'s dispatch-time `Status.Interactive=false` write by
+tens of milliseconds — a real TOCTOU race, not a mock-LLM or test-harness artifact.
+
+**Options considered and rejected:**
+
+- **Bounded retry/re-check on KA's dispatcher** (re-run `hasInvestigationSession()` a few times with
+  backoff before committing to autonomous). Rejected: this narrows the race window but does not
+  remove it — it is fundamentally probabilistic, and this is a security-sensitive control-flow
+  decision (autonomous vs. human-driven investigation) where auto-execution can complete and act on
+  a cluster *before* a delayed retry would have flipped the answer. A probabilistic fix is not an
+  acceptable fix for this class of gap.
+- **RR annotation as an interactivity signal** (AF sets an annotation on the RR itself at create
+  time, read by downstream components instead of/alongside the IS CRD). Rejected on security
+  grounds: an annotation is a bare key/value string with no admission-time validation tying it to
+  the actual caller's identity or intent — it is a control-flow flag an actor with RR write access
+  could tamper with to force (or suppress) interactive routing they weren't entitled to, unlike the
+  IS CRD's existence check, which is anchored to a real, independently-RBAC'd resource.
+
+**Resolution: reorder AF's own two calls so the IS CRD is created *before* the RR it references,
+closing the race at its actual source instead of narrowing it downstream.** The IS CRD's
+`spec.remediationRequestRef.name` is a plain string, not a UID-anchored `OwnerReference` — nothing
+requires the referenced RR to exist yet, and RR names are client-generated (deterministic,
+pre-computable before the RR object is created), so `createRRForInvestigation`
+(`ka_investigate_mcp.go`) and `HandleInvestigateAlert` (`af_investigate_alert.go`) now pass a new
+`CreateRRHooks{BeforeCreate, AfterCreate}` pair into `HandleCreateRRWithHooks`
+(`af_create_rr.go`): `BeforeCreate` fires with the about-to-be-created RR's name after dedup has
+resolved to "genuinely new" but strictly before the RR's `client.Create` call — signaling
+interactively (`ISSignaler.SignalInteractive`/`AlertISSignaler.SignalInteractive`) here means the IS
+CRD is guaranteed to exist before *any* other component (RO, AA, KA) can possibly observe the RR at
+all, not just before KA's dispatch check specifically. `AfterCreate` fires once the RR is actually
+persisted (real UID assigned by the API server) and backfills the IS CRD's `OwnerReference` — deferred
+from `CreateInvestigationSession`'s existing best-effort `setRROwnerReference` lookup, which
+necessarily missed it since the RR didn't exist yet — via the new `OwnerReferenceBackfiller`
+interface, checked with a type assertion rather than added to `ISSignaler`/`AlertISSignaler` directly
+so every existing signaler implementation (including test doubles that don't need backfill) is
+unaffected. The pre-existing dedup (`AlreadyExists`) branch is untouched: that RR already existed
+before this call, so it was never at risk of this ordering race, and both call sites fall back to
+the original post-hoc `signalInteractiveSession`/`signalInteractiveIfConfigured` call exactly as
+before whenever the hook didn't fire (dedup hit) or fired but didn't produce a usable IS CRD name.
+
+**Fire-and-forget semantics preserved exactly per call site.** `ka_investigate_mcp.go`'s hook keeps
+its existing single-driver conflict check (`session_active` errors still propagate and abort RR
+creation — a genuine conflicting session must still block); `af_investigate_alert.go`'s hook keeps
+its existing best-effort contract (`BeforeCreate` never returns a non-nil error regardless of the
+signaler's outcome, matching #1440/SC-24's "a signaling failure must never fail RR creation").
+
+**Business Requirements**: BR-INTERACTIVE-010 (interactive investigation routing must be reliable,
+not probabilistic), SI-10 (this closes an information-flow ordering defect, not an input-validation
+one), AC-6 (rejecting the annotation option preserves least-privilege: interactivity control stays
+anchored to an RBAC'd CRD, never a tamperable free-form field).
+
+**Implemented**: `pkg/apifrontend/tools/af_create_rr.go` (`CreateRRHooks`, `HandleCreateRRWithHooks`,
+`OwnerReferenceBackfiller`); `pkg/apifrontend/tools/ka_investigate_mcp.go`
+(`buildPreCreateISHooks`, `resolveInvestigationRR`/`createRRForInvestigation` reordered);
+`pkg/apifrontend/tools/af_investigate_alert.go` (`buildAlertPreCreateISHooks`); `pkg/apifrontend/
+session/service.go` (`CRDSessionService.BackfillOwnerReference`); production adapter wiring in
+`pkg/apifrontend/agent/root.go` (`agentISSignalerAdapter`, `alertISSignalerAdapter`) and
+`pkg/apifrontend/handler/mcp_bridge.go` (`isSignalerAdapter`, `ISSessionInitializer` interface).
+Test coverage: `pkg/apifrontend/tools/af_create_rr_test.go` (UT-AF-2265-001..006, hook-layer),
+`pkg/apifrontend/tools/ka_investigate_intent_test.go` (UT-AF-2265-101..103, create-new-RR ordering),
+`pkg/apifrontend/tools/af_investigate_alert_1440_test.go` (UT-AF-2265-201..204, alert-path ordering),
+`pkg/apifrontend/tools/af_investigate_alert_1440_it_test.go` (IT-AF-2265-001, real
+`CRDSessionService`-backed production adapter wiring, not a test double).
+
 ## Amendment: #2204 — controller concurrency + deadline-driven backstop requeue (2026-08-20)
 
 **Problem.** Once E2E-AA-065's own flakiness was fixed (previous section), CI still showed

--- a/pkg/apifrontend/agent/root.go
+++ b/pkg/apifrontend/agent/root.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/adk/v2/tool"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/types"
 
 	isv1alpha1 "github.com/jordigilh/kubernaut/api/investigationsession/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
@@ -534,6 +535,11 @@ func (a *agentISSignalerAdapter) UpdateCorrelation(ctx context.Context, crdName,
 	return a.svc.UpdateISCorrelation(ctx, crdName, kaSessionID)
 }
 
+// BackfillOwnerReference implements tools.OwnerReferenceBackfiller (#2265).
+func (a *agentISSignalerAdapter) BackfillOwnerReference(ctx context.Context, rrNamespace, rrName string, rrUID types.UID) {
+	a.svc.BackfillOwnerReference(ctx, rrNamespace, rrName, rrUID)
+}
+
 // buildAlertISSignaler returns an AlertISSignaler wired to the CRDSessionService.
 // Returns nil when no SessionService is configured (backward compat).
 func buildAlertISSignaler(cfg AgentConfig) tools.AlertISSignaler {
@@ -558,6 +564,11 @@ func (a *alertISSignalerAdapter) SignalInteractive(ctx context.Context, taskID, 
 		JoinMode:    isv1alpha1.SessionJoinModeStart,
 	})
 	return err
+}
+
+// BackfillOwnerReference implements tools.OwnerReferenceBackfiller (#2265).
+func (a *alertISSignalerAdapter) BackfillOwnerReference(ctx context.Context, rrNamespace, rrName string, rrUID types.UID) {
+	a.svc.BackfillOwnerReference(ctx, rrNamespace, rrName, rrUID)
 }
 
 // newAuditToolCallback returns an AfterToolCallback that emits a structured

--- a/pkg/apifrontend/handler/mcp_bridge.go
+++ b/pkg/apifrontend/handler/mcp_bridge.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/semaphore"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -47,6 +48,9 @@ type ISSessionInitializer interface {
 	InitializeSessionByRR(ctx context.Context, rrNamespace, rrName, kaSessionID, username string, groups []string) error
 	CreateInvestigationSession(ctx context.Context, cfg session.CreateISConfig) (string, error)
 	UpdateISCorrelation(ctx context.Context, crdName, kaSessionID string) error
+	// BackfillOwnerReference sets the OwnerReference on an IS CRD created
+	// before its target RR existed (#2265), once the RR is persisted.
+	BackfillOwnerReference(ctx context.Context, rrNamespace, rrName string, rrUID types.UID)
 }
 
 // MCPBridgeConfig holds the configuration for the real MCP tool bridge.
@@ -758,4 +762,9 @@ func (a *isSignalerAdapter) SignalInteractive(ctx context.Context, rrNamespace, 
 
 func (a *isSignalerAdapter) UpdateCorrelation(ctx context.Context, crdName, kaSessionID string) error {
 	return a.initializer.UpdateISCorrelation(ctx, crdName, kaSessionID)
+}
+
+// BackfillOwnerReference implements tools.OwnerReferenceBackfiller (#2265).
+func (a *isSignalerAdapter) BackfillOwnerReference(ctx context.Context, rrNamespace, rrName string, rrUID types.UID) {
+	a.initializer.BackfillOwnerReference(ctx, rrNamespace, rrName, rrUID)
 }

--- a/pkg/apifrontend/handler/mcp_bridge_integration_test.go
+++ b/pkg/apifrontend/handler/mcp_bridge_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
@@ -1270,4 +1271,7 @@ func (r *recordingSessionInitializer) CreateInvestigationSession(_ context.Conte
 func (r *recordingSessionInitializer) UpdateISCorrelation(_ context.Context, crdName, kaSessionID string) error {
 	r.correlations = append(r.correlations, correlationCall{crdName: crdName, kaSessionID: kaSessionID})
 	return nil
+}
+
+func (r *recordingSessionInitializer) BackfillOwnerReference(_ context.Context, _, _ string, _ k8stypes.UID) {
 }

--- a/pkg/apifrontend/session/service.go
+++ b/pkg/apifrontend/session/service.go
@@ -781,6 +781,46 @@ func (s *CRDSessionService) UpdateISCorrelation(ctx context.Context, crdName, ka
 	return nil
 }
 
+// BackfillOwnerReference sets rrNamespace/rrName/rrUID as the OwnerReference
+// on the IS CRD for this RR (named deterministically as is-<rrName>, per
+// CreateInvestigationSession), enabling cascade-GC (#1300). This exists
+// because #2265 deliberately creates the IS *before* its target RR (closing
+// a TOCTOU race in KA's dispatch-time interactivity check) -- so
+// CreateInvestigationSession's own best-effort setRROwnerReference lookup,
+// which runs inline at IS-create time, necessarily misses an RR that
+// doesn't exist yet. This is the deferred completion of that same
+// best-effort contract, called once the RR is actually persisted.
+// Best-effort: failures are logged, not returned -- the RR is already
+// committed, so a backfill failure only delays cascade-GC, it doesn't lose
+// functionality. A no-op if the OwnerReference is already set (idempotent).
+func (s *CRDSessionService) BackfillOwnerReference(ctx context.Context, rrNamespace, rrName string, rrUID types.UID) {
+	crdName := fmt.Sprintf("is-%s", rrName)
+
+	var is v1alpha1.InvestigationSession
+	if err := s.getReader().Get(ctx, types.NamespacedName{Namespace: s.namespace, Name: crdName}, &is); err != nil {
+		s.logger.Error(err, "backfill OwnerReference: get IS CRD failed", "is_name", crdName, "rr_ref", rrNamespace+"/"+rrName)
+		return
+	}
+	if len(is.OwnerReferences) > 0 {
+		return
+	}
+
+	patch := client.MergeFrom(is.DeepCopy())
+	is.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "kubernaut.ai/v1alpha1",
+			Kind:       "RemediationRequest",
+			Name:       rrName,
+			UID:        rrUID,
+		},
+	}
+	if err := s.client.Patch(ctx, &is, patch); err != nil {
+		s.logger.Error(err, "backfill OwnerReference: patch IS CRD failed", "is_name", crdName, "rr_ref", rrNamespace+"/"+rrName)
+		return
+	}
+	s.logger.Info("IS CRD OwnerReference backfilled", "is_name", crdName, "rr_ref", rrNamespace+"/"+rrName)
+}
+
 var rrGVK = schema.GroupVersionKind{Group: "kubernaut.ai", Version: "v1alpha1", Kind: "RemediationRequest"}
 
 // setRROwnerReference looks up the RemediationRequest and, if found, sets an

--- a/pkg/apifrontend/tools/af_create_rr.go
+++ b/pkg/apifrontend/tools/af_create_rr.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/sync/singleflight"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -105,6 +106,50 @@ type CreateRRResult struct {
 	CandidateSeverity   string `json:"candidate_severity,omitempty"`
 }
 
+// CreateRRHooks lets a caller interleave work strictly between "the new
+// RR's name is known" and "the RR becomes visible to any other component"
+// (#2265, DD-AF-013). Both fields are optional; the zero value preserves
+// HandleCreateRR's original behavior exactly (see HandleCreateRR's
+// delegation to HandleCreateRRWithHooks below) -- neither hook is invoked on
+// the dedup/AlreadyExists branch, since that RR predates this call and no
+// ordering race exists for it.
+type CreateRRHooks struct {
+	// BeforeCreate fires with the about-to-be-created RR's name after dedup
+	// has resolved to "genuinely new", strictly before the RR's Create call
+	// is issued. Returning a non-nil error aborts RR creation entirely --
+	// used by the interactive-investigation callers (ka_investigate_mcp.go,
+	// af_investigate_alert.go) to create the InvestigationSession CRD first,
+	// closing the race where RO/AA/KA could otherwise process the RR before
+	// AF's own, separately-issued InvestigationSession Create call lands.
+	BeforeCreate func(ctx context.Context, rrName string) error
+	// AfterCreate fires once the new RR is actually persisted (a real UID
+	// assigned by the API server) -- used to back-fill the
+	// InvestigationSession's OwnerReference (#1300 cascade-GC), which
+	// couldn't be set at BeforeCreate time since the RR didn't exist yet.
+	// Best-effort by design: unlike BeforeCreate, it has no error return --
+	// the RR is already committed at this point, so a backfill failure must
+	// never unwind a successful creation; callers log/handle their own
+	// errors internally (mirrors setRROwnerReference's existing
+	// best-effort convention).
+	AfterCreate func(ctx context.Context, rr *remediationv1.RemediationRequest)
+}
+
+// OwnerReferenceBackfiller is an optional capability an ISSignaler/
+// AlertISSignaler implementation may support, checked via type assertion
+// (#2265) so signaler implementations that don't need it -- including every
+// existing test double -- are unaffected. Implemented by the production
+// CRDSessionService-backed adapters to back-fill the InvestigationSession's
+// OwnerReference (#1300 cascade-GC) once its target RR (created after the IS
+// under the #2265 ordering) is actually persisted.
+type OwnerReferenceBackfiller interface {
+	// BackfillOwnerReference sets rrNamespace/rrName/rrUID as the
+	// OwnerReference on the InvestigationSession CRD for this RR (named
+	// deterministically as is-<rrName> per CreateInvestigationSession).
+	// Best-effort: implementations log failures internally rather than
+	// returning an error, since the RR is already committed at this point.
+	BackfillOwnerReference(ctx context.Context, rrNamespace, rrName string, rrUID types.UID)
+}
+
 // rrCreateGroup provides singleflight deduplication per fingerprint.
 // Dedup is intentionally user-agnostic: concurrent RR creation for the same
 // target resource is deduplicated regardless of which user initiated it.
@@ -159,6 +204,14 @@ func checkExistingRRByFingerprint(ctx context.Context, client crclient.Client, c
 // by the LLM. Severity is resolved via the triage pipeline when a triager is
 // available, otherwise defaults to "warning".
 func HandleCreateRR(ctx context.Context, d *ToolDeps, args *CreateRRArgs, username string) (CreateRRResult, error) {
+	return HandleCreateRRWithHooks(ctx, d, args, username, CreateRRHooks{})
+}
+
+// HandleCreateRRWithHooks is HandleCreateRR with the addition of hooks
+// (#2265, DD-AF-013) letting a caller interleave work around the moment a
+// genuinely-new RR is created -- see CreateRRHooks' doc comment. An empty
+// CreateRRHooks{} makes this identical to HandleCreateRR.
+func HandleCreateRRWithHooks(ctx context.Context, d *ToolDeps, args *CreateRRArgs, username string, hooks CreateRRHooks) (CreateRRResult, error) {
 	if d.Client == nil {
 		return CreateRRResult{}, ErrK8sUnavailable
 	}
@@ -209,7 +262,7 @@ func HandleCreateRR(ctx context.Context, d *ToolDeps, args *CreateRRArgs, userna
 		return createOrReuseRR(ctx, d, createRRRequest{
 			Args: args, Username: username, Fingerprint: fingerprint,
 			SignalName: signalName, ResolvedSeverity: resolvedSeverity, TriageResult: triageResult,
-		})
+		}, hooks)
 	})
 	if err != nil {
 		return CreateRRResult{}, fmt.Errorf("create RR for %s/%s: %w", args.Kind, args.Name, err)
@@ -302,8 +355,11 @@ type createRRRequest struct {
 
 // createOrReuseRR is the singleflight-guarded body of HandleCreateRR: it
 // returns the existing RR if one is already active for req's fingerprint,
-// otherwise creates a new RemediationRequest CRD.
-func createOrReuseRR(ctx context.Context, d *ToolDeps, req createRRRequest) (*CreateRRResult, error) {
+// otherwise creates a new RemediationRequest CRD. hooks.BeforeCreate/
+// AfterCreate (#2265) fire only on this "genuinely new" path -- the dedup
+// branch above returns an RR that predates this call, so neither hook
+// applies to it (see CreateRRHooks' doc comment).
+func createOrReuseRR(ctx context.Context, d *ToolDeps, req createRRRequest, hooks CreateRRHooks) (*CreateRRResult, error) {
 	existing, checkErr := checkExistingRRByFingerprint(ctx, d.Client, d.ControllerNS, req.Fingerprint)
 	if checkErr != nil {
 		return nil, checkErr
@@ -320,8 +376,19 @@ func createOrReuseRR(ctx context.Context, d *ToolDeps, req createRRRequest) (*Cr
 	}
 
 	rrObj := buildRRObject(d.ControllerNS, req.Args, req.Fingerprint, req.SignalName, req.ResolvedSeverity, req.TriageResult)
+
+	if hooks.BeforeCreate != nil {
+		if hookErr := hooks.BeforeCreate(ctx, rrObj.Name); hookErr != nil {
+			return nil, hookErr
+		}
+	}
+
 	if createErr := d.Client.Create(ctx, rrObj); createErr != nil {
 		return nil, ToUserFriendlyError(createErr)
+	}
+
+	if hooks.AfterCreate != nil {
+		hooks.AfterCreate(ctx, rrObj)
 	}
 
 	out := &CreateRRResult{

--- a/pkg/apifrontend/tools/af_create_rr_test.go
+++ b/pkg/apifrontend/tools/af_create_rr_test.go
@@ -13,9 +13,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
@@ -144,6 +147,25 @@ func newDynEventClient(objects ...runtime.Object) dynamic.Interface {
 			eventsGVR: "EventList",
 		},
 		objects...)
+}
+
+// newTypedFakeClientWithUIDAssignment wraps a fake client's Create so it
+// assigns a UID like a real API server would (the fake client's own
+// ObjectTracker leaves UID empty, unlike a real cluster -- see #1300's
+// existing rr.SetUID(...) convention in session/deferred_crd_test.go for the
+// same underlying limitation).
+func newTypedFakeClientWithUIDAssignment() crclient.Client {
+	return fake.NewClientBuilder().
+		WithScheme(rrTestScheme()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c crclient.WithWatch, obj crclient.Object, opts ...crclient.CreateOption) error {
+				if obj.GetUID() == "" {
+					obj.SetUID(uuid.NewUUID())
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
 }
 
 func verifyTypedRR(tc crclient.Client, ns, name string) *remediationv1.RemediationRequest {
@@ -1086,6 +1108,123 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			Expect(rec.events[0].Detail["namespace"]).To(Equal("prod"))
 			Expect(rec.events[0].Detail["kind"]).To(Equal("Deployment"))
 			Expect(rec.events[0].Detail["name"]).To(Equal("web"))
+		})
+	})
+
+	// #2265 / DD-AF-013: BeforeCreate/AfterCreate hooks let a caller
+	// interleave InvestigationSession CRD creation strictly between "the
+	// new RR's name is known" and "the RR becomes visible to any other
+	// component" -- closing the race where RO/AA/KA can process a
+	// freshly-created RR before AF's own later, separate InvestigationSession
+	// Create call lands (see ka_investigate_mcp.go/af_investigate_alert.go
+	// for the actual reordering that consumes these hooks).
+	Describe("CreateRRHooks / HandleCreateRRWithHooks (#2265)", func() {
+		It("UT-AF-2265-001: BeforeCreate fires with the about-to-be-created RR's name strictly before the RR is visible to any reader", func() {
+			tc := newTypedFakeClient()
+			var hookRRName string
+			var rrVisibleAtHookTime bool
+			hooks := tools.CreateRRHooks{
+				BeforeCreate: func(ctx context.Context, rrName string) error {
+					hookRRName = rrName
+					var probe remediationv1.RemediationRequest
+					err := tc.Get(ctx, crclient.ObjectKey{Namespace: "prod", Name: rrName}, &probe)
+					rrVisibleAtHookTime = err == nil
+					return nil
+				},
+			}
+
+			result, err := tools.HandleCreateRRWithHooks(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web", Description: "hook order test", APIVersion: "apps/v1",
+			}, "sre-user", hooks)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(hookRRName).To(Equal(result.RRID), "BeforeCreate must fire with exactly the name the RR is ultimately created under")
+			Expect(rrVisibleAtHookTime).To(BeFalse(),
+				"#2265: BeforeCreate must fire before the RR becomes visible to any reader, so a caller creating an InvestigationSession from this hook can never lose the race")
+			verifyTypedRR(tc, "prod", result.RRID)
+		})
+
+		It("UT-AF-2265-002: BeforeCreate is never invoked on the dedup (AlreadyExists) branch", func() {
+			tc := newTypedFakeClient()
+			triager := defaultTestTriager("prod", "Deployment", "dedup-hooks")
+			deps := &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: triager}
+			args := &tools.CreateRRArgs{Namespace: "prod", Kind: "Deployment", Name: "dedup-hooks", Description: "first", APIVersion: "apps/v1"}
+
+			first, err := tools.HandleCreateRR(context.Background(), deps, args, "user")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(first.AlreadyExists).To(BeFalse())
+
+			hookCalled := false
+			second, err := tools.HandleCreateRRWithHooks(context.Background(), deps, args, "user", tools.CreateRRHooks{
+				BeforeCreate: func(ctx context.Context, rrName string) error {
+					hookCalled = true
+					return nil
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(second.AlreadyExists).To(BeTrue(), "the second call with identical fingerprint-producing args must hit the dedup branch")
+			Expect(second.RRID).To(Equal(first.RRID))
+			Expect(hookCalled).To(BeFalse(), "BeforeCreate must only fire for a genuinely new RR -- the dedup branch's RR predates this call, so no race exists for it")
+		})
+
+		It("UT-AF-2265-003: a BeforeCreate error aborts RR creation entirely", func() {
+			tc := newTypedFakeClient()
+			boom := errors.New("simulated InvestigationSession creation failure")
+
+			_, err := tools.HandleCreateRRWithHooks(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "abort-test")}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "abort-test", Description: "abort test", APIVersion: "apps/v1",
+			}, "user", tools.CreateRRHooks{
+				BeforeCreate: func(ctx context.Context, rrName string) error { return boom },
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, boom)).To(BeTrue())
+
+			var list remediationv1.RemediationRequestList
+			Expect(tc.List(context.Background(), &list, crclient.InNamespace("prod"))).To(Succeed())
+			Expect(list.Items).To(BeEmpty(), "an aborted BeforeCreate hook must prevent the RR from ever being created")
+		})
+
+		It("UT-AF-2265-004: AfterCreate fires with the persisted RR, real UID included, after Create succeeds", func() {
+			tc := newTypedFakeClientWithUIDAssignment()
+			var afterCreateRR *remediationv1.RemediationRequest
+
+			result, err := tools.HandleCreateRRWithHooks(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "backfill-test")}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "backfill-test", Description: "backfill test", APIVersion: "apps/v1",
+			}, "user", tools.CreateRRHooks{
+				AfterCreate: func(ctx context.Context, rr *remediationv1.RemediationRequest) { afterCreateRR = rr },
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(afterCreateRR).NotTo(BeNil())
+			Expect(afterCreateRR.Name).To(Equal(result.RRID))
+			Expect(afterCreateRR.UID).NotTo(BeEmpty(), "#1300: AfterCreate must see the real, persisted RR so its UID can back-fill the InvestigationSession's OwnerReference")
+		})
+
+		It("UT-AF-2265-005: AfterCreate is never invoked on the dedup (AlreadyExists) branch", func() {
+			tc := newTypedFakeClient()
+			triager := defaultTestTriager("prod", "Deployment", "dedup-after")
+			deps := &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: triager}
+			args := &tools.CreateRRArgs{Namespace: "prod", Kind: "Deployment", Name: "dedup-after", Description: "first", APIVersion: "apps/v1"}
+
+			_, err := tools.HandleCreateRR(context.Background(), deps, args, "user")
+			Expect(err).NotTo(HaveOccurred())
+
+			afterCreateCalled := false
+			second, err := tools.HandleCreateRRWithHooks(context.Background(), deps, args, "user", tools.CreateRRHooks{
+				AfterCreate: func(ctx context.Context, rr *remediationv1.RemediationRequest) { afterCreateCalled = true },
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(second.AlreadyExists).To(BeTrue())
+			Expect(afterCreateCalled).To(BeFalse(), "AfterCreate must only fire for a genuinely new RR")
+		})
+
+		It("UT-AF-2265-006: HandleCreateRR (no hooks) behaves identically to HandleCreateRRWithHooks with an empty CreateRRHooks{}", func() {
+			tc := newTypedFakeClient()
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web", Description: "backward compat", APIVersion: "apps/v1",
+			}, "user")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RRID).NotTo(BeEmpty())
+			Expect(result.AlreadyExists).To(BeFalse())
 		})
 	})
 })

--- a/pkg/apifrontend/tools/af_investigate_alert.go
+++ b/pkg/apifrontend/tools/af_investigate_alert.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
@@ -145,7 +146,8 @@ func HandleInvestigateAlert(
 		ConfirmedAmbiguousSignalName: args.ConfirmedSignalName,
 	}
 
-	result, err := HandleCreateRR(ctx, &ToolDeps{Client: cfg.Client, DynClient: cfg.DynClient, ControllerNS: cfg.ControllerNS, Triager: cfg.Triager, Auditor: cfg.Auditor, ScopeChecker: cfg.ScopeChecker}, createArgs, username)
+	hooks, hookFired := buildAlertPreCreateISHooks(cfg.Signaler, username)
+	result, err := HandleCreateRRWithHooks(ctx, &ToolDeps{Client: cfg.Client, DynClient: cfg.DynClient, ControllerNS: cfg.ControllerNS, Triager: cfg.Triager, Auditor: cfg.Auditor, ScopeChecker: cfg.ScopeChecker}, createArgs, username, hooks)
 	if err != nil {
 		return InvestigateAlertResult{}, fmt.Errorf("create RR for alert investigation: %w", err)
 	}
@@ -161,7 +163,14 @@ func HandleInvestigateAlert(
 		}, nil
 	}
 
-	signalInteractiveIfConfigured(ctx, cfg.Signaler, result.RRID, username)
+	// #2265: the dedup (AlreadyExists) branch predates this call -- its RR
+	// was never at risk of this ordering race, so it still goes through the
+	// original post-hoc signal below. A genuinely-new RR was already
+	// signaled from BeforeCreate, strictly before it became visible to any
+	// other component; signaling it again here would just be a duplicate.
+	if !*hookFired {
+		signalInteractiveIfConfigured(ctx, cfg.Signaler, result.RRID, username)
+	}
 
 	launcher.SetRRContextSafe(ctx, newlyCreatedRRContext(result.RRID, args.Namespace, args.Kind, args.Name, args.AlertName, result.ClusterID))
 
@@ -280,6 +289,48 @@ func signalInteractiveIfConfigured(ctx context.Context, signaler AlertISSignaler
 	taskID := "a2a-" + rrName
 	signalerUsername, signalerGroups := resolveSignalerIdentity(ctx, username)
 	_ = signaler.SignalInteractive(ctx, taskID, rrName, signalerUsername, signalerGroups)
+}
+
+// buildAlertPreCreateISHooks builds the CreateRRHooks (#2265) that let
+// HandleInvestigateAlert signal interactive intent (and later back-fill the
+// resulting IS CRD's OwnerReference) strictly between "the new RR's name is
+// known" and "the RR becomes visible to any other component" -- closing the
+// same ordering race documented on buildPreCreateISHooks in
+// ka_investigate_mcp.go. Unlike that path, this one preserves the existing
+// fire-and-forget contract exactly (#1440, SC-24): BeforeCreate never
+// aborts RR creation regardless of the signaler's outcome. The returned
+// *bool reports whether BeforeCreate fired at all (regardless of success),
+// so the caller knows whether to fall back to the original post-hoc
+// signalInteractiveIfConfigured call.
+func buildAlertPreCreateISHooks(signaler AlertISSignaler, username string) (CreateRRHooks, *bool) {
+	hookFired := new(bool)
+	if signaler == nil {
+		return CreateRRHooks{}, hookFired
+	}
+
+	signalSucceeded := false
+	hooks := CreateRRHooks{
+		BeforeCreate: func(ctx context.Context, rrName string) error {
+			*hookFired = true
+			taskID := "a2a-" + rrName
+			signalerUsername, signalerGroups := resolveSignalerIdentity(ctx, username)
+			if sigErr := signaler.SignalInteractive(ctx, taskID, rrName, signalerUsername, signalerGroups); sigErr != nil {
+				logr.FromContextOrDiscard(ctx).Error(sigErr, "failed to create IS CRD before RR (proceeding without IS signal)", "rr_name", rrName)
+				return nil
+			}
+			signalSucceeded = true
+			return nil
+		},
+		AfterCreate: func(ctx context.Context, rr *remediationv1.RemediationRequest) {
+			if !signalSucceeded {
+				return
+			}
+			if backfiller, ok := signaler.(OwnerReferenceBackfiller); ok {
+				backfiller.BackfillOwnerReference(ctx, rr.Namespace, rr.Name, rr.UID)
+			}
+		},
+	}
+	return hooks, hookFired
 }
 
 // extractRRNameFromID extracts the RR name from an RRID like "namespace/name".

--- a/pkg/apifrontend/tools/af_investigate_alert_1440_it_test.go
+++ b/pkg/apifrontend/tools/af_investigate_alert_1440_it_test.go
@@ -7,12 +7,14 @@ import (
 	. "github.com/onsi/gomega"
 
 	isv1alpha1 "github.com/jordigilh/kubernaut/api/investigationsession/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 
 	adksession "google.golang.org/adk/v2/session"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -56,6 +58,12 @@ func (a *productionSignalerAdapter) SignalInteractive(ctx context.Context, taskI
 		JoinMode:    isv1alpha1.SessionJoinModeStart,
 	})
 	return err
+}
+
+// BackfillOwnerReference implements tools.OwnerReferenceBackfiller (#2265),
+// mirroring the production agent.alertISSignalerAdapter wiring.
+func (a *productionSignalerAdapter) BackfillOwnerReference(ctx context.Context, rrNamespace, rrName string, rrUID k8stypes.UID) {
+	a.svc.BackfillOwnerReference(ctx, rrNamespace, rrName, rrUID)
 }
 
 var _ = Describe("Fix #1440 Integration: IS CRD co-creation wiring", func() {
@@ -111,4 +119,51 @@ var _ = Describe("Fix #1440 Integration: IS CRD co-creation wiring", func() {
 	// check before acquiring the dispatch Lease), not in AA. The
 	// InvestigationSession CRD itself is NOT removed (AF still owns it for
 	// reconnect/resume bookkeeping); only AA's consumption of it is gone.
+
+	Describe("IT-AF-2265-001: IS-before-RR ordering and OwnerReference backfill through the real production signaler wiring", func() {
+		It("creates the IS CRD strictly before the RR is visible, then backfills its OwnerReference once the RR is persisted", func() {
+			isClient := newISITClient()
+			svc := session.NewCRDSessionService(adksession.InMemoryService(), isClient, isITScheme(), "kubernaut-system")
+			signaler := &productionSignalerAdapter{svc: svc, namespace: "kubernaut-system"}
+			rrClient := newTypedFakeClientWithUIDAssignment()
+
+			cfg := tools.InvestigateAlertConfig{
+				Client:       rrClient,
+				ControllerNS: "kubernaut-system",
+				Signaler:     signaler,
+				Triager:      defaultTestTriager("prod", "Deployment", "web-2265-it"),
+			}
+
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "sre-alice",
+				Groups:   []string{"sre-team"},
+			})
+
+			result, err := tools.HandleInvestigateAlert(ctx, cfg, &tools.InvestigateAlertArgs{
+				AlertName:  "KubePodCrashLooping",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "web-2265-it",
+				Namespace:  "prod",
+			}, "sre-alice")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RRID).NotTo(BeEmpty())
+
+			rrName := extractRRName(result.RRID)
+			expectedISName := "is-" + rrName
+
+			var is isv1alpha1.InvestigationSession
+			Expect(isClient.Get(ctx, crclient.ObjectKey{Namespace: "kubernaut-system", Name: expectedISName}, &is)).To(Succeed(),
+				"the IS CRD must exist via the real CreateInvestigationSession call")
+			Expect(is.OwnerReferences).To(HaveLen(1),
+				"#2265: the production BackfillOwnerReference call must set the RR OwnerReference once the RR is persisted")
+			Expect(is.OwnerReferences[0].Name).To(Equal(rrName))
+			Expect(is.OwnerReferences[0].UID).NotTo(BeEmpty())
+
+			var rr remediationv1.RemediationRequest
+			Expect(rrClient.Get(ctx, crclient.ObjectKey{Namespace: "kubernaut-system", Name: rrName}, &rr)).To(Succeed())
+			Expect(is.OwnerReferences[0].UID).To(Equal(rr.UID),
+				"the backfilled OwnerReference UID must match the actually-persisted RR's real UID")
+		})
+	})
 })

--- a/pkg/apifrontend/tools/af_investigate_alert_1440_test.go
+++ b/pkg/apifrontend/tools/af_investigate_alert_1440_test.go
@@ -8,6 +8,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 )
@@ -20,14 +24,28 @@ type signalerCall struct {
 	groups   []string
 }
 
-// recordingSignaler captures AlertISSignaler calls for test assertions.
-type recordingSignaler struct {
-	mu    sync.Mutex
-	calls []signalerCall
-	err   error
+// alertBackfillCall records a single call to BackfillOwnerReference (#2265).
+type alertBackfillCall struct {
+	rrNamespace, rrName string
+	rrUID               k8stypes.UID
 }
 
-func (r *recordingSignaler) SignalInteractive(_ context.Context, taskID, rrName, username string, groups []string) error {
+// recordingSignaler captures AlertISSignaler calls for test assertions.
+type recordingSignaler struct {
+	mu            sync.Mutex
+	calls         []signalerCall
+	backfillCalls []alertBackfillCall
+	err           error
+	// onSignal, when set, is invoked synchronously from SignalInteractive
+	// (before returning) so a test can probe co-temporal state (#2265's
+	// ordering proof: is the RR visible yet?).
+	onSignal func(ctx context.Context, rrName string)
+}
+
+func (r *recordingSignaler) SignalInteractive(ctx context.Context, taskID, rrName, username string, groups []string) error {
+	if r.onSignal != nil {
+		r.onSignal(ctx, rrName)
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.calls = append(r.calls, signalerCall{
@@ -39,11 +57,25 @@ func (r *recordingSignaler) SignalInteractive(_ context.Context, taskID, rrName,
 	return r.err
 }
 
+func (r *recordingSignaler) BackfillOwnerReference(_ context.Context, rrNamespace, rrName string, rrUID k8stypes.UID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.backfillCalls = append(r.backfillCalls, alertBackfillCall{rrNamespace: rrNamespace, rrName: rrName, rrUID: rrUID})
+}
+
 func (r *recordingSignaler) Calls() []signalerCall {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	cp := make([]signalerCall, len(r.calls))
 	copy(cp, r.calls)
+	return cp
+}
+
+func (r *recordingSignaler) BackfillCalls() []alertBackfillCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]alertBackfillCall, len(r.backfillCalls))
+	copy(cp, r.backfillCalls)
 	return cp
 }
 
@@ -144,6 +176,85 @@ var _ = Describe("Fix #1440: IS CRD co-creation in HandleInvestigateAlert", func
 				"taskID must follow a2a-{RRID} convention")
 			Expect(call.username).To(Equal("sre-alice"))
 			Expect(call.groups).To(Equal([]string{"sre-team", "oncall"}))
+		})
+	})
+
+	// #2265 / DD-AF-013: SignalInteractive must fire from HandleCreateRR's
+	// BeforeCreate hook -- strictly before the RR becomes visible to any
+	// other component -- instead of the old post-hoc call issued after RR
+	// creation had already completed.
+	Describe("IS-before-RR ordering (#2265)", func() {
+		It("UT-AF-2265-201: SignalInteractive fires with the about-to-be-created RR's name before the RR is visible to any reader", func() {
+			tc := newTypedFakeClientWithUIDAssignment()
+			cfg := baseCfg()
+			cfg.Client = tc
+
+			recorder := &recordingSignaler{}
+			var rrVisibleAtSignalTime bool
+			recorder.onSignal = func(ctx context.Context, rrName string) {
+				var probe remediationv1.RemediationRequest
+				err := tc.Get(ctx, crclient.ObjectKey{Namespace: "kubernaut-system", Name: rrName}, &probe)
+				rrVisibleAtSignalTime = err == nil
+			}
+			cfg.Signaler = recorder
+
+			result, err := tools.HandleInvestigateAlert(context.Background(), cfg, validArgs(), "sre-alice")
+			Expect(err).NotTo(HaveOccurred())
+
+			calls := recorder.Calls()
+			Expect(calls).To(HaveLen(1), "SignalInteractive must fire exactly once for a fresh RR (no duplicate post-hoc call)")
+			Expect(calls[0].rrName).To(Equal(extractRRName(result.RRID)))
+			Expect(rrVisibleAtSignalTime).To(BeFalse(),
+				"#2265: SignalInteractive must fire before the RR becomes visible to any reader")
+		})
+
+		It("UT-AF-2265-202: BackfillOwnerReference fires with the persisted RR's namespace/name/UID once the RR is created", func() {
+			tc := newTypedFakeClientWithUIDAssignment()
+			cfg := baseCfg()
+			cfg.Client = tc
+			recorder := &recordingSignaler{}
+			cfg.Signaler = recorder
+
+			result, err := tools.HandleInvestigateAlert(context.Background(), cfg, validArgs(), "sre-alice")
+			Expect(err).NotTo(HaveOccurred())
+
+			backfills := recorder.BackfillCalls()
+			Expect(backfills).To(HaveLen(1), "#1300: OwnerReference backfill must fire once the RR exists")
+			Expect(backfills[0].rrName).To(Equal(extractRRName(result.RRID)))
+			Expect(backfills[0].rrNamespace).To(Equal("kubernaut-system"))
+			Expect(backfills[0].rrUID).NotTo(BeEmpty())
+		})
+
+		It("UT-AF-2265-203: the dedup (AlreadyExists) branch still signals via the existing post-hoc path, not the hook, without double-signaling the fresh-create call", func() {
+			tc := newTypedFakeClientWithUIDAssignment()
+			cfg := baseCfg()
+			cfg.Client = tc
+			recorder := &recordingSignaler{}
+			cfg.Signaler = recorder
+
+			first, err := tools.HandleInvestigateAlert(context.Background(), cfg, validArgs(), "sre-alice")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(first.AlreadyExists).To(BeFalse())
+
+			second, err := tools.HandleInvestigateAlert(context.Background(), cfg, validArgs(), "sre-alice")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(second.AlreadyExists).To(BeTrue())
+
+			Expect(recorder.Calls()).To(HaveLen(2), "one signal from the fresh-create hook, one from the dedup branch's post-hoc call")
+			Expect(recorder.BackfillCalls()).To(HaveLen(1), "backfill only applies to the genuinely-new RR from the first call")
+		})
+
+		It("UT-AF-2265-204: a signaler error during BeforeCreate does not abort RR creation (fire-and-forget, unchanged from pre-#2265 semantics)", func() {
+			tc := newTypedFakeClientWithUIDAssignment()
+			cfg := baseCfg()
+			cfg.Client = tc
+			recorder := &recordingSignaler{err: errors.New("IS CRD creation failed: simulated")}
+			cfg.Signaler = recorder
+
+			result, err := tools.HandleInvestigateAlert(context.Background(), cfg, validArgs(), "sre-alice")
+			Expect(err).NotTo(HaveOccurred(), "HandleInvestigateAlert must NOT fail when the signaler errors (best-effort, SC-24)")
+			Expect(result.RRID).NotTo(BeEmpty())
+			Expect(recorder.Calls()).To(HaveLen(1), "signaler must still be attempted exactly once, not retried via the post-hoc path")
 		})
 	})
 })

--- a/pkg/apifrontend/tools/ka_investigate_intent_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_intent_test.go
@@ -26,8 +26,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	aiav1alpha1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
 	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
@@ -618,11 +621,141 @@ var _ = Describe("kubernaut_investigate intent-based enhancement (#1332)", func(
 			Expect(confirmed.RRID).NotTo(BeEmpty())
 		})
 	})
+
+	// #2265 / DD-AF-013: for the create-new-RR path (api_version/kind/name,
+	// no rr_id given), SignalInteractive must fire from HandleCreateRR's
+	// BeforeCreate hook -- strictly before the RR becomes visible to any
+	// other component -- instead of the old post-hoc call issued after RR
+	// creation had already completed, which raced RO/AA/KA processing the
+	// RR before this call's own separate InvestigationSession Create landed.
+	Describe("IS-before-RR ordering for the create-new-RR path (#2265)", func() {
+		It("UT-AF-2265-101: SignalInteractive fires with the about-to-be-created RR's name before the RR is visible to any reader", func() {
+			tc := newTypedClientForInvestigateWithUIDAssignment()
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					return &ka.StartInvestigationResult{SessionID: "ka-sess-2265-101", Status: "investigation_started", Closer: func() {}}, nil
+				},
+			}
+			recorder := &recordingISSignaler{}
+			var rrVisibleAtSignalTime bool
+			recorder.onSignal = func(ctx context.Context, rrNamespace, rrName string) {
+				var probe remediationv1.RemediationRequest
+				err := tc.Get(ctx, crclient.ObjectKey{Namespace: rrNamespace, Name: rrName}, &probe)
+				rrVisibleAtSignalTime = err == nil
+			}
+
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "sre@kubernaut.ai", Groups: []string{"sre"}})
+			result, err := tools.HandleInvestigationMCPWithRegistry(
+				shortCtx(ctx), &tools.InvestigateConfig{
+					MCPClient: mockMCP,
+					Client:    tc,
+					Namespace: "kubernaut-system",
+					Signaler:  recorder,
+					Triager:   defaultTestTriager("prod", "Deployment", "web-2265"),
+				}, tools.InvestigateMCPArgs{
+					APIVersion: "apps/v1", Namespace: "prod", Kind: "Deployment", Name: "web-2265",
+				},
+				false, "sre-user",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(recorder.signalCalls).To(HaveLen(1), "SignalInteractive must fire exactly once for a fresh create-new-RR investigation")
+			Expect(recorder.signalCalls[0].joinMode).To(Equal("start"), "a brand-new RR cannot already have an autonomous investigation running")
+			Expect(recorder.signalCalls[0].rrName).To(Equal(result.RRID), "SignalInteractive must fire with exactly the name the RR is ultimately created under")
+			Expect(rrVisibleAtSignalTime).To(BeFalse(),
+				"#2265: SignalInteractive must fire before the RR becomes visible to any reader, closing the race where RO/AA/KA could process the RR before AF's own IS create lands")
+
+			verifyTypedRR(tc, "kubernaut-system", result.RRID)
+		})
+
+		It("UT-AF-2265-102: BackfillOwnerReference fires with the persisted RR's namespace/name/UID once the RR is created", func() {
+			tc := newTypedClientForInvestigateWithUIDAssignment()
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					return &ka.StartInvestigationResult{SessionID: "ka-sess-2265-102", Status: "investigation_started", Closer: func() {}}, nil
+				},
+			}
+			recorder := &recordingISSignaler{}
+
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "sre@kubernaut.ai", Groups: []string{"sre"}})
+			result, err := tools.HandleInvestigationMCPWithRegistry(
+				shortCtx(ctx), &tools.InvestigateConfig{
+					MCPClient: mockMCP,
+					Client:    tc,
+					Namespace: "kubernaut-system",
+					Signaler:  recorder,
+					Triager:   defaultTestTriager("prod", "Deployment", "web-2265-b"),
+				}, tools.InvestigateMCPArgs{
+					APIVersion: "apps/v1", Namespace: "prod", Kind: "Deployment", Name: "web-2265-b",
+				},
+				false, "sre-user",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(recorder.backfillCalls).To(HaveLen(1), "#1300: OwnerReference backfill must fire once the RR exists")
+			Expect(recorder.backfillCalls[0].rrName).To(Equal(result.RRID))
+			Expect(recorder.backfillCalls[0].rrNamespace).To(Equal("kubernaut-system"), "the RR CRD lives in the AF controller namespace, not the workload namespace")
+			Expect(recorder.backfillCalls[0].rrUID).NotTo(BeEmpty())
+		})
+
+		It("UT-AF-2265-103: the dedup (AlreadyExists) branch still signals via the existing post-hoc path, not the hook", func() {
+			tc := newTypedClientForInvestigateWithUIDAssignment()
+			triager := defaultTestTriager("prod", "Deployment", "dedup-2265")
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					return &ka.StartInvestigationResult{SessionID: "ka-sess-2265-103", Status: "investigation_started", Closer: func() {}}, nil
+				},
+			}
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "sre-first@kubernaut.ai", Groups: []string{"sre"}})
+
+			first, err := tools.HandleInvestigationMCPWithRegistry(
+				shortCtx(ctx), &tools.InvestigateConfig{
+					MCPClient: mockMCP, Client: tc, Namespace: "kubernaut-system", Triager: triager,
+				}, tools.InvestigateMCPArgs{APIVersion: "apps/v1", Namespace: "prod", Kind: "Deployment", Name: "dedup-2265"},
+				false, "sre-first",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			recorder := &recordingISSignaler{}
+			second, err := tools.HandleInvestigationMCPWithRegistry(
+				shortCtx(ctx), &tools.InvestigateConfig{
+					MCPClient: mockMCP, Client: tc, Namespace: "kubernaut-system", Triager: triager, Signaler: recorder,
+				}, tools.InvestigateMCPArgs{APIVersion: "apps/v1", Namespace: "prod", Kind: "Deployment", Name: "dedup-2265"},
+				false, "sre-second",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(second.RRID).To(Equal(first.RRID), "the second call must hit the dedup branch and reuse the same RR")
+
+			Expect(recorder.signalCalls).To(HaveLen(1), "the dedup branch's RR predates this call -- it must still be signaled via the existing post-hoc call")
+			Expect(recorder.backfillCalls).To(BeEmpty(), "backfill only applies to a genuinely-new RR created by this call")
+		})
+	})
 })
+
+func newTypedClientForInvestigateWithUIDAssignment(objects ...crclient.Object) crclient.Client {
+	return fake.NewClientBuilder().
+		WithScheme(investigateTestScheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(objects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c crclient.WithWatch, obj crclient.Object, opts ...crclient.CreateOption) error {
+				if obj.GetUID() == "" {
+					obj.SetUID(uuid.NewUUID())
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+}
 
 type recordingISSignaler struct {
 	signalCalls      []signalCall
 	correlationCalls []corrCall
+	backfillCalls    []backfillCall
+	// onSignal, when set, is invoked synchronously from SignalInteractive
+	// (before returning) so a test can probe co-temporal state (#2265's
+	// ordering proof: is the RR visible yet?).
+	onSignal func(ctx context.Context, rrNamespace, rrName string)
 }
 
 type signalCall struct {
@@ -634,7 +767,15 @@ type corrCall struct {
 	crdName, kaSessionID string
 }
 
-func (r *recordingISSignaler) SignalInteractive(_ context.Context, rrNamespace, rrName, taskID, username string, groups []string, joinMode string) (string, error) {
+type backfillCall struct {
+	rrNamespace, rrName string
+	rrUID               k8stypes.UID
+}
+
+func (r *recordingISSignaler) SignalInteractive(ctx context.Context, rrNamespace, rrName, taskID, username string, groups []string, joinMode string) (string, error) {
+	if r.onSignal != nil {
+		r.onSignal(ctx, rrNamespace, rrName)
+	}
 	r.signalCalls = append(r.signalCalls, signalCall{
 		rrNamespace: rrNamespace, rrName: rrName, taskID: taskID,
 		username: username, groups: groups, joinMode: joinMode,
@@ -645,4 +786,8 @@ func (r *recordingISSignaler) SignalInteractive(_ context.Context, rrNamespace, 
 func (r *recordingISSignaler) UpdateCorrelation(_ context.Context, crdName, kaSessionID string) error {
 	r.correlationCalls = append(r.correlationCalls, corrCall{crdName: crdName, kaSessionID: kaSessionID})
 	return nil
+}
+
+func (r *recordingISSignaler) BackfillOwnerReference(_ context.Context, rrNamespace, rrName string, rrUID k8stypes.UID) {
+	r.backfillCalls = append(r.backfillCalls, backfillCall{rrNamespace: rrNamespace, rrName: rrName, rrUID: rrUID})
 }

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -255,7 +255,7 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, cfg *InvestigateCon
 		return InvestigateMCPResult{}, fmt.Errorf("KA MCP client unavailable")
 	}
 
-	rrSeverity, ambiguous, err := resolveInvestigationRR(ctx, cfg, &args)
+	rrSeverity, ambiguous, preSignaledISCRDName, err := resolveInvestigationRR(ctx, cfg, &args)
 	if err != nil {
 		return InvestigateMCPResult{}, err
 	}
@@ -269,9 +269,18 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, cfg *InvestigateCon
 	}
 
 	identity := auth.UserIdentityFromContext(ctx)
-	isCRDName, err := signalInteractiveSession(ctx, cfg, args.RRID, identity)
-	if err != nil {
-		return InvestigateMCPResult{}, err
+	// #2265: for a genuinely-new RR, createRRForInvestigation's BeforeCreate
+	// hook already signaled interactively -- strictly before the RR became
+	// visible to any other component. Calling signalInteractiveSession again
+	// here would be a redundant (if harmless) second attempt for that case,
+	// so it only runs when the hook didn't already succeed (pre-existing RR
+	// via rr_id, a dedup/AlreadyExists hit, or the hook itself fail-opened).
+	isCRDName := preSignaledISCRDName
+	if isCRDName == "" {
+		isCRDName, err = signalInteractiveSession(ctx, cfg, args.RRID, identity)
+		if err != nil {
+			return InvestigateMCPResult{}, err
+		}
 	}
 
 	kaSessionID := awaitInvestigationReady(ctx, cfg, args.RRID, isCRDName, blocking)
@@ -329,37 +338,40 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, cfg *InvestigateCon
 // resolveInvestigationRR validates args, optionally creates a new RR from
 // resource args (rr_id vs api_version/kind/name), and seeds the EventBridge
 // RR context (#1423) for Console banner population. Returns the severity
-// assessed during RR creation (if any) for later fallback-RCA use.
-func resolveInvestigationRR(ctx context.Context, cfg *InvestigateConfig, args *InvestigateMCPArgs) (rrSeverity string, ambiguous *CreateRRResult, err error) {
+// assessed during RR creation (if any) for later fallback-RCA use, and
+// (#2265) the IS CRD name if createRRForInvestigation's BeforeCreate hook
+// already signaled interactively for a genuinely-new RR -- empty otherwise,
+// so the caller falls back to its own post-hoc signalInteractiveSession call.
+func resolveInvestigationRR(ctx context.Context, cfg *InvestigateConfig, args *InvestigateMCPArgs) (rrSeverity string, ambiguous *CreateRRResult, preSignaledISCRDName string, err error) {
 	hasRRID := args.RRID != ""
 	hasResourceArgs := args.APIVersion != "" || args.Kind != "" || args.Name != "" || args.Namespace != ""
 
 	if !hasRRID && !hasResourceArgs {
-		return "", nil, fmt.Errorf("rr_id or api_version/kind/name required")
+		return "", nil, "", fmt.Errorf("rr_id or api_version/kind/name required")
 	}
 	if hasRRID {
 		if err := validate.RRID(args.RRID); err != nil {
-			return "", nil, fmt.Errorf("invalid rr_id: %w", err)
+			return "", nil, "", fmt.Errorf("invalid rr_id: %w", err)
 		}
 	}
 
 	identity := auth.UserIdentityFromContext(ctx)
 
 	if !hasRRID && hasResourceArgs {
-		rrSeverity, ambiguous, err = createRRForInvestigation(ctx, cfg, args, identity)
+		rrSeverity, ambiguous, preSignaledISCRDName, err = createRRForInvestigation(ctx, cfg, args, identity)
 		if err != nil {
-			return "", nil, err
+			return "", nil, "", err
 		}
 		// DD-AF-012/#2027/#2028: no RR was created -- the caller must ask
 		// the user to confirm the candidate before retrying. args.RRID was
 		// never populated, so the takeover-fetch logic below must not run.
 		if ambiguous != nil {
-			return "", ambiguous, nil
+			return "", ambiguous, "", nil
 		}
 	}
 
 	if args.RRID == "" {
-		return "", nil, fmt.Errorf("rr_id is required for MCP investigation")
+		return "", nil, "", fmt.Errorf("rr_id is required for MCP investigation")
 	}
 
 	// For the existing-RR path (rr_id provided as input, i.e. a takeover of
@@ -372,7 +384,7 @@ func resolveInvestigationRR(ctx context.Context, cfg *InvestigateConfig, args *I
 		setTakeoverRRContext(ctx, cfg, args.RRID)
 	}
 
-	return rrSeverity, nil, nil
+	return rrSeverity, nil, preSignaledISCRDName, nil
 }
 
 // setTakeoverRRContext seeds the EventBridge RR context for the takeover
@@ -411,13 +423,16 @@ func setTakeoverRRContext(ctx context.Context, cfg *InvestigateConfig, rrID stri
 // api_version/kind/name/namespace args, resolving cluster-scoped namespace
 // stripping and rejecting service-account-initiated interactive
 // investigations. Mutates args.RRID/args.Namespace and seeds the
-// EventBridge RR context (#1423, AU-3, SI-4).
-func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args *InvestigateMCPArgs, identity *auth.UserIdentity) (severityOut string, ambiguous *CreateRRResult, err error) {
+// EventBridge RR context (#1423, AU-3, SI-4). Returns (#2265) the IS CRD
+// name if buildPreCreateISHooks's BeforeCreate hook signaled interactively
+// for a genuinely-new RR -- empty when the hook didn't fire (dedup hit) or
+// fail-opened (signaler error other than a single-driver conflict).
+func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args *InvestigateMCPArgs, identity *auth.UserIdentity) (severityOut string, ambiguous *CreateRRResult, preSignaledISCRDName string, err error) {
 	if err := validate.APIVersion(args.APIVersion); err != nil {
-		return "", nil, fmt.Errorf("%w", err)
+		return "", nil, "", fmt.Errorf("%w", err)
 	}
 	if args.Kind == "" || args.Name == "" {
-		return "", nil, fmt.Errorf("kind and name required when providing api_version/kind/name")
+		return "", nil, "", fmt.Errorf("kind and name required when providing api_version/kind/name")
 	}
 
 	clusterScoped := resolveClusterScoped(ctx, args)
@@ -426,10 +441,10 @@ func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args 
 	}
 
 	if identity != nil && identity.IsServiceAccount {
-		return "", nil, fmt.Errorf("interactive investigation cannot be started by service accounts")
+		return "", nil, "", fmt.Errorf("interactive investigation cannot be started by service accounts")
 	}
 	if cfg.Client == nil {
-		return "", nil, fmt.Errorf("k8s client unavailable for RR creation")
+		return "", nil, "", fmt.Errorf("k8s client unavailable for RR creation")
 	}
 
 	createArgs := &CreateRRArgs{
@@ -445,20 +460,78 @@ func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args 
 	if identity != nil {
 		createUser = identity.Username
 	}
-	result, err := HandleCreateRR(ctx, &ToolDeps{Client: cfg.Client, ControllerNS: cfg.Namespace, Triager: cfg.Triager, Auditor: cfg.Auditor, ScopeChecker: cfg.ScopeChecker}, createArgs, createUser)
+
+	hooks, signaledISCRDName := buildPreCreateISHooks(cfg, identity)
+	result, err := HandleCreateRRWithHooks(ctx, &ToolDeps{Client: cfg.Client, ControllerNS: cfg.Namespace, Triager: cfg.Triager, Auditor: cfg.Auditor, ScopeChecker: cfg.ScopeChecker}, createArgs, createUser, hooks)
 	if err != nil {
-		return "", nil, fmt.Errorf("create RR for investigation: %w", err)
+		return "", nil, "", fmt.Errorf("create RR for investigation: %w", err)
 	}
 	// DD-AF-012/#2027/#2028: no RR was created -- surface the candidate to
 	// the caller instead of treating this as a fatal error.
 	if result.Ambiguous {
-		return "", &result, nil
+		return "", &result, "", nil
 	}
 	args.RRID = result.RRID
 
 	launcher.SetRRContextSafe(ctx, newlyCreatedRRContext(result.RRID, args.Namespace, args.Kind, args.Name, result.SignalName, result.ClusterID))
 
-	return result.Severity, nil, nil
+	return result.Severity, nil, *signaledISCRDName, nil
+}
+
+// buildPreCreateISHooks builds the CreateRRHooks (#2265) that let
+// createRRForInvestigation signal interactive intent (and later back-fill
+// the resulting IS CRD's OwnerReference) strictly between "the new RR's
+// name is known" and "the RR becomes visible to any other component" --
+// closing the race where RO/AA/KA could otherwise process the RR before
+// AF's own, separately-issued InvestigationSession Create call lands. The
+// returned *string is populated with the created IS CRD's name once
+// BeforeCreate succeeds (read by the caller after HandleCreateRRWithHooks
+// returns); it stays empty when no signaler is configured, the dedup branch
+// is hit (BeforeCreate never fires), or the signal itself fails open.
+func buildPreCreateISHooks(cfg *InvestigateConfig, identity *auth.UserIdentity) (CreateRRHooks, *string) {
+	signaledISCRDName := new(string)
+	if cfg.Signaler == nil || cfg.Client == nil || cfg.Namespace == "" {
+		return CreateRRHooks{}, signaledISCRDName
+	}
+
+	signalUsername := ""
+	var groups []string
+	if identity != nil {
+		signalUsername = identity.Username
+		groups = identity.Groups
+	}
+
+	hooks := CreateRRHooks{
+		BeforeCreate: func(hctx context.Context, rrName string) error {
+			// A genuinely-new RR cannot yet have an autonomous investigation
+			// running (AA needs the RR to exist and be processed by
+			// SignalProcessing -> RemediationOrchestrator -> AIAnalysis
+			// first) -- joinMode is unconditionally "start", unlike the
+			// pre-existing-RR takeover path in signalInteractiveSession.
+			taskID := fmt.Sprintf("a2a-%s", rrName)
+			isCRDName, sigErr := cfg.Signaler.SignalInteractive(hctx, cfg.Namespace, rrName, taskID, signalUsername, groups, "start")
+			if sigErr != nil {
+				logger := logr.FromContextOrDiscard(hctx)
+				if strings.Contains(sigErr.Error(), "session_active") {
+					logger.Info("IS CRD single-driver enforcement: rejecting duplicate session", "rr_id", rrName, "error", sigErr)
+					return sigErr
+				}
+				logger.Error(sigErr, "failed to create IS CRD before RR (proceeding without IS signal)", "rr_id", rrName)
+				return nil
+			}
+			*signaledISCRDName = isCRDName
+			return nil
+		},
+		AfterCreate: func(actx context.Context, rr *remediationv1.RemediationRequest) {
+			if *signaledISCRDName == "" {
+				return
+			}
+			if backfiller, ok := cfg.Signaler.(OwnerReferenceBackfiller); ok {
+				backfiller.BackfillOwnerReference(actx, rr.Namespace, rr.Name, rr.UID)
+			}
+		},
+	}
+	return hooks, signaledISCRDName
 }
 
 // resolveClusterScoped determines whether the target resource is

--- a/pkg/apifrontend/tools/ka_investigate_mcp_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp_test.go
@@ -1398,7 +1398,7 @@ var _ = Describe("Takeover RR context reconstruction — #1409, #1423 (AU-3, CC8
 		queue := &bridgeQueue{}
 		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-011", "ctx-1409-011", nil)
 
-		_, _, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
+		_, _, _, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
 			Client:    tc,
 			Namespace: "kubernaut-system",
 		}, &tools.InvestigateMCPArgs{RRID: "rr-takeover-011"})
@@ -1425,7 +1425,7 @@ var _ = Describe("Takeover RR context reconstruction — #1409, #1423 (AU-3, CC8
 		queue := &bridgeQueue{}
 		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-012", "ctx-1409-012", nil)
 
-		_, _, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
+		_, _, _, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
 			Client:    tc,
 			Namespace: "kubernaut-system",
 		}, &tools.InvestigateMCPArgs{RRID: "rr-takeover-012"})
@@ -1444,7 +1444,7 @@ var _ = Describe("Takeover RR context reconstruction — #1409, #1423 (AU-3, CC8
 		queue := &bridgeQueue{}
 		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-013", "ctx-1409-013", nil)
 
-		_, _, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
+		_, _, _, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
 			Namespace: "kubernaut-system",
 		}, &tools.InvestigateMCPArgs{RRID: "rr-takeover-013"})
 		Expect(err).NotTo(HaveOccurred())
@@ -1646,7 +1646,7 @@ var _ = Describe("HandleInvestigationMCPWithRegistry — fleet cluster_id wiring
 var _ = Describe("ScopeChecker pre-check (#2025)", func() {
 	It("UT-AF-2025-050: rejects a new-RR investigation for an unmanaged target resource", func() {
 		tc := newTypedFakeClient()
-		_, _, err := tools.ResolveInvestigationRR(context.Background(), &tools.InvestigateConfig{
+		_, _, _, err := tools.ResolveInvestigationRR(context.Background(), &tools.InvestigateConfig{
 			Client:       tc,
 			Namespace:    "kubernaut-system",
 			Triager:      defaultTestTriager("prod", "Deployment", "web"),
@@ -1660,7 +1660,7 @@ var _ = Describe("ScopeChecker pre-check (#2025)", func() {
 
 	It("UT-AF-2025-051: allows a new-RR investigation for a managed target resource", func() {
 		tc := newTypedFakeClient()
-		_, _, err := tools.ResolveInvestigationRR(context.Background(), &tools.InvestigateConfig{
+		_, _, _, err := tools.ResolveInvestigationRR(context.Background(), &tools.InvestigateConfig{
 			Client:       tc,
 			Namespace:    "kubernaut-system",
 			Triager:      defaultTestTriager("prod", "Deployment", "web"),
@@ -1679,7 +1679,7 @@ var _ = Describe("ScopeChecker pre-check (#2025)", func() {
 			},
 		}
 		tc := newTypedFakeClient(rr)
-		_, _, err := tools.ResolveInvestigationRR(context.Background(), &tools.InvestigateConfig{
+		_, _, _, err := tools.ResolveInvestigationRR(context.Background(), &tools.InvestigateConfig{
 			Client:       tc,
 			Namespace:    "kubernaut-system",
 			ScopeChecker: &mocks.NeverManagedScopeChecker{},


### PR DESCRIPTION
## Summary

Closes #2265.

`kubernaut_investigate` and `kubernaut_investigate_alert` previously created the RemediationRequest (RR) first, then issued a separate `SignalInteractive` call afterward to create the `InvestigationSession` (IS) CRD. Nothing serialized RO/AA/KA processing the newly-visible RR against that second call actually landing, so under real cluster latency KA's dispatch-time `hasInvestigationSession()` check could read "no IS yet" and permanently commit a fresh interactive request to autonomous investigation (`Status.Interactive` is write-once). Confirmed via must-gather RCA on CI flake `E2E-FP-1912-001`.

- `HandleCreateRR` gains `BeforeCreate`/`AfterCreate` hook points (`HandleCreateRRWithHooks`) so callers can act strictly between "the new RR's name is known" and "the RR becomes visible to any other component."
- Both `kubernaut_investigate` (`createRRForInvestigation`) and `kubernaut_investigate_alert` (`HandleInvestigateAlert`) now signal interactively from `BeforeCreate`, guaranteeing the IS CRD exists before any other component can possibly observe the RR at all — not just before KA's dispatch check specifically.
- `AfterCreate` backfills the IS CRD's `OwnerReference` (cascade-GC, #1300) once the RR is actually persisted, via a new `OwnerReferenceBackfiller` capability checked with a type assertion (so existing signaler test doubles are unaffected).
- The pre-existing dedup (`AlreadyExists`) branch is untouched — that RR predates the call, so it was never at risk of this race, and still uses the original post-hoc signal call.

Two alternatives were considered and rejected (see DD-AA-KA-001 Gap 6 for the full writeup):
- **Bounded dispatch-time retry** — narrows the race window but stays probabilistic for a security-sensitive routing decision (autonomous vs. human-driven).
- **RR annotation as an interactivity signal** — tamperable by any actor with RR write access, unlike an RBAC'd CRD's existence.

Stacked on #2263 (`fix/2259-discover-workflows-dead-context-race`) since this branch was rebased on top of it; the diff here contains only the #2265 changes.

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run` clean on all touched packages
- [x] `go test ./pkg/apifrontend/...` — all green
- [x] New UT coverage: hook-layer (`af_create_rr_test.go`, UT-AF-2265-001..006), `kubernaut_investigate` ordering (`ka_investigate_intent_test.go`, UT-AF-2265-101..103), `kubernaut_investigate_alert` ordering (`af_investigate_alert_1440_test.go`, UT-AF-2265-201..204)
- [x] New IT coverage proving ordering + backfill through the real `CRDSessionService`-backed production adapter, not a test double (`af_investigate_alert_1440_it_test.go`, IT-AF-2265-001)
- [ ] Confirm CI green, in particular that the previously-flaking `E2E-FP-1912-001` (fullpipeline) passes reliably across reruns