### PR TITLE
fix(fleet): bound MCP server/discover probe timeout + expose ResilienceConfig via Helm (#2262)

### DIFF
--- a/charts/kubernaut/.helm-coverage-allowlist.yaml
+++ b/charts/kubernaut/.helm-coverage-allowlist.yaml
@@ -96,6 +96,12 @@
 - global.fleet.oauth2.scopes
 - global.fleet.oauth2.tlsCAFile
 - global.fleet.oauth2.tokenURL
+- global.fleet.resilience.connectTimeout
+- global.fleet.resilience.discoverProbeTimeout
+- global.fleet.resilience.initialInterval
+- global.fleet.resilience.maxElapsedTime
+- global.fleet.resilience.maxInterval
+- global.fleet.resilience.tokenRefreshTimeout
 - global.fleet.tlsCAFile
 - global.fleet.tokenSecretRef
 - global.image.digest
@@ -119,6 +125,12 @@
 - kubernautAgent.alignmentCheck.maxStepTokens
 - kubernautAgent.alignmentCheck.timeout
 - kubernautAgent.fleet.oauth2.credentialsSecretRef
+- kubernautAgent.fleet.resilience.connectTimeout
+- kubernautAgent.fleet.resilience.discoverProbeTimeout
+- kubernautAgent.fleet.resilience.initialInterval
+- kubernautAgent.fleet.resilience.maxElapsedTime
+- kubernautAgent.fleet.resilience.maxInterval
+- kubernautAgent.fleet.resilience.tokenRefreshTimeout
 - kubernautAgent.interactive.enabled
 - kubernautAgent.interactive.inactivityTimeout
 - kubernautAgent.interactive.maxAnalyzingTimeout

--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -87,6 +87,13 @@ apifrontend:
         namespace: ""
         oauth2:
             credentialsSecretRef: ""
+        resilience:
+            connectTimeout: 30s
+            discoverProbeTimeout: 5s
+            initialInterval: 1s
+            maxElapsedTime: 5m
+            maxInterval: 30s
+            tokenRefreshTimeout: 10s
     image:
         pullPolicy: IfNotPresent
         repository: ghcr.io/jordigilh/kubernaut/apifrontend
@@ -185,6 +192,13 @@ effectivenessmonitor:
         namespace: ""
         oauth2:
             credentialsSecretRef: ""
+        resilience:
+            connectTimeout: 30s
+            discoverProbeTimeout: 5s
+            initialInterval: 1s
+            maxElapsedTime: 5m
+            maxInterval: 30s
+            tokenRefreshTimeout: 10s
     logging:
         level: INFO
     pdb:
@@ -203,6 +217,13 @@ fleetmetadatacache:
     pdb:
         enabled: true
     replicas: 1
+    resilience:
+        connectTimeout: 30s
+        discoverProbeTimeout: 5s
+        initialInterval: 1s
+        maxElapsedTime: 5m
+        maxInterval: 30s
+        tokenRefreshTimeout: 10s
     syncInterval: 30s
     valkeyAddr: ""
     valkeyTLS:
@@ -231,6 +252,13 @@ gateway:
     fleet:
         oauth2:
             credentialsSecretRef: ""
+        resilience:
+            connectTimeout: 30s
+            discoverProbeTimeout: 5s
+            initialInterval: 1s
+            maxElapsedTime: 5m
+            maxInterval: 30s
+            tokenRefreshTimeout: 10s
     ingress:
         annotations: {}
         className: ""
@@ -261,6 +289,13 @@ global:
             scopes: []
             tlsCAFile: ""
             tokenURL: ""
+        resilience:
+            connectTimeout: 30s
+            discoverProbeTimeout: 5s
+            initialInterval: 1s
+            maxElapsedTime: 5m
+            maxInterval: 30s
+            tokenRefreshTimeout: 10s
         tlsCAFile: ""
         tokenSecretRef: ""
     image:
@@ -294,6 +329,13 @@ kubernautAgent:
     fleet:
         oauth2:
             credentialsSecretRef: ""
+        resilience:
+            connectTimeout: 30s
+            discoverProbeTimeout: 5s
+            initialInterval: 1s
+            maxElapsedTime: 5m
+            maxInterval: 30s
+            tokenRefreshTimeout: 10s
     interactive:
         enabled: false
         inactivityTimeout: 10m
@@ -436,6 +478,13 @@ remediationorchestrator:
     fleet:
         oauth2:
             credentialsSecretRef: ""
+        resilience:
+            connectTimeout: 30s
+            discoverProbeTimeout: 5s
+            initialInterval: 1s
+            maxElapsedTime: 5m
+            maxInterval: 30s
+            tokenRefreshTimeout: 10s
     logging:
         level: INFO
     pdb:
@@ -451,6 +500,13 @@ signalprocessing:
         namespace: ""
         oauth2:
             credentialsSecretRef: ""
+        resilience:
+            connectTimeout: 30s
+            discoverProbeTimeout: 5s
+            initialInterval: 1s
+            maxElapsedTime: 5m
+            maxInterval: 30s
+            tokenRefreshTimeout: 10s
     logging:
         level: INFO
     pdb:

--- a/charts/kubernaut/templates/_helpers.tpl
+++ b/charts/kubernaut/templates/_helpers.tpl
@@ -143,20 +143,50 @@ Usage:
 {{- end }}
 
 {{/*
-Combines kubernaut.fleet.oauth2 and kubernaut.fleet.config into a single
-call, replacing the two-line `include | fromYaml` preamble every
-fleet-capable service (gateway, remediationorchestrator, signalprocessing,
-effectivenessmonitor, apifrontend, fleetmetadatacache) previously repeated
-at its own top. Returns a dict with "oauth2" and "config" keys (both
-already fromYaml-parsed).
+Merged fleet resilience config (issue #2262 Phase 2): deep-merges
+global.fleet.resilience (shared baseline) with a service's own
+fleet.resilience override. Unlike kubernaut.fleet.oauth2/kubernaut.fleet.config
+(which enumerate specific known keys with per-field fallback), this is a
+generic dict merge -- every field of the `fleetResilienceSpec` schema follows
+the identical "per-service field wins if set, otherwise inherit the global
+value" rule, so a future new field is covered automatically without a helper
+change.
+Sprig's `merge`/`mergeOverwrite` mutate their first argument in place, so
+`deepCopy` is applied to both operands first to avoid mutating the shared
+`global.fleet.resilience` dict (and hence leaking one service's resolved
+values into another's) across the multiple calls this template receives, one
+per fleet-capable service, in a single `helm template` render.
+`mergeOverwrite` (not `merge`) is used so the per-service dict's own fields
+take precedence over the global baseline for any key both define -- Sprig's
+`merge` gives precedence to its FIRST argument instead, which would silently
+make the global value win over an explicit per-service override.
+Usage:
+  {{- $r := include "kubernaut.fleet.resilience" (dict "root" $ "svc" .Values.gateway.fleet.resilience) | fromYaml }}
+  {{ $r.discoverProbeTimeout }}
+*/}}
+{{- define "kubernaut.fleet.resilience" -}}
+{{- $g := .root.Values.global.fleet.resilience | default dict -}}
+{{- $svc := .svc | default dict -}}
+{{- mergeOverwrite (deepCopy $g) (deepCopy $svc) | toYaml -}}
+{{- end }}
+
+{{/*
+Combines kubernaut.fleet.oauth2, kubernaut.fleet.config and
+kubernaut.fleet.resilience into a single call, replacing the two-line
+`include | fromYaml` preamble every fleet-capable service (gateway,
+remediationorchestrator, signalprocessing, effectivenessmonitor, apifrontend,
+kubernautAgent, fleetmetadatacache) previously repeated at its own top.
+Returns a dict with "oauth2", "config" and "resilience" keys (all already
+fromYaml-parsed).
 Usage:
   {{- $f := include "kubernaut.fleet.preamble" (dict "root" $ "fleet" .Values.gateway.fleet "oauth2" .Values.gateway.fleet.oauth2) | fromYaml -}}
-  {{ $f.oauth2.tokenURL }} / {{ $f.config.mcpGatewayEndpoint }}
+  {{ $f.oauth2.tokenURL }} / {{ $f.config.mcpGatewayEndpoint }} / {{ $f.resilience.discoverProbeTimeout }}
 */}}
 {{- define "kubernaut.fleet.preamble" -}}
 {{- $oauth2 := include "kubernaut.fleet.oauth2" (dict "root" .root "svc" .oauth2) | fromYaml -}}
 {{- $config := include "kubernaut.fleet.config" (dict "root" .root "svc" .fleet) | fromYaml -}}
-{{- dict "oauth2" $oauth2 "config" $config | toYaml -}}
+{{- $resilience := include "kubernaut.fleet.resilience" (dict "root" .root "svc" (.fleet.resilience | default dict)) | fromYaml -}}
+{{- dict "oauth2" $oauth2 "config" $config "resilience" $resilience | toYaml -}}
 {{- end }}
 
 {{/*

--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -291,6 +291,13 @@ fleet:
     {{- end }}
     tlsCAFile: {{ $apifrontendFleetPreamble.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
   {{- end }}
+  {{- /* Issue #2262 Phase 2: only render keys the operator actually set --
+  an unset field keeps mcpclient.DefaultResilienceConfig()'s pre-#2262
+  default unchanged (see mcpclient.ResilienceConfigFromFleet). */}}
+  {{- if $apifrontendFleetPreamble.resilience }}
+  resilience:
+    {{- $apifrontendFleetPreamble.resilience | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- /*

--- a/charts/kubernaut/templates/effectivenessmonitor/effectivenessmonitor.yaml
+++ b/charts/kubernaut/templates/effectivenessmonitor/effectivenessmonitor.yaml
@@ -65,6 +65,13 @@ fleet:
     {{- end }}
     tlsCAFile: {{ $effectivenessmonitorFleetPreamble.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
   {{- end }}
+  {{- /* Issue #2262 Phase 2: only render keys the operator actually set --
+  an unset field keeps mcpclient.DefaultResilienceConfig()'s pre-#2262
+  default unchanged (see mcpclient.ResilienceConfigFromFleet). */}}
+  {{- if $effectivenessmonitorFleetPreamble.resilience }}
+  resilience:
+    {{- $effectivenessmonitorFleetPreamble.resilience | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{/* BYO ConfigMap (Issue #848 v1.5): the chart no longer auto-creates this ConfigMap (it

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -22,6 +22,15 @@ mcpGateway:
   $v.namespace's own schema default ("kubernaut-system") is the final
   fallback when neither is set, preserving pre-#1730 behavior. */}}
   namespace: {{ $fmcFleetPreamble.config.namespace | default $v.namespace | quote }}
+  {{- /* Issue #2262 Phase 2: fleet.MCPGatewayConfig.Resilience (pkg/fleet/config.go)
+  nests under mcpGateway, unlike every other service's fleet.resilience --
+  only render keys the operator actually set; an unset field keeps
+  mcpclient.DefaultResilienceConfig()'s pre-#2262 default unchanged (see
+  mcpclient.ResilienceConfigFromFleet). */}}
+  {{- if $fmcFleetPreamble.resilience }}
+  resilience:
+    {{- $fmcFleetPreamble.resilience | toYaml | nindent 4 }}
+  {{- end }}
 valkey:
   {{- /* values.yaml documents valkeyAddr: "" as "uses shared Valkey
   instance", but left unimplemented that default actually falls through to

--- a/charts/kubernaut/templates/gateway/gateway.yaml
+++ b/charts/kubernaut/templates/gateway/gateway.yaml
@@ -112,6 +112,16 @@ fleet:
     {{- end }}
     tlsCAFile: {{ $gatewayFleetPreamble.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
   {{- end }}
+  {{- /* Issue #2262 Phase 2: only render keys the operator actually set (via
+  global.fleet.resilience or gateway.fleet.resilience) -- omitting a field
+  here means pkg/fleet.FleetConfig.Resilience's zero value for it, and
+  mcpclient.ResilienceConfigFromFleet only overrides a mcpclient default when
+  the FleetConfig field is non-zero, so an unset field is indistinguishable
+  from "not configured" and keeps its pre-#2262 hardcoded default. */}}
+  {{- if $gatewayFleetPreamble.resilience }}
+  resilience:
+    {{- $gatewayFleetPreamble.resilience | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- /*

--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -274,6 +274,13 @@ Helm-side behavior.
       */}}
       tlsCaFile: {{ $kaFleetPreamble.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
 {{- end }}
+{{- /* Issue #2262 Phase 2: only render keys the operator actually set --
+an unset field keeps mcpclient.DefaultResilienceConfig()'s pre-#2262
+default unchanged (see mcpclient.ResilienceConfigFromFleet). */}}
+{{- if $kaFleetPreamble.resilience }}
+    resilience:
+      {{- $kaFleetPreamble.resilience | toYaml | nindent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- define "kubernaut.kubernautAgent.llmRuntimeYAML" -}}

--- a/charts/kubernaut/templates/remediationorchestrator/remediationorchestrator.yaml
+++ b/charts/kubernaut/templates/remediationorchestrator/remediationorchestrator.yaml
@@ -107,6 +107,13 @@ fleet:
     {{- end }}
     tlsCAFile: {{ $remediationorchestratorFleetPreamble.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
   {{- end }}
+  {{- /* Issue #2262 Phase 2: only render keys the operator actually set --
+  an unset field keeps mcpclient.DefaultResilienceConfig()'s pre-#2262
+  default unchanged (see mcpclient.ResilienceConfigFromFleet). */}}
+  {{- if $remediationorchestratorFleetPreamble.resilience }}
+  resilience:
+    {{- $remediationorchestratorFleetPreamble.resilience | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
+++ b/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
@@ -99,6 +99,13 @@ fleet:
     {{- end }}
     tlsCAFile: {{ $signalprocessingFleetPreamble.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
   {{- end }}
+  {{- /* Issue #2262 Phase 2: only render keys the operator actually set --
+  an unset field keeps mcpclient.DefaultResilienceConfig()'s pre-#2262
+  default unchanged (see mcpclient.ResilienceConfigFromFleet). */}}
+  {{- if $signalprocessingFleetPreamble.resilience }}
+  resilience:
+    {{- $signalprocessingFleetPreamble.resilience | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/charts/kubernaut/templates/workflowexecution/workflowexecution.yaml
+++ b/charts/kubernaut/templates/workflowexecution/workflowexecution.yaml
@@ -247,6 +247,16 @@ fleet:
     {{- end }}
     tlsCAFile: {{ .Values.global.fleet.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
   {{- end }}
+  {{- /* Issue #2262 Phase 2: WE has no per-service fleet.resilience override
+  (unlike GW/RO/SP/EM/KA/AF/FMC) -- it reads global.fleet.* directly with no
+  per-service fleet block at all (see file-top comment), so this reads
+  global.fleet.resilience directly too, with no merge needed. Only rendered
+  when the operator actually set it -- an unset field keeps
+  mcpclient.DefaultResilienceConfig()'s pre-#2262 default unchanged. */}}
+  {{- if .Values.global.fleet.resilience }}
+  resilience:
+    {{- .Values.global.fleet.resilience | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/charts/kubernaut/tests/fleet_resilience_config_test.yaml
+++ b/charts/kubernaut/tests/fleet_resilience_config_test.yaml
@@ -332,6 +332,32 @@ tests:
           path: data["config.yaml"]
           pattern: "(?m)^\\s*maxElapsedTime: 5m"
 
+  - it: "signalprocessing.fleet.resilience.maxInterval overrides the global value, while tokenRefreshTimeout is inherited from global.fleet.resilience"
+    set:
+      global:
+        fleet:
+          resilience:
+            maxInterval: "30s"
+            tokenRefreshTimeout: "12s"
+      signalprocessing:
+        fleet:
+          resilience:
+            maxInterval: "45s"
+    template: templates/signalprocessing/signalprocessing.yaml
+    documentSelector:
+      path: metadata.name
+      value: signalprocessing-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*maxInterval: 45s"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*maxInterval: 30s"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*tokenRefreshTimeout: 12s"
+
   - it: "kubernautAgent.fleet.resilience.tokenRefreshTimeout overrides the global value, while initialInterval is inherited from global.fleet.resilience"
     set:
       global:

--- a/charts/kubernaut/tests/fleet_resilience_config_test.yaml
+++ b/charts/kubernaut/tests/fleet_resilience_config_test.yaml
@@ -1,0 +1,359 @@
+suite: "Issue #2262 Phase 2: global.fleet.resilience / <service>.fleet.resilience knob for pkg/fleet/mcpclient.ResilienceConfig"
+# pkg/fleet/mcpclient.ResilienceConfig (InitialInterval, MaxInterval,
+# MaxElapsedTime, TokenRefreshTimeout, ConnectTimeout, DiscoverProbeTimeout)
+# had zero Helm exposure before this issue -- every cmd/*/main.go call site
+# hardcoded mcpclient.DefaultResilienceConfig(). This suite proves the new
+# chart-side wiring: kubernaut.fleet.resilience (charts/kubernaut/templates/
+# _helpers.tpl) deep-merges global.fleet.resilience (shared baseline) with
+# each service's own <service>.fleet.resilience override (fleetmetadatacache
+# uses its own top-level fleetmetadatacache.resilience, and
+# workflowexecution has no per-service override at all, reading
+# global.fleet.resilience directly) -- mirroring the schema-default-must-
+# match-Go-default discipline established by
+# apifrontend_resilience_prometheus_timeout_test.yaml (#1839), but for the
+# shared fleet resilience config rather than an AF-only dependency.
+templates:
+  - templates/gateway/gateway.yaml
+  - templates/remediationorchestrator/remediationorchestrator.yaml
+  - templates/apifrontend/apifrontend.yaml
+  - templates/effectivenessmonitor/effectivenessmonitor.yaml
+  - templates/signalprocessing/signalprocessing.yaml
+  - templates/fleetmetadatacache/fleetmetadatacache.yaml
+  - templates/kubernaut-agent/kubernaut-agent.yaml
+  - templates/workflowexecution/workflowexecution.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  global:
+    llmProfiles:
+      primary:
+        provider: openai
+        model: gpt-4
+        credentialsSecretName: llm-credentials-primary
+    fleet:
+      enabled: true
+      mcpGatewayEndpoint: "http://mcp.example.com"
+      backend: "fleetmetadatacache"
+      mcpGatewayType: "eaigw"
+      oauth2:
+        enabled: true
+        tokenURL: "https://dex.example.com/token"
+        credentialsSecretRef: fleet-oauth2-creds
+  kubernautAgent:
+    llmProfileRef: primary
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+  # Issue #1984 Phase D: WE's own oauth2.credentialsSecretRef is a dedicated,
+  # non-fallback-able field (unlike the other 6 read-only fleet consumers) --
+  # required whenever global.fleet.mcpGatewayEndpoint is set, independent of
+  # anything this suite is actually testing.
+  workflowexecution:
+    fleet:
+      oauth2:
+        credentialsSecretRef: we-oauth2-creds
+tests:
+  # ---------------------------------------------------------------------
+  # Default install: no resilience.* override anywhere. Omitting the block
+  # entirely must keep mcpclient.DefaultResilienceConfig()'s existing
+  # values in effect -- proven by discoverProbeTimeout (unique to this
+  # fleet resilience spec; AF's PRE-EXISTING, unrelated
+  # resilience.prometheus.* block from #1839 also uses the generic
+  # `resilience:` key and even reuses `connectTimeout`, so asserting on
+  # the bare `resilience:` key would false-negative for AF specifically)
+  # being absent, not present-with-defaults (unlike AF's Prometheus
+  # resilience block, which always renders; this design avoids
+  # duplicating the same 6 defaults in both Go and YAML).
+  # ---------------------------------------------------------------------
+  - it: "default install (no resilience.* override) omits discoverProbeTimeout from gateway-config entirely"
+    template: templates/gateway/gateway.yaml
+    documentSelector:
+      path: metadata.name
+      value: gateway-config
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*discoverProbeTimeout:"
+
+  - it: "default install (no resilience.* override) omits discoverProbeTimeout from remediationorchestrator-config entirely"
+    template: templates/remediationorchestrator/remediationorchestrator.yaml
+    documentSelector:
+      path: metadata.name
+      value: remediationorchestrator-config
+    asserts:
+      - notMatchRegex:
+          path: data["remediationorchestrator.yaml"]
+          pattern: "(?m)^\\s*discoverProbeTimeout:"
+
+  - it: "default install (no resilience.* override) omits discoverProbeTimeout from apifrontend-config entirely (AF's own pre-existing resilience.prometheus.* block from #1839 is unaffected and still renders)"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-config
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*discoverProbeTimeout:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*prometheus:"
+
+  - it: "default install (no resilience.* override) omits discoverProbeTimeout from effectivenessmonitor-config entirely"
+    template: templates/effectivenessmonitor/effectivenessmonitor.yaml
+    documentSelector:
+      path: metadata.name
+      value: effectivenessmonitor-config
+    asserts:
+      - notMatchRegex:
+          path: data["effectivenessmonitor.yaml"]
+          pattern: "(?m)^\\s*discoverProbeTimeout:"
+
+  - it: "default install (no resilience.* override) omits discoverProbeTimeout from signalprocessing-config entirely"
+    template: templates/signalprocessing/signalprocessing.yaml
+    documentSelector:
+      path: metadata.name
+      value: signalprocessing-config
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*discoverProbeTimeout:"
+
+  - it: "default install (no resilience.* override) omits discoverProbeTimeout from fleetmetadatacache-config entirely"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: metadata.name
+      value: fleetmetadatacache-config
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*discoverProbeTimeout:"
+
+  - it: "default install (no resilience.* override) omits discoverProbeTimeout from kubernaut-agent-config entirely"
+    template: templates/kubernaut-agent/kubernaut-agent.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-agent-config
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*discoverProbeTimeout:"
+
+  - it: "default install (no resilience.* override) omits discoverProbeTimeout from workflowexecution-config entirely"
+    template: templates/workflowexecution/workflowexecution.yaml
+    documentSelector:
+      path: metadata.name
+      value: workflowexecution-config
+    asserts:
+      - notMatchRegex:
+          path: data["workflowexecution.yaml"]
+          pattern: "(?m)^\\s*discoverProbeTimeout:"
+
+  # ---------------------------------------------------------------------
+  # global.fleet.resilience propagates identically to every fleet-aware
+  # service via the shared kubernaut.fleet.resilience/kubernaut.fleet.preamble
+  # helper (7 of 8 services) or a direct .Values.global.fleet.resilience
+  # read (workflowexecution).
+  # ---------------------------------------------------------------------
+  - it: "global.fleet.resilience.connectTimeout propagates to gateway-config"
+    set:
+      global:
+        fleet:
+          resilience:
+            connectTimeout: "45s"
+    template: templates/gateway/gateway.yaml
+    documentSelector:
+      path: metadata.name
+      value: gateway-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*connectTimeout: 45s"
+
+  - it: "global.fleet.resilience.connectTimeout propagates to remediationorchestrator-config"
+    set:
+      global:
+        fleet:
+          resilience:
+            connectTimeout: "45s"
+    template: templates/remediationorchestrator/remediationorchestrator.yaml
+    documentSelector:
+      path: metadata.name
+      value: remediationorchestrator-config
+    asserts:
+      - matchRegex:
+          path: data["remediationorchestrator.yaml"]
+          pattern: "(?m)^\\s*connectTimeout: 45s"
+
+  - it: "global.fleet.resilience.connectTimeout propagates to apifrontend-config"
+    set:
+      global:
+        fleet:
+          resilience:
+            connectTimeout: "45s"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*connectTimeout: 45s"
+
+  - it: "global.fleet.resilience.connectTimeout propagates to effectivenessmonitor-config"
+    set:
+      global:
+        fleet:
+          resilience:
+            connectTimeout: "45s"
+    template: templates/effectivenessmonitor/effectivenessmonitor.yaml
+    documentSelector:
+      path: metadata.name
+      value: effectivenessmonitor-config
+    asserts:
+      - matchRegex:
+          path: data["effectivenessmonitor.yaml"]
+          pattern: "(?m)^\\s*connectTimeout: 45s"
+
+  - it: "global.fleet.resilience.connectTimeout propagates to signalprocessing-config"
+    set:
+      global:
+        fleet:
+          resilience:
+            connectTimeout: "45s"
+    template: templates/signalprocessing/signalprocessing.yaml
+    documentSelector:
+      path: metadata.name
+      value: signalprocessing-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*connectTimeout: 45s"
+
+  - it: "global.fleet.resilience.connectTimeout propagates to fleetmetadatacache-config"
+    set:
+      global:
+        fleet:
+          resilience:
+            connectTimeout: "45s"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: metadata.name
+      value: fleetmetadatacache-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*connectTimeout: 45s"
+
+  - it: "global.fleet.resilience.connectTimeout propagates to kubernaut-agent-config"
+    set:
+      global:
+        fleet:
+          resilience:
+            connectTimeout: "45s"
+    template: templates/kubernaut-agent/kubernaut-agent.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-agent-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*connectTimeout: 45s"
+
+  - it: "global.fleet.resilience.connectTimeout reaches workflowexecution-config via its direct global.fleet.* read (WE has no per-service fleet.resilience override)"
+    set:
+      global:
+        fleet:
+          resilience:
+            connectTimeout: "45s"
+    template: templates/workflowexecution/workflowexecution.yaml
+    documentSelector:
+      path: metadata.name
+      value: workflowexecution-config
+    asserts:
+      - matchRegex:
+          path: data["workflowexecution.yaml"]
+          pattern: "(?m)^\\s*connectTimeout: 45s"
+
+  # ---------------------------------------------------------------------
+  # Per-service override wins over the global baseline for the same
+  # field, while inheriting every other field from global (deep-merge
+  # semantics via kubernaut.fleet.resilience's mergeOverwrite).
+  # ---------------------------------------------------------------------
+  - it: "gateway.fleet.resilience.connectTimeout overrides the global value, while discoverProbeTimeout is inherited from global.fleet.resilience"
+    set:
+      global:
+        fleet:
+          resilience:
+            connectTimeout: "45s"
+            discoverProbeTimeout: "8s"
+      gateway:
+        fleet:
+          resilience:
+            connectTimeout: "12s"
+    template: templates/gateway/gateway.yaml
+    documentSelector:
+      path: metadata.name
+      value: gateway-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*connectTimeout: 12s"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*connectTimeout: 45s"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*discoverProbeTimeout: 8s"
+
+  - it: "fleetmetadatacache.resilience.maxElapsedTime overrides the global value (FMC's own top-level resilience key, not nested under a fleet: block)"
+    set:
+      global:
+        fleet:
+          resilience:
+            maxElapsedTime: "5m"
+      fleetmetadatacache:
+        resilience:
+          maxElapsedTime: "2m"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: metadata.name
+      value: fleetmetadatacache-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*maxElapsedTime: 2m"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*maxElapsedTime: 5m"
+
+  - it: "kubernautAgent.fleet.resilience.tokenRefreshTimeout overrides the global value, while initialInterval is inherited from global.fleet.resilience"
+    set:
+      global:
+        fleet:
+          resilience:
+            tokenRefreshTimeout: "10s"
+            initialInterval: "2s"
+      kubernautAgent:
+        fleet:
+          resilience:
+            tokenRefreshTimeout: "25s"
+    template: templates/kubernaut-agent/kubernaut-agent.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-agent-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*tokenRefreshTimeout: 25s"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*tokenRefreshTimeout: 10s"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*initialInterval: 2s"

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -15,6 +15,67 @@
       "type": "string",
       "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|\u00b5s|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|\u00b5s|ms|s|m|h))*$"
     },
+    "fleetResilienceSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Per-attempt backoff/timeout tuning for pkg/fleet/mcpclient.ResilienceConfig (issue #2262). Every field is optional; omitting a field (or the whole block) keeps mcpclient.DefaultResilienceConfig()'s existing value for that field unchanged -- this is what makes it safe to newly expose an already-shipping default via Helm.",
+      "properties": {
+        "initialInterval": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/goDuration"
+            }
+          ],
+          "default": "1s",
+          "description": "Starting backoff interval for startup connect retries."
+        },
+        "maxInterval": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/goDuration"
+            }
+          ],
+          "default": "30s",
+          "description": "Maximum backoff interval between connect retries."
+        },
+        "maxElapsedTime": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/goDuration"
+            }
+          ],
+          "default": "5m",
+          "description": "Total time before giving up on startup connection."
+        },
+        "tokenRefreshTimeout": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/goDuration"
+            }
+          ],
+          "default": "10s",
+          "description": "Bounds OAuth2 token refresh HTTP calls."
+        },
+        "connectTimeout": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/goDuration"
+            }
+          ],
+          "default": "30s",
+          "description": "Bounds each individual MCP connect attempt, independent of whether the caller's context carries a deadline (issue #1934)."
+        },
+        "discoverProbeTimeout": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/goDuration"
+            }
+          ],
+          "default": "5s",
+          "description": "Bounds the SEP-2575 server/discover probe independently of connectTimeout, so a gateway that hangs (rather than erroring) on that probe cannot consume connectTimeout's entire budget before the legacy initialize handshake fallback gets a chance to run (issue #2262)."
+        }
+      }
+    },
     "k8sLabelSelector": {
       "description": "A Kubernetes LabelSelector (matchLabels/matchExpressions), used as a raw namespaceSelector value in a NetworkPolicy ingress peer.",
       "type": "object",
@@ -693,6 +754,15 @@
                   "description": "Shared CA bundle path for verifying tokenURL's TLS certificate, used by every fleet-integration-capable service (Issue #1707 follow-up: global-only, no per-service override)."
                 }
               }
+            },
+            "resilience": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/fleetResilienceSpec"
+                }
+              ],
+              "default": {},
+              "description": "Shared default resilience/timeout tuning (issue #2262 Phase 2) for every fleet-integration-capable service's mcpclient.ResilienceConfig. Each service's own fleet.resilience (fleetmetadatacache.resilience for FMC) may override a subset of these 6 fields while inheriting the rest from here. Omitting this block entirely keeps every service's pre-#2262 hardcoded Go defaults unchanged."
             }
           }
         },
@@ -1136,6 +1206,9 @@
           "properties": {
             "oauth2": {
               "$ref": "#/definitions/fleetOAuth2CredentialsOverride"
+            },
+            "resilience": {
+              "$ref": "#/definitions/fleetResilienceSpec"
             }
           }
         }
@@ -1562,6 +1635,9 @@
             },
             "oauth2": {
               "$ref": "#/definitions/fleetOAuth2CredentialsOverride"
+            },
+            "resilience": {
+              "$ref": "#/definitions/fleetResilienceSpec"
             }
           }
         },
@@ -1858,6 +1934,9 @@
           "properties": {
             "oauth2": {
               "$ref": "#/definitions/fleetOAuth2CredentialsOverride"
+            },
+            "resilience": {
+              "$ref": "#/definitions/fleetResilienceSpec"
             }
           }
         }
@@ -2184,6 +2263,9 @@
             },
             "oauth2": {
               "$ref": "#/definitions/fleetOAuth2CredentialsOverride"
+            },
+            "resilience": {
+              "$ref": "#/definitions/fleetResilienceSpec"
             }
           }
         },
@@ -2442,6 +2524,9 @@
           "properties": {
             "oauth2": {
               "$ref": "#/definitions/fleetOAuth2CredentialsOverride"
+            },
+            "resilience": {
+              "$ref": "#/definitions/fleetResilienceSpec"
             }
           }
         },
@@ -2737,6 +2822,9 @@
         "oauth2": {
           "$ref": "#/definitions/fleetOAuth2CredentialsOverride"
         },
+        "resilience": {
+          "$ref": "#/definitions/fleetResilienceSpec"
+        },
         "resources": {
           "$ref": "#/definitions/resources"
         },
@@ -2819,6 +2907,9 @@
             },
             "oauth2": {
               "$ref": "#/definitions/fleetOAuth2CredentialsOverride"
+            },
+            "resilience": {
+              "$ref": "#/definitions/fleetResilienceSpec"
             }
           }
         },

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -64,6 +64,24 @@ global:
     oauth2:
       # -- OAuth2 client_credentials auth on/off for MCP Gateway authentication.
       enabled: false
+    # -- Shared backoff/timeout tuning for every fleet-integration-capable
+    # service's mcpclient.ResilienceConfig (issue #2262 Phase 2). Every field
+    # is optional; omitting a field (or this whole block) keeps
+    # mcpclient.DefaultResilienceConfig()'s existing value unchanged -- this
+    # is what makes it safe to newly expose an already-shipping default via
+    # Helm. Each service's own fleet.resilience (fleetmetadatacache.resilience
+    # for FMC) may override a subset of these fields while inheriting the
+    # rest from here.
+    # resilience:
+    #   initialInterval: 1s     # starting backoff interval for startup connect retries
+    #   maxInterval: 30s        # maximum backoff interval between connect retries
+    #   maxElapsedTime: 5m      # total time before giving up on startup connection
+    #   tokenRefreshTimeout: 10s  # bounds OAuth2 token refresh HTTP calls
+    #   connectTimeout: 30s     # bounds each individual MCP connect attempt (issue #1934)
+    #   discoverProbeTimeout: 5s # bounds the SEP-2575 server/discover probe independently
+    #                            # of connectTimeout, so a gateway that hangs (rather than
+    #                            # erroring) on it cannot starve the legacy initialize
+    #                            # handshake fallback (issue #2262)
   # -- Named LLM provider profiles (DD-PLATFORM-007), referenced by name from
   # kubernautAgent.llmProfileRef (required), kubernautAgent.phaseModels,
   # kubernautAgent.alignmentCheck.llmProfileRef, apifrontend.llmProfileRef,

--- a/cmd/apifrontend/backend_deps.go
+++ b/cmd/apifrontend/backend_deps.go
@@ -570,7 +570,7 @@ func buildFleetReaderDeps(ctx context.Context, cfg *config.Config, deps *backend
 		opts = append(opts, mcpclient.WithReloadableOAuth2Transport(reloadCfg, fleetLog)) //nolint:contextcheck // OAuth2 token source refresh runs as a background reload, independent of any single request
 	}
 
-	resilienceCfg := mcpclient.DefaultResilienceConfig()
+	resilienceCfg := mcpclient.ResilienceConfigFromFleet(cfg.Fleet.Resilience)
 	mcpFleetClient, err := mcpclient.NewResilient(ctx, cfg.Fleet.MCPGatewayEndpoint, resilienceCfg, fleetLog, opts...)
 	if err != nil {
 		// #1553: keep (don't discard) the disconnected client — the fleet

--- a/cmd/apifrontend/fleet_readiness_wiring_test.go
+++ b/cmd/apifrontend/fleet_readiness_wiring_test.go
@@ -75,7 +75,7 @@ func TestWireFleetReadinessGate_AF_Unreachable_NotReady(t *testing.T) {
 	resilienceCfg := mcpclient.DefaultResilienceConfig()
 	resilienceCfg.InitialInterval = 50 * time.Millisecond
 	resilienceCfg.MaxElapsedTime = 500 * time.Millisecond
-	fleetClient, connErr := mcpclient.NewResilient(ctx, "http://127.0.0.1:1/unreachable", resilienceCfg, logr.Discard())
+	fleetClient, connErr := mcpclient.NewResilient(ctx, unreachableTestEndpoint, resilienceCfg, logr.Discard())
 	_ = connErr
 	if fleetClient != nil {
 		t.Cleanup(func() { _ = fleetClient.Close() })

--- a/cmd/apifrontend/fleet_wiring_test.go
+++ b/cmd/apifrontend/fleet_wiring_test.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/config"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+	"github.com/jordigilh/kubernaut/pkg/fleet"
+	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
 	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
 	mockgw "github.com/jordigilh/kubernaut/test/services/mock-mcp-gateway/testutil"
@@ -39,6 +41,12 @@ import (
 const (
 	mockModel = "mock-model"
 	testKey   = "test-key"
+	// unreachableTestEndpoint is a deliberately-unreachable address (port 1
+	// on loopback, RFC 6335 "system port" almost never listening) used
+	// across this package's fleet/DataStorage readiness wiring tests to
+	// force mcpclient.NewResilient/health-check dials to fail fast rather
+	// than hang or flake on an actually-reachable-but-wrong endpoint.
+	unreachableTestEndpoint = "http://127.0.0.1:1/unreachable"
 )
 
 // backendGVRListKinds mirrors the GVR the EAIGWRegistry watches (Envoy AI
@@ -146,7 +154,7 @@ func TestBuildFleetReaderDeps_EnabledUnreachableEndpoint_DegradesGracefully(t *t
 	deps := &backendDeps{k8sDynClient: dynClient}
 	cfg := &config.Config{}
 	cfg.Fleet.Enabled = true
-	cfg.Fleet.MCPGatewayEndpoint = "http://127.0.0.1:1/unreachable"
+	cfg.Fleet.MCPGatewayEndpoint = unreachableTestEndpoint
 	cfg.Fleet.MCPGatewayType = registry.GatewayEAIGW
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -170,6 +178,60 @@ func TestBuildFleetReaderDeps_EnabledUnreachableEndpoint_DegradesGracefully(t *t
 		t.Error("IT-AF-1553-001: FleetReady() must report false when the initial connection failed")
 	}
 	t.Cleanup(deps.fleetReadinessGate.Stop)
+}
+
+// TestBuildFleetReaderDeps_ResilienceOverrideReachesNewResilient proves the
+// issue #2262 Phase 2 wiring: a chart-shaped Config.Fleet.Resilience
+// override (fleet.FleetResilienceConfig) actually reaches the real
+// mcpclient.NewResilient call inside buildFleetReaderDeps
+// (cmd/apifrontend/backend_deps.go), not just
+// mcpclient.ResilienceConfigFromFleet in isolation (already unit-tested by
+// UT-FLEET-RES-013/014). Asserts via ResilientClient.ResilienceConfig()
+// rather than timing, so the test is deterministic.
+func TestBuildFleetReaderDeps_ResilienceOverrideReachesNewResilient(t *testing.T) {
+	t.Parallel()
+
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), backendGVRListKinds)
+
+	deps := &backendDeps{k8sDynClient: dynClient}
+	cfg := &config.Config{}
+	cfg.Fleet.Enabled = true
+	cfg.Fleet.MCPGatewayEndpoint = unreachableTestEndpoint
+	cfg.Fleet.MCPGatewayType = registry.GatewayEAIGW
+	cfg.Fleet.Resilience = fleet.FleetResilienceConfig{
+		ConnectTimeout:       7 * time.Second,
+		DiscoverProbeTimeout: 3 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := buildFleetReaderDeps(ctx, cfg, deps, logr.Discard())
+	if err != nil {
+		t.Fatalf("unexpected error for an unreachable Fleet MCP Gateway endpoint: %v", err)
+	}
+	fc := deps.FleetResilientClient()
+	if fc == nil {
+		t.Fatal("expected a kept (non-nil) *mcpclient.ResilientClient even for an unreachable endpoint (#1553)")
+	}
+	t.Cleanup(func() { _ = fc.Close() })
+	if deps.fleetReadinessGate != nil {
+		t.Cleanup(deps.fleetReadinessGate.Stop)
+	}
+
+	got := fc.ResilienceConfig()
+	want := mcpclient.ResilienceConfigFromFleet(cfg.Fleet.Resilience)
+	if got != want {
+		t.Fatalf("issue #2262 Phase 2: Config.Fleet.Resilience did not reach the real NewResilient call inside "+
+			"buildFleetReaderDeps -- got %+v, want %+v", got, want)
+	}
+	if got.ConnectTimeout != 7*time.Second || got.DiscoverProbeTimeout != 3*time.Second {
+		t.Fatalf("overridden fields did not survive the chart-shaped override -> NewResilient round trip: %+v", got)
+	}
+	defaults := mcpclient.DefaultResilienceConfig()
+	if got.InitialInterval != defaults.InitialInterval || got.MaxInterval != defaults.MaxInterval || got.MaxElapsedTime != defaults.MaxElapsedTime {
+		t.Fatalf("fields left unset in the override must keep mcpclient.DefaultResilienceConfig()'s values, got %+v", got)
+	}
 }
 
 // TestBuildFleetReaderDeps_Enabled_WithNamespace_ScopesClusterRegistryWatch is

--- a/cmd/effectivenessmonitor/fleet_wiring_test.go
+++ b/cmd/effectivenessmonitor/fleet_wiring_test.go
@@ -28,6 +28,8 @@ import (
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	config "github.com/jordigilh/kubernaut/internal/config/effectivenessmonitor"
+	"github.com/jordigilh/kubernaut/pkg/fleet"
+	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
 	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
 	mockgw "github.com/jordigilh/kubernaut/test/services/mock-mcp-gateway/testutil"
 )
@@ -224,5 +226,52 @@ func TestBuildFleetReaderFactory_EnabledUnreachableEndpoint_DegradesGracefully(t
 	}
 	if fc.Ready() {
 		t.Error("IT-EM-1553-001: the kept client must not report Ready() when its initial connection failed")
+	}
+}
+
+// TestBuildFleetReaderFactory_ResilienceOverrideReachesNewResilient proves
+// the issue #2262 Phase 2 wiring: a chart-shaped Config.Fleet.Resilience
+// override (fleet.FleetResilienceConfig) actually reaches the real
+// mcpclient.NewResilient call inside buildFleetReaderFactory
+// (cmd/effectivenessmonitor/main.go), not just
+// mcpclient.ResilienceConfigFromFleet in isolation (already unit-tested by
+// UT-FLEET-RES-013/014). Asserts via ResilientClient.ResilienceConfig()
+// rather than timing, so the test is deterministic.
+func TestBuildFleetReaderFactory_ResilienceOverrideReachesNewResilient(t *testing.T) {
+	localClient := crfake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), backendGVRListKinds)
+	cfg := config.DefaultConfig()
+	cfg.Fleet.Enabled = true
+	cfg.Fleet.MCPGatewayEndpoint = unreachableTestEndpoint
+	cfg.Fleet.MCPGatewayType = registry.GatewayEAIGW
+	cfg.Fleet.Resilience = fleet.FleetResilienceConfig{
+		ConnectTimeout:       7 * time.Second,
+		DiscoverProbeTimeout: 3 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, fc, err := buildFleetReaderFactory(ctx, localClient, dynClient, cfg, logr.Discard())
+	if err != nil {
+		t.Fatalf("unexpected error for an unreachable Fleet MCP Gateway endpoint: %v", err)
+	}
+	if fc == nil {
+		t.Fatal("expected a kept (non-nil) *mcpclient.ResilientClient even for an unreachable endpoint (#1553)")
+	}
+	t.Cleanup(func() { _ = fc.Close() })
+
+	got := fc.ResilienceConfig()
+	want := mcpclient.ResilienceConfigFromFleet(cfg.Fleet.Resilience)
+	if got != want {
+		t.Fatalf("issue #2262 Phase 2: Config.Fleet.Resilience did not reach the real NewResilient call inside "+
+			"buildFleetReaderFactory -- got %+v, want %+v", got, want)
+	}
+	if got.ConnectTimeout != 7*time.Second || got.DiscoverProbeTimeout != 3*time.Second {
+		t.Fatalf("overridden fields did not survive the chart-shaped override -> NewResilient round trip: %+v", got)
+	}
+	defaults := mcpclient.DefaultResilienceConfig()
+	if got.InitialInterval != defaults.InitialInterval || got.MaxInterval != defaults.MaxInterval || got.MaxElapsedTime != defaults.MaxElapsedTime {
+		t.Fatalf("fields left unset in the override must keep mcpclient.DefaultResilienceConfig()'s values, got %+v", got)
 	}
 }

--- a/cmd/effectivenessmonitor/main.go
+++ b/cmd/effectivenessmonitor/main.go
@@ -474,7 +474,7 @@ func buildFleetReaderFactory(ctx context.Context, localClient client.Client, dyn
 		opts = append(opts, mcpclient.WithReloadableOAuth2Transport(reloadCfg, fleetLog)) //nolint:contextcheck // OAuth2 token source refresh runs as a background reload, independent of any single request
 	}
 
-	resilienceCfg := mcpclient.DefaultResilienceConfig()
+	resilienceCfg := mcpclient.ResilienceConfigFromFleet(cfg.Fleet.Resilience)
 	mcpFleetClient, err := mcpclient.NewResilient(ctx, cfg.Fleet.MCPGatewayEndpoint, resilienceCfg, fleetLog, opts...)
 	if err != nil {
 		// #1553: keep (don't discard) the disconnected client — the fleet

--- a/cmd/fleetmetadatacache/main.go
+++ b/cmd/fleetmetadatacache/main.go
@@ -173,7 +173,7 @@ func wireFMCDependencies(ctx context.Context, cfg *fmcconfig.ServiceConfig, logg
 		"tokenURL", cfg.OAuth2.TokenURL,
 		"credentialsDir", cfg.OAuth2.CredentialsDir)
 
-	resilienceCfg := mcpclient.DefaultResilienceConfig()
+	resilienceCfg := mcpclient.ResilienceConfigFromFleet(cfg.MCPGateway.Resilience)
 	mcpClient, err := mcpclient.NewResilient(ctx, cfg.MCPGateway.Endpoint, resilienceCfg, logger, opts...)
 	if err != nil {
 		logger.Error(err, "Failed to connect to MCP Gateway")

--- a/cmd/gateway/fleet_readiness_wiring_test.go
+++ b/cmd/gateway/fleet_readiness_wiring_test.go
@@ -24,7 +24,9 @@ import (
 
 	"github.com/go-logr/logr"
 
+	"github.com/jordigilh/kubernaut/pkg/fleet"
 	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
+	"github.com/jordigilh/kubernaut/pkg/gateway/adapters"
 	mockgw "github.com/jordigilh/kubernaut/test/services/mock-mcp-gateway/testutil"
 )
 
@@ -93,7 +95,7 @@ func TestWireFleetReadinessGate_EnabledUnreachable_NotReady(t *testing.T) {
 	srv := newTestGatewayServer(t)
 	cfg := testServerConfig()
 	cfg.Fleet.Enabled = true
-	cfg.Fleet.MCPGatewayEndpoint = "http://127.0.0.1:1/unreachable"
+	cfg.Fleet.MCPGatewayEndpoint = unreachableTestEndpoint
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -118,5 +120,62 @@ func TestWireFleetReadinessGate_EnabledUnreachable_NotReady(t *testing.T) {
 	if err := gate.Check(httptest.NewRequest("GET", "/readyz", nil)); err == nil {
 		t.Fatal("BR-INTEGRATION-065 / #1553: gate must report NotReady when the configured MCP Gateway " +
 			"is unreachable, so Kubernetes removes the pod from Service endpoints (pod-wide fail closed)")
+	}
+}
+
+// TestRegisterAdapters_FleetResilienceOverrideReachesNewResilient proves the
+// issue #2262 Phase 2 wiring: a chart-shaped Config.Fleet.Resilience override
+// (fleet.FleetResilienceConfig, populated by the Helm chart's
+// kubernaut.fleet.resilience/kubernaut.fleet.preamble merge) actually reaches
+// the real mcpclient.NewResilient call inside registerAdapters ->
+// wireFleetOwnerResolution (cmd/gateway/main.go), not just
+// mcpclient.ResilienceConfigFromFleet in isolation (already unit-tested by
+// UT-FLEET-RES-013/014 in pkg/fleet/mcpclient/resilience_test.go). Asserts
+// via ResilientClient.ResilienceConfig() rather than timing, so the test is
+// deterministic (no reliance on an unreachable endpoint's connect/backoff
+// wall-clock behavior).
+func TestRegisterAdapters_FleetResilienceOverrideReachesNewResilient(t *testing.T) {
+	srv := newTestGatewayServer(t)
+	apiRegistry := adapters.NewTestAPIResourceRegistry()
+
+	cfg := testServerConfig()
+	cfg.Fleet.Enabled = true
+	cfg.Fleet.MCPGatewayEndpoint = unreachableTestEndpoint
+	cfg.Fleet.Resilience = fleet.FleetResilienceConfig{
+		ConnectTimeout:       7 * time.Second,
+		DiscoverProbeTimeout: 3 * time.Second,
+	}
+
+	// A short ctx deadline (rather than context.Background()) keeps this test
+	// fast: ResilientClient.config is set before connectWithBackoff's retry
+	// loop even starts (see NewResilient), so the assertion below is valid
+	// regardless of how many backoff attempts actually run before ctx.Done().
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	fleetClient, err := registerAdapters(ctx, srv, apiRegistry, cfg, logr.Discard())
+	if err != nil {
+		t.Fatalf("registerAdapters returned unexpected error: %v", err)
+	}
+	if fleetClient == nil {
+		t.Fatal("expected a non-nil fleet client (graceful degradation) even for an unreachable endpoint")
+	}
+	t.Cleanup(func() { _ = fleetClient.Close() })
+
+	got := fleetClient.ResilienceConfig()
+	want := mcpclient.ResilienceConfigFromFleet(cfg.Fleet.Resilience)
+	if got != want {
+		t.Fatalf("issue #2262 Phase 2: Config.Fleet.Resilience did not reach the real NewResilient call inside "+
+			"registerAdapters/wireFleetOwnerResolution -- got %+v, want %+v (mcpclient.ResilienceConfigFromFleet "+
+			"applied to the same override)", got, want)
+	}
+	if got.ConnectTimeout != 7*time.Second || got.DiscoverProbeTimeout != 3*time.Second {
+		t.Fatalf("overridden fields did not survive the chart-shaped override -> NewResilient round trip: %+v", got)
+	}
+	// Fields the chart-shaped override left zero must still fall back to
+	// mcpclient.DefaultResilienceConfig(), not to Go zero values.
+	defaults := mcpclient.DefaultResilienceConfig()
+	if got.InitialInterval != defaults.InitialInterval || got.MaxInterval != defaults.MaxInterval || got.MaxElapsedTime != defaults.MaxElapsedTime {
+		t.Fatalf("fields left unset in the override must keep mcpclient.DefaultResilienceConfig()'s values, got %+v", got)
 	}
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -380,7 +380,7 @@ func wireFleetOwnerResolution(
 		fleetOpts = append(fleetOpts, buildFleetOAuth2Option(serverCfg, logger.WithName("fleet-oauth2"))) //nolint:contextcheck // OAuth2 token source refresh runs as a background reload, independent of any single request
 	}
 
-	resilienceCfg := fleetclient.DefaultResilienceConfig()
+	resilienceCfg := fleetclient.ResilienceConfigFromFleet(serverCfg.Fleet.Resilience)
 	fleetResilientClient, fleetErr := fleetclient.NewResilient(
 		ctx, serverCfg.Fleet.MCPGatewayEndpoint, resilienceCfg,
 		logger.WithName("fleet-client"), fleetOpts...,

--- a/cmd/gateway/main_helpers_test.go
+++ b/cmd/gateway/main_helpers_test.go
@@ -33,6 +33,11 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/gateway/metrics"
 )
 
+// unreachableTestEndpoint is a deliberately-unreachable address (port 1 on
+// loopback, RFC 6335 "system port" almost never listening) used across this
+// package's Fleet readiness wiring tests (goconst dedup).
+const unreachableTestEndpoint = "http://127.0.0.1:1/unreachable"
+
 // TestRegisterAdapters_FleetDisabled is a characterization test for
 // registerAdapters, extracted from main() in GO-ANTIPATTERN-AUDIT-2026-07-01
 // Wave 0a. Pins the default (Fleet federation disabled) contract: both
@@ -65,7 +70,7 @@ func TestRegisterAdapters_FleetEnabledUnreachable(t *testing.T) {
 
 	cfg := testServerConfig()
 	cfg.Fleet.Enabled = true
-	cfg.Fleet.MCPGatewayEndpoint = "http://127.0.0.1:1/unreachable"
+	cfg.Fleet.MCPGatewayEndpoint = unreachableTestEndpoint
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/cmd/kubernautagent/fleet_readiness_wiring_test.go
+++ b/cmd/kubernautagent/fleet_readiness_wiring_test.go
@@ -26,9 +26,15 @@ import (
 	. "github.com/onsi/gomega"
 
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
+	"github.com/jordigilh/kubernaut/pkg/fleet"
 	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
 	mockgw "github.com/jordigilh/kubernaut/test/services/mock-mcp-gateway/testutil"
 )
+
+// eaigwGatewayType is the fleet.GatewayType value for the Envoy AI Gateway
+// backend, used across this file's fleet readiness wiring specs (goconst
+// dedup).
+const eaigwGatewayType = "eaigw"
 
 // IT-FLEET-READY-KA-001: cmd/kubernautagent must wire a readiness.Gate from
 // the resilient client produced by registerFleetTools into readinessHandler
@@ -58,7 +64,7 @@ var _ = Describe("registerFleetTools and wireFleetReadinessGate wiring (#1553)",
 
 			cfg := kaconfig.DefaultConfig()
 			cfg.Integrations.Fleet.Endpoint = gw.URL()
-			cfg.Integrations.Fleet.GatewayType = "eaigw"
+			cfg.Integrations.Fleet.GatewayType = eaigwGatewayType
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			DeferCleanup(cancel)
@@ -74,7 +80,7 @@ var _ = Describe("registerFleetTools and wireFleetReadinessGate wiring (#1553)",
 		It("IT-KA-1553-001: retains the client (not discarded) when the gateway is unreachable", func() {
 			cfg := kaconfig.DefaultConfig()
 			cfg.Integrations.Fleet.Endpoint = "http://127.0.0.1:1/unreachable"
-			cfg.Integrations.Fleet.GatewayType = "eaigw"
+			cfg.Integrations.Fleet.GatewayType = eaigwGatewayType
 
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			DeferCleanup(cancel)
@@ -86,6 +92,43 @@ var _ = Describe("registerFleetTools and wireFleetReadinessGate wiring (#1553)",
 
 			Expect(fc.Ready()).To(BeFalse(), "the kept client must not report Ready() when its initial connection failed")
 			Expect(resolver).To(BeNil(), "no fleet overlay resolver should be returned when the initial connection failed")
+		})
+
+		// Issue #2262 Phase 2: proves a chart-shaped
+		// Config.Integrations.Fleet.Resilience override actually reaches the
+		// real mcpclient.NewResilient call inside registerFleetTools
+		// (cmd/kubernautagent/toolregistry.go), not just
+		// mcpclient.ResilienceConfigFromFleet in isolation (already
+		// unit-tested by UT-FLEET-RES-013/014). Asserts via
+		// ResilientClient.ResilienceConfig() rather than timing, so the test
+		// is deterministic.
+		It("issue #2262: a Resilience override reaches the real NewResilient call", func() {
+			cfg := kaconfig.DefaultConfig()
+			cfg.Integrations.Fleet.Endpoint = "http://127.0.0.1:1/unreachable"
+			cfg.Integrations.Fleet.GatewayType = eaigwGatewayType
+			cfg.Integrations.Fleet.Resilience = fleet.FleetResilienceConfig{
+				ConnectTimeout:       7 * time.Second,
+				DiscoverProbeTimeout: 3 * time.Second,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			DeferCleanup(cancel)
+
+			fc, _ := registerFleetTools(ctx, cfg, logr.Discard())
+			Expect(fc).NotTo(BeNil(), "*mcpclient.ResilientClient must be kept (not discarded) when the Fleet MCP Gateway is unreachable (#1553)")
+			DeferCleanup(func() { _ = fc.Close() })
+
+			got := fc.ResilienceConfig()
+			want := mcpclient.ResilienceConfigFromFleet(cfg.Integrations.Fleet.Resilience)
+			Expect(got).To(Equal(want), "issue #2262 Phase 2: Config.Integrations.Fleet.Resilience did not reach the real "+
+				"NewResilient call inside registerFleetTools")
+			Expect(got.ConnectTimeout).To(Equal(7 * time.Second))
+			Expect(got.DiscoverProbeTimeout).To(Equal(3 * time.Second))
+
+			defaults := mcpclient.DefaultResilienceConfig()
+			Expect(got.InitialInterval).To(Equal(defaults.InitialInterval), "fields left unset in the override must keep mcpclient.DefaultResilienceConfig()'s values")
+			Expect(got.MaxInterval).To(Equal(defaults.MaxInterval))
+			Expect(got.MaxElapsedTime).To(Equal(defaults.MaxElapsedTime))
 		})
 	})
 

--- a/cmd/kubernautagent/toolregistry.go
+++ b/cmd/kubernautagent/toolregistry.go
@@ -340,7 +340,7 @@ func registerFleetTools(ctx context.Context, cfg *kaconfig.Config, logger logr.L
 			"tlsCaFile", cfg.Integrations.Fleet.OAuth2.TLSCaFile)
 	}
 
-	resilienceCfg := fleetclient.DefaultResilienceConfig()
+	resilienceCfg := fleetclient.ResilienceConfigFromFleet(cfg.Integrations.Fleet.Resilience)
 	resilientClient, err := fleetclient.NewResilient(ctx, endpoint, resilienceCfg, fleetLog, opts...)
 	if err != nil {
 		// #1553: keep (don't discard) the disconnected client — the fleet

--- a/cmd/remediationorchestrator/fleet_wiring_test.go
+++ b/cmd/remediationorchestrator/fleet_wiring_test.go
@@ -26,6 +26,8 @@ import (
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	config "github.com/jordigilh/kubernaut/internal/config/remediationorchestrator"
+	"github.com/jordigilh/kubernaut/pkg/fleet"
+	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
 	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
 	mockgw "github.com/jordigilh/kubernaut/test/services/mock-mcp-gateway/testutil"
 )
@@ -160,5 +162,55 @@ func TestBuildFleetReaderFactory_EnabledUnreachableEndpoint_DegradesGracefully(t
 	}
 	if fc.Ready() {
 		t.Error("IT-RO-1553-001: the kept client must not report Ready() when its initial connection failed")
+	}
+}
+
+// TestBuildFleetReaderFactory_ResilienceOverrideReachesNewResilient proves
+// the issue #2262 Phase 2 wiring: a chart-shaped Config.Fleet.Resilience
+// override (fleet.FleetResilienceConfig) actually reaches the real
+// mcpclient.NewResilient call inside buildFleetReaderFactory
+// (cmd/remediationorchestrator/main.go), not just
+// mcpclient.ResilienceConfigFromFleet in isolation (already unit-tested by
+// UT-FLEET-RES-013/014). Asserts via ResilientClient.ResilienceConfig()
+// rather than timing, so the test is deterministic.
+func TestBuildFleetReaderFactory_ResilienceOverrideReachesNewResilient(t *testing.T) {
+	t.Parallel()
+
+	localClient := crfake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+	cfg := config.DefaultConfig()
+	cfg.Fleet.Enabled = true
+	cfg.Fleet.MCPGatewayEndpoint = unreachableTestEndpoint
+	cfg.Fleet.MCPGatewayType = registry.GatewayEAIGW
+	cfg.Fleet.Resilience = fleet.FleetResilienceConfig{
+		ConnectTimeout:       7 * time.Second,
+		DiscoverProbeTimeout: 3 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, fc, err := buildFleetReaderFactory(ctx, localClient, cfg, logr.Discard())
+	if fc != nil {
+		t.Cleanup(func() { _ = fc.Close() })
+	}
+	if err != nil {
+		t.Fatalf("unexpected error for an unreachable Fleet MCP Gateway endpoint: %v", err)
+	}
+	if fc == nil {
+		t.Fatal("expected a kept (non-nil) *mcpclient.ResilientClient even for an unreachable endpoint (#1553)")
+	}
+
+	got := fc.ResilienceConfig()
+	want := mcpclient.ResilienceConfigFromFleet(cfg.Fleet.Resilience)
+	if got != want {
+		t.Fatalf("issue #2262 Phase 2: Config.Fleet.Resilience did not reach the real NewResilient call inside "+
+			"buildFleetReaderFactory -- got %+v, want %+v", got, want)
+	}
+	if got.ConnectTimeout != 7*time.Second || got.DiscoverProbeTimeout != 3*time.Second {
+		t.Fatalf("overridden fields did not survive the chart-shaped override -> NewResilient round trip: %+v", got)
+	}
+	defaults := mcpclient.DefaultResilienceConfig()
+	if got.InitialInterval != defaults.InitialInterval || got.MaxInterval != defaults.MaxInterval || got.MaxElapsedTime != defaults.MaxElapsedTime {
+		t.Fatalf("fields left unset in the override must keep mcpclient.DefaultResilienceConfig()'s values, got %+v", got)
 	}
 }

--- a/cmd/remediationorchestrator/main.go
+++ b/cmd/remediationorchestrator/main.go
@@ -769,7 +769,7 @@ func buildFleetReaderFactory(ctx context.Context, localClient client.Client, cfg
 		opts = append(opts, mcpclient.WithReloadableOAuth2Transport(reloadCfg, fleetLog)) //nolint:contextcheck // OAuth2 token source refresh runs as a background reload, independent of any single request
 	}
 
-	resilienceCfg := mcpclient.DefaultResilienceConfig()
+	resilienceCfg := mcpclient.ResilienceConfigFromFleet(cfg.Fleet.Resilience)
 	mcpFleetClient, err := mcpclient.NewResilient(ctx, cfg.Fleet.MCPGatewayEndpoint, resilienceCfg, fleetLog, opts...)
 	if err != nil {
 		// #1553: keep (don't discard) the disconnected client — the fleet

--- a/cmd/signalprocessing/datastorage_readiness_wiring_test.go
+++ b/cmd/signalprocessing/datastorage_readiness_wiring_test.go
@@ -61,7 +61,7 @@ func TestWireDataStorageReadinessGate_SP_Reachable_ReadyImmediately(t *testing.T
 
 func TestWireDataStorageReadinessGate_SP_Unreachable_NotReady(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.DataStorage.HealthURL = "http://127.0.0.1:1/unreachable"
+	cfg.DataStorage.HealthURL = unreachableTestEndpoint
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/cmd/signalprocessing/fleet_readiness_wiring_test.go
+++ b/cmd/signalprocessing/fleet_readiness_wiring_test.go
@@ -29,6 +29,7 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/jordigilh/kubernaut/pkg/fleet"
 	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
 	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
 	"github.com/jordigilh/kubernaut/pkg/signalprocessing/config"
@@ -56,6 +57,11 @@ var backendGVRListKinds = map[schema.GroupVersionResource]string{
 	registry.BackendGVR: "BackendList",
 }
 
+// unreachableTestEndpoint is a deliberately-unreachable address (port 1 on
+// loopback, RFC 6335 "system port" almost never listening) used across this
+// package's Fleet readiness wiring tests (goconst dedup).
+const unreachableTestEndpoint = "http://127.0.0.1:1/unreachable"
+
 // newTestEnricher builds a K8sEnricher with an isolated (non-global)
 // metrics registry so repeated calls across test cases in this file don't
 // panic on duplicate Prometheus collector registration.
@@ -79,7 +85,7 @@ func TestWireFleetMCPClient_Disabled_NoOp(t *testing.T) {
 
 func TestWireFleetMCPClient_EnabledUnreachable_RetainsClient(t *testing.T) {
 	cfg := config.DefaultConfig()
-	cfg.Fleet.Endpoint = "http://127.0.0.1:1/unreachable"
+	cfg.Fleet.Endpoint = unreachableTestEndpoint
 	localClient := crfake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -93,6 +99,47 @@ func TestWireFleetMCPClient_EnabledUnreachable_RetainsClient(t *testing.T) {
 	t.Cleanup(func() { _ = fc.Close() })
 	if fc.Ready() {
 		t.Error("IT-SP-1553-001: the kept client must not report Ready() when its initial connection failed")
+	}
+}
+
+// TestWireFleetMCPClient_ResilienceOverrideReachesNewResilient proves the
+// issue #2262 Phase 2 wiring: a chart-shaped Config.Fleet.Resilience
+// override (fleet.FleetResilienceConfig) actually reaches the real
+// mcpclient.NewResilient call inside wireFleetMCPClient
+// (cmd/signalprocessing/main.go), not just mcpclient.ResilienceConfigFromFleet
+// in isolation (already unit-tested by UT-FLEET-RES-013/014). Asserts via
+// ResilientClient.ResilienceConfig() rather than timing, so the test is
+// deterministic.
+func TestWireFleetMCPClient_ResilienceOverrideReachesNewResilient(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Fleet.Endpoint = unreachableTestEndpoint
+	cfg.Fleet.Resilience = fleet.FleetResilienceConfig{
+		ConnectTimeout:       7 * time.Second,
+		DiscoverProbeTimeout: 3 * time.Second,
+	}
+	localClient := crfake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	fc := wireFleetMCPClient(ctx, cfg, localClient, newTestEnricher())
+	if fc == nil {
+		t.Fatal("expected a kept (non-nil) *mcpclient.ResilientClient even for an unreachable endpoint (#1553)")
+	}
+	t.Cleanup(func() { _ = fc.Close() })
+
+	got := fc.ResilienceConfig()
+	want := mcpclient.ResilienceConfigFromFleet(cfg.Fleet.Resilience)
+	if got != want {
+		t.Fatalf("issue #2262 Phase 2: Config.Fleet.Resilience did not reach the real NewResilient call inside "+
+			"wireFleetMCPClient -- got %+v, want %+v", got, want)
+	}
+	if got.ConnectTimeout != 7*time.Second || got.DiscoverProbeTimeout != 3*time.Second {
+		t.Fatalf("overridden fields did not survive the chart-shaped override -> NewResilient round trip: %+v", got)
+	}
+	defaults := mcpclient.DefaultResilienceConfig()
+	if got.InitialInterval != defaults.InitialInterval || got.MaxInterval != defaults.MaxInterval || got.MaxElapsedTime != defaults.MaxElapsedTime {
+		t.Fatalf("fields left unset in the override must keep mcpclient.DefaultResilienceConfig()'s values, got %+v", got)
 	}
 }
 
@@ -204,7 +251,7 @@ func TestWireFleetReadinessGate_SP_MCPClientUnreachable_NotReady(t *testing.T) {
 	resilienceCfg := mcpclient.DefaultResilienceConfig()
 	resilienceCfg.InitialInterval = 50 * time.Millisecond
 	resilienceCfg.MaxElapsedTime = 500 * time.Millisecond
-	fleetClient, connErr := mcpclient.NewResilient(ctx, "http://127.0.0.1:1/unreachable", resilienceCfg, logr.Discard())
+	fleetClient, connErr := mcpclient.NewResilient(ctx, unreachableTestEndpoint, resilienceCfg, logr.Discard())
 	_ = connErr
 	if fleetClient != nil {
 		t.Cleanup(func() { _ = fleetClient.Close() })

--- a/cmd/signalprocessing/main.go
+++ b/cmd/signalprocessing/main.go
@@ -307,7 +307,7 @@ func wireFleetMCPClient(ctx context.Context, cfg *config.Config, localClient cli
 		"oauth2Enabled", cfg.Fleet.OAuth2.Enabled)
 
 	fleetOpts := buildFleetOAuth2Options(cfg) //nolint:contextcheck // OAuth2 token source refresh runs as a background reload, independent of any single request
-	resilienceCfg := fleetclient.DefaultResilienceConfig()
+	resilienceCfg := fleetclient.ResilienceConfigFromFleet(cfg.Fleet.Resilience)
 	fleetResilientClient, fleetErr := fleetclient.NewResilient(
 		ctx, cfg.Fleet.Endpoint, resilienceCfg,
 		ctrl.Log.WithName("fleet-client"), fleetOpts...,

--- a/cmd/workflowexecution/main.go
+++ b/cmd/workflowexecution/main.go
@@ -461,7 +461,7 @@ func buildClientFactory(ctx context.Context, cfg *weconfig.Config, localClient c
 			"secretPath", basePath)
 	}
 
-	resilienceCfg := fleetclient.DefaultResilienceConfig()
+	resilienceCfg := fleetclient.ResilienceConfigFromFleet(cfg.Fleet.Resilience)
 	fleetResilientClient, fleetErr := fleetclient.NewResilient(
 		ctx, cfg.Fleet.Endpoint, resilienceCfg,
 		ctrl.Log.WithName("fleet-client"), fleetOpts...,

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -84,6 +84,12 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `enabled` | boolean |  | `true` | No |
 | `fleet.namespace` | string | Restricts the ClusterRegistry CRD watch to a single namespace instead of cluster-wide (BR-RBAC-020, #1686). Empty (default) watches all namespaces and grants cluster-wide RBAC | `""` | No |
 | `fleet.oauth2.credentialsSecretRef` | string | K8s Secret with keys: client-id, client-secret. Overrides global.fleet.oauth2.credentialsSecretRef for this service only. | `""` | No |
+| `fleet.resilience.connectTimeout` | string | Bounds each individual MCP connect attempt, independent of whether the caller's context carries a deadline (issue #1934). | `"30s"` | No |
+| `fleet.resilience.discoverProbeTimeout` | string | Bounds the SEP-2575 server/discover probe independently of connectTimeout, so a gateway that hangs (rather than erroring) on that probe cannot consume connectTimeout's entire budget before the legacy initialize handshake fallback gets a chance to run (issue #2262). | `"5s"` | No |
+| `fleet.resilience.initialInterval` | string | Starting backoff interval for startup connect retries. | `"1s"` | No |
+| `fleet.resilience.maxElapsedTime` | string | Total time before giving up on startup connection. | `"5m"` | No |
+| `fleet.resilience.maxInterval` | string | Maximum backoff interval between connect retries. | `"30s"` | No |
+| `fleet.resilience.tokenRefreshTimeout` | string | Bounds OAuth2 token refresh HTTP calls. | `"10s"` | No |
 | `image.pullPolicy` | string |  | `"IfNotPresent"` | No |
 | `image.repository` | string |  | `"ghcr.io/jordigilh/kubernaut/apifrontend"` | No |
 | `image.tag` | string |  | `""` | No |
@@ -214,6 +220,12 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `containerSecurityContext` | object | Kubernetes securityContext (pod or container level) | `` | No |
 | `fleet.namespace` | string | Restricts the ClusterRegistry CRD watch to a single namespace instead of cluster-wide (BR-RBAC-020, #1686). Empty (default) watches all namespaces and grants cluster-wide RBAC | `""` | No |
 | `fleet.oauth2.credentialsSecretRef` | string | K8s Secret with keys: client-id, client-secret. Overrides global.fleet.oauth2.credentialsSecretRef for this service only. | `""` | No |
+| `fleet.resilience.connectTimeout` | string | Bounds each individual MCP connect attempt, independent of whether the caller's context carries a deadline (issue #1934). | `"30s"` | No |
+| `fleet.resilience.discoverProbeTimeout` | string | Bounds the SEP-2575 server/discover probe independently of connectTimeout, so a gateway that hangs (rather than erroring) on that probe cannot consume connectTimeout's entire budget before the legacy initialize handshake fallback gets a chance to run (issue #2262). | `"5s"` | No |
+| `fleet.resilience.initialInterval` | string | Starting backoff interval for startup connect retries. | `"1s"` | No |
+| `fleet.resilience.maxElapsedTime` | string | Total time before giving up on startup connection. | `"5m"` | No |
+| `fleet.resilience.maxInterval` | string | Maximum backoff interval between connect retries. | `"30s"` | No |
+| `fleet.resilience.tokenRefreshTimeout` | string | Bounds OAuth2 token refresh HTTP calls. | `"10s"` | No |
 | `logging.level` | string | Log level (Issue #875) | `"INFO"` | No |
 | `nodeSelector` | map[string]object | Kubernetes node selector | `` | No |
 | `pdb.enabled` | boolean |  | `true` | No |
@@ -247,6 +259,12 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `pdb.minAvailable` | object |  | `` | No |
 | `podSecurityContext` | object | Kubernetes securityContext (pod or container level) | `` | No |
 | `replicas` | integer |  | `1` | No |
+| `resilience.connectTimeout` | string | Bounds each individual MCP connect attempt, independent of whether the caller's context carries a deadline (issue #1934). | `"30s"` | No |
+| `resilience.discoverProbeTimeout` | string | Bounds the SEP-2575 server/discover probe independently of connectTimeout, so a gateway that hangs (rather than erroring) on that probe cannot consume connectTimeout's entire budget before the legacy initialize handshake fallback gets a chance to run (issue #2262). | `"5s"` | No |
+| `resilience.initialInterval` | string | Starting backoff interval for startup connect retries. | `"1s"` | No |
+| `resilience.maxElapsedTime` | string | Total time before giving up on startup connection. | `"5m"` | No |
+| `resilience.maxInterval` | string | Maximum backoff interval between connect retries. | `"30s"` | No |
+| `resilience.tokenRefreshTimeout` | string | Bounds OAuth2 token refresh HTTP calls. | `"10s"` | No |
 | `resources.limits.cpu` | string | Kubernetes resource quantity (e.g., 256Mi, 100m) | `` | No |
 | `resources.limits.memory` | string | Kubernetes resource quantity (e.g., 256Mi, 100m) | `` | No |
 | `resources.requests.cpu` | string | Kubernetes resource quantity (e.g., 256Mi, 100m) | `` | No |
@@ -285,6 +303,12 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `containerSecurityContext` | object | Kubernetes securityContext (pod or container level) | `` | No |
 | `enabled` | boolean | Issue #2162: whether the Gateway component (Deployment, Service, RBAC) is deployed. Independent of apifrontend.enabled -- either, both, or neither ingress point may be enabled. | `true` | No |
 | `fleet.oauth2.credentialsSecretRef` | string | K8s Secret with keys: client-id, client-secret. Overrides global.fleet.oauth2.credentialsSecretRef for this service only. | `""` | No |
+| `fleet.resilience.connectTimeout` | string | Bounds each individual MCP connect attempt, independent of whether the caller's context carries a deadline (issue #1934). | `"30s"` | No |
+| `fleet.resilience.discoverProbeTimeout` | string | Bounds the SEP-2575 server/discover probe independently of connectTimeout, so a gateway that hangs (rather than erroring) on that probe cannot consume connectTimeout's entire budget before the legacy initialize handshake fallback gets a chance to run (issue #2262). | `"5s"` | No |
+| `fleet.resilience.initialInterval` | string | Starting backoff interval for startup connect retries. | `"1s"` | No |
+| `fleet.resilience.maxElapsedTime` | string | Total time before giving up on startup connection. | `"5m"` | No |
+| `fleet.resilience.maxInterval` | string | Maximum backoff interval between connect retries. | `"30s"` | No |
+| `fleet.resilience.tokenRefreshTimeout` | string | Bounds OAuth2 token refresh HTTP calls. | `"10s"` | No |
 | `ingress.annotations` | object |  | `{}` | No |
 | `ingress.className` | string |  | `""` | No |
 | `ingress.enabled` | boolean |  | `false` | No |
@@ -326,6 +350,12 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `fleet.oauth2.scopes` | array of string | Shared OAuth2 scopes for MCP Gateway authentication, used by every fleet-integration-capable service (Issue #1707 follow-up: global-only, no per-service override). | `[]` | No |
 | `fleet.oauth2.tlsCAFile` | string | Shared CA bundle path for verifying tokenURL's TLS certificate, used by every fleet-integration-capable service (Issue #1707 follow-up: global-only, no per-service override). | `""` | No |
 | `fleet.oauth2.tokenURL` | string | Shared OAuth2 token URL for MCP Gateway authentication, used by every fleet-integration-capable service (Issue #1707 follow-up: global-only, no per-service override). | `""` | No |
+| `fleet.resilience.connectTimeout` | string | Bounds each individual MCP connect attempt, independent of whether the caller's context carries a deadline (issue #1934). | `"30s"` | No |
+| `fleet.resilience.discoverProbeTimeout` | string | Bounds the SEP-2575 server/discover probe independently of connectTimeout, so a gateway that hangs (rather than erroring) on that probe cannot consume connectTimeout's entire budget before the legacy initialize handshake fallback gets a chance to run (issue #2262). | `"5s"` | No |
+| `fleet.resilience.initialInterval` | string | Starting backoff interval for startup connect retries. | `"1s"` | No |
+| `fleet.resilience.maxElapsedTime` | string | Total time before giving up on startup connection. | `"5m"` | No |
+| `fleet.resilience.maxInterval` | string | Maximum backoff interval between connect retries. | `"30s"` | No |
+| `fleet.resilience.tokenRefreshTimeout` | string | Bounds OAuth2 token refresh HTTP calls. | `"10s"` | No |
 | `fleet.tlsCAFile` | string | Shared CA bundle path for verifying the MCP Gateway's TLS certificate, used by every fleet-integration-capable service (Issue #1707 follow-up: global-only, no per-service override). | `""` | No |
 | `fleet.tokenSecretRef` | string | K8s Secret (key: token) with a bearer token for authenticating to the ACM Search GraphQL API (backend=acm). Mandatory when backend=acm; FleetConfig.Validate() rejects backend=acm without it (#1556). | `""` | No |
 | `image.digest` | string | Image digest (e.g. sha256:abc...); when set, overrides tag for immutable references | `""` | No |
@@ -364,6 +394,12 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `alignmentCheck.timeout` | string | Per-step evaluation timeout. | `"10s"` | No |
 | `containerSecurityContext` | object | Kubernetes securityContext (pod or container level) | `` | No |
 | `fleet.oauth2.credentialsSecretRef` | string | K8s Secret with keys: client-id, client-secret. Overrides global.fleet.oauth2.credentialsSecretRef for this service only. | `""` | No |
+| `fleet.resilience.connectTimeout` | string | Bounds each individual MCP connect attempt, independent of whether the caller's context carries a deadline (issue #1934). | `"30s"` | No |
+| `fleet.resilience.discoverProbeTimeout` | string | Bounds the SEP-2575 server/discover probe independently of connectTimeout, so a gateway that hangs (rather than erroring) on that probe cannot consume connectTimeout's entire budget before the legacy initialize handshake fallback gets a chance to run (issue #2262). | `"5s"` | No |
+| `fleet.resilience.initialInterval` | string | Starting backoff interval for startup connect retries. | `"1s"` | No |
+| `fleet.resilience.maxElapsedTime` | string | Total time before giving up on startup connection. | `"5m"` | No |
+| `fleet.resilience.maxInterval` | string | Maximum backoff interval between connect retries. | `"30s"` | No |
+| `fleet.resilience.tokenRefreshTimeout` | string | Bounds OAuth2 token refresh HTTP calls. | `"10s"` | No |
 | `interactive.enabled` | boolean | Enable MCP interactive mode endpoint and Lease-based session management. DD-PLATFORM-006 Decision Area 11: requires apifrontend.enabled=true (APIFrontend's ka.NewSDKMCPClient is the only caller of this endpoint); the render fails otherwise. | `false` | No |
 | `interactive.inactivityTimeout` | string | Session timeout after last activity. | `"10m"` | No |
 | `interactive.jwtProviders` | array of object | JWT providers for Pattern B authentication (DD-AUTH-MCP-001 v2.0). | `` | No |
@@ -529,6 +565,12 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `config.timeouts.verifying` | string | Effectiveness verification phase timeout | `"30m"` | No |
 | `containerSecurityContext` | object | Kubernetes securityContext (pod or container level) | `` | No |
 | `fleet.oauth2.credentialsSecretRef` | string | K8s Secret with keys: client-id, client-secret. Overrides global.fleet.oauth2.credentialsSecretRef for this service only. | `""` | No |
+| `fleet.resilience.connectTimeout` | string | Bounds each individual MCP connect attempt, independent of whether the caller's context carries a deadline (issue #1934). | `"30s"` | No |
+| `fleet.resilience.discoverProbeTimeout` | string | Bounds the SEP-2575 server/discover probe independently of connectTimeout, so a gateway that hangs (rather than erroring) on that probe cannot consume connectTimeout's entire budget before the legacy initialize handshake fallback gets a chance to run (issue #2262). | `"5s"` | No |
+| `fleet.resilience.initialInterval` | string | Starting backoff interval for startup connect retries. | `"1s"` | No |
+| `fleet.resilience.maxElapsedTime` | string | Total time before giving up on startup connection. | `"5m"` | No |
+| `fleet.resilience.maxInterval` | string | Maximum backoff interval between connect retries. | `"30s"` | No |
+| `fleet.resilience.tokenRefreshTimeout` | string | Bounds OAuth2 token refresh HTTP calls. | `"10s"` | No |
 | `logging.level` | string | Log level (Issue #875) | `"INFO"` | No |
 | `nodeSelector` | map[string]object | Kubernetes node selector | `` | No |
 | `pdb.enabled` | boolean |  | `true` | No |
@@ -553,6 +595,12 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `containerSecurityContext` | object | Kubernetes securityContext (pod or container level) | `` | No |
 | `fleet.namespace` | string | Restricts the ClusterRegistry CRD watch; empty watches all namespaces | `""` | No |
 | `fleet.oauth2.credentialsSecretRef` | string | K8s Secret with keys: client-id, client-secret. Overrides global.fleet.oauth2.credentialsSecretRef for this service only. | `""` | No |
+| `fleet.resilience.connectTimeout` | string | Bounds each individual MCP connect attempt, independent of whether the caller's context carries a deadline (issue #1934). | `"30s"` | No |
+| `fleet.resilience.discoverProbeTimeout` | string | Bounds the SEP-2575 server/discover probe independently of connectTimeout, so a gateway that hangs (rather than erroring) on that probe cannot consume connectTimeout's entire budget before the legacy initialize handshake fallback gets a chance to run (issue #2262). | `"5s"` | No |
+| `fleet.resilience.initialInterval` | string | Starting backoff interval for startup connect retries. | `"1s"` | No |
+| `fleet.resilience.maxElapsedTime` | string | Total time before giving up on startup connection. | `"5m"` | No |
+| `fleet.resilience.maxInterval` | string | Maximum backoff interval between connect retries. | `"30s"` | No |
+| `fleet.resilience.tokenRefreshTimeout` | string | Bounds OAuth2 token refresh HTTP calls. | `"10s"` | No |
 | `logging.level` | string | Log level (Issue #875) | `"INFO"` | No |
 | `nodeSelector` | map[string]object | Kubernetes node selector | `` | No |
 | `pdb.enabled` | boolean |  | `true` | No |

--- a/docs/testing/2262/TEST_PLAN.md
+++ b/docs/testing/2262/TEST_PLAN.md
@@ -1,0 +1,186 @@
+# Test Plan: MCP `server/discover` Probe Starves the Legacy `initialize` Fallback
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-2262
+**Feature**: Bound the go-sdk v1.7.0 SEP-2575 `server/discover` probe with
+its own short sub-timeout inside `pkg/fleet/mcpclient`, so a gateway that
+hangs (rather than erroring) on that probe cannot consume the entire
+`ConnectTimeout` budget before the SDK's own legacy `initialize` fallback
+gets a chance to run. Phase 2 (referenced, not detailed here) exposes the
+resulting (and pre-existing) `ResilienceConfig` fields via the Helm chart
+and Go config layer.
+**Version**: 1.0
+**Created**: 2026-08-23
+**Author**: AI Agent
+**Status**: Draft
+**Branch**: `fix/2262-mcp-discover-probe-hang`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+`go-sdk@v1.7.0`'s `Client.Connect()` (`mcp/client.go`) always attempts the
+newer stateless `server/discover` RPC (SEP-2575) before falling back to the
+legacy `initialize` handshake. Per that file's own comment, it "fall[s] back
+to the legacy initialize handshake on any non-modern error from
+server/discover" — i.e. **any** error from the discover step (JSON-RPC or
+transport-level) triggers the fallback, and the fallback `initialize` call
+reuses the *original* `ctx`, not a context derived from the discover
+attempt.
+
+Both steps, however, share that one `ctx` today, bounded only by
+`ResilienceConfig.ConnectTimeout` (30s default, added by issue #1934/TP-1934).
+Against the Kuadrant-fronted MCP Gateway reported in issue #2262,
+`server/discover` never responds (hangs, does not error) and so consumes the
+entire `ConnectTimeout` budget itself — by the time `Client.Connect` would
+otherwise fall through to `initialize`, `ctx` is already expired, so every
+attempt fails identically, even though the backend `kube-mcp-server`
+(confirmed on the same `go-sdk@v1.7.0`) and the legacy handshake path both
+work correctly in isolation.
+
+### 1.2 Objectives
+
+1. **Bounded discover probe**: the `server/discover` HTTP request is bounded
+   by a new `ResilienceConfig.DiscoverProbeTimeout` (default 5s), independent
+   of `ConnectTimeout`, so a hanging probe fails fast and leaves the rest of
+   `ConnectTimeout`'s budget for the legacy `initialize` fallback.
+2. **Behavioral proof, not implementation inspection**: tests exercise the
+   real `New`/`NewResilient` production entry points against a fake MCP
+   server whose `server/discover` handler hangs but whose `initialize`
+   handler answers immediately — proving the fallback actually completes
+   within a bounded wall-clock margin.
+3. **Observability**: a timed-out discover probe is logged at `Info` level
+   with `method`/`endpoint`/`discoverProbeTimeout`/`elapsed` fields (SOC2
+   CC7.2 diagnostic signal), making a future recurrence immediately visible
+   without a fresh investigation.
+4. **No regression**: existing connect/backoff/reconnect behavior
+   (`UT-FLEET-RES-001..009`) is unaffected when `server/discover` answers
+   quickly (the existing fake server's default behavior), and when it is
+   rejected outright (`-32601 method not found`, the pre-existing fixture
+   default).
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./pkg/fleet/mcpclient/...` |
+| Regression pass rate (pre-existing) | 100% | `UT-FLEET-RES-001..009` unchanged |
+| Build/Lint | Clean | `go build ./...`, `golangci-lint run` |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- Issue #2262: this bug report.
+- Issue #1934 / TP-1934 (`docs/tests/1934/TEST_PLAN.md`): prior fix adding
+  `ResilienceConfig.ConnectTimeout`, whose budget this issue shows can be
+  entirely consumed by one sub-step of a single connect attempt.
+- `go-sdk@v1.7.0` `mcp/client.go` `Client.Connect`: SEP-2575 discover-first,
+  fallback-on-any-error behavior this fix relies on and bounds.
+- BR-INTEGRATION-065 (governing `pkg/fleet/mcpclient`, per TP-1934 and
+  `docs/testing/BR-INTEGRATION-054/TEST_PLAN.md`).
+
+### 2.2 FedRAMP Controls
+
+| Control | Intent | Application | Test ID |
+|---------|--------|-------------|---------|
+| CP-10 (Information System Recovery and Reconstitution) | The system must be able to retry and recover from failed dependencies within a bounded time | Bounding the discover sub-step is what allows the SDK's own fallback path to actually run within `ConnectTimeout`, instead of that budget being silently consumed by a hung probe | UT-FLEET-RES-010, UT-FLEET-RES-011 |
+| CC7.2 (SOC2 — Monitoring for anomalies) | Anomalous/degraded dependency behavior must be observable for investigation | `Info`-level log on discover-probe timeout, with structured fields, gives operators a durable diagnostic signal the moment this recurs | UT-FLEET-RES-010 |
+
+---
+
+## 3. Scope
+
+### 3.1 In Scope
+
+| Area | Description |
+|------|--------------|
+| `ResilienceConfig` | Add `DiscoverProbeTimeout time.Duration` field, default 5s in `DefaultResilienceConfig()` |
+| `discoverProbeRoundTripper` (new) | `http.RoundTripper` wrapper in `pkg/fleet/mcpclient` that peeks the outgoing JSON-RPC `method`; applies `DiscoverProbeTimeout` only to `server/discover` requests |
+| `Option` (`options.go`) | New `WithDiscoverProbeTimeout(time.Duration)` and `WithDiscoverProbeLogger(logr.Logger)` options |
+| `New()` (`client.go`) | Wraps `cfg.httpClient.Transport` with `discoverProbeRoundTripper` as the outermost layer when `discoverProbeTimeout > 0` |
+| `connectWithBackoff` / `doReconnect` (`resilience.go`) | Automatically append the two new options (using `rc.config.DiscoverProbeTimeout` and `rc.logger`) to every `New()` call, so all 8 `cmd/*/main.go` call sites get the fix with zero call-site changes |
+
+### 3.2 Out of Scope
+
+- Any change to, or investigation of, the Kuadrant `mcp-gateway` or any
+  other pluggable gateway implementation — flagged in a GitHub issue
+  comment instead (75-80% confidence hypothesis, below the 90% bar for
+  further investigation).
+- Downgrading `go-sdk`.
+- Exposing `DiscoverProbeTimeout` (or the rest of `ResilienceConfig`) via
+  the Helm chart / Go service config layer — see Phase 2 below.
+- Any change to the backoff schedule (`InitialInterval`/`MaxInterval`/`MaxElapsedTime`)
+  itself.
+
+---
+
+## 4. Test Scenarios (Unit — behavioral, via production entry points)
+
+All three scenarios reuse a new `newFakeMCPServerWithDiscover(onInitialize,
+onDiscover)` fixture (backward-compatible superset of the existing
+`newFakeMCPServer`, which becomes a thin wrapper passing `onDiscover=nil`)
+and call the real `New`/`NewResilient` production entry points.
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| UT-FLEET-RES-010 | CP-10, CC7.2 | `New()` + `WithDiscoverProbeTimeout` falls back to a successful `initialize` handshake when `server/discover` hangs past the sub-timeout; the timeout is logged | Call returns success within a bounded wall-clock margin (not the full test timeout); captured log output contains `server/discover` and the configured timeout | Pending |
+| UT-FLEET-RES-011 | CP-10 | `NewResilient` (production entry point, via `connectWithBackoff`) succeeds against a fake gateway that hangs forever on `server/discover` but answers `initialize` immediately, using `DefaultResilienceConfig()`'s wiring (no direct `WithDiscoverProbeTimeout` call by the test) | `NewResilient` returns no error and `Ready()` is true, within a bounded wall-clock margin | Pending |
+| UT-FLEET-RES-012 | CP-10 | Regression — when `server/discover` is rejected quickly (existing fixture default, `-32601`), `DiscoverProbeTimeout` has no observable effect on `NewResilient`'s existing behavior | Behavior identical to pre-fix; `UT-FLEET-RES-001..009` still pass unmodified | Pending |
+
+**Test file**: `pkg/fleet/mcpclient/resilience_test.go`
+
+---
+
+## 5. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|-----------|------------------------|-----------------------|---------|
+| `discoverProbeRoundTripper` | `New()` | `pkg/fleet/mcpclient/client.go` | UT-FLEET-RES-010 |
+| `ResilienceConfig.DiscoverProbeTimeout` | `connectWithBackoff` / `doReconnect` | `pkg/fleet/mcpclient/resilience.go` | UT-FLEET-RES-011 / UT-FLEET-RES-012 |
+| `WithDiscoverProbeTimeout` / `WithDiscoverProbeLogger` options | `New()` (folded into `clientConfig`) | `pkg/fleet/mcpclient/options.go` | UT-FLEET-RES-010 / UT-FLEET-RES-011 |
+
+No new `cmd/` integration needed for Phase 1: all 8 existing `cmd/*/main.go`
+call sites are unchanged; this alters `connectWithBackoff`/`doReconnect`'s
+already-production-wired call to `New()`.
+
+---
+
+## 6. TDD Execution Phases
+
+| Phase | Type | Scope | Tests |
+|-------|------|-------|-------|
+| 1 | RED | Extend fixture with `onDiscover` hook; add `UT-FLEET-RES-010/011/012` against unfixed code; confirm 010/011 fail (hang past a short deadline) | UT-FLEET-RES-010, UT-FLEET-RES-011, UT-FLEET-RES-012 |
+| 2 | GREEN | Add `DiscoverProbeTimeout` to `ResilienceConfig`; add `discoverProbeRoundTripper`; add the two new `Option`s; wrap the transport in `New()`; append the options in `connectWithBackoff`/`doReconnect` | All three new tests pass; no regression in `UT-FLEET-RES-001..009` |
+| 3 | REFACTOR | Dedupe body-peek logic if needed vs. the fixture's own peek; verify no goroutine/context leak; confirm `logr` key-value conventions; lint/build/race for `pkg/fleet/mcpclient` | All tests remain green |
+
+---
+
+## 7. Execution
+
+```bash
+go build ./...
+go test ./pkg/fleet/mcpclient/... -run "UT-FLEET-RES-01[012]" -v -count=1
+go test ./pkg/fleet/mcpclient/... -v -count=1
+golangci-lint run --timeout=5m ./pkg/fleet/mcpclient/...
+```
+
+---
+
+## 8. Phase 2 (referenced only — separate implementation section, same PR)
+
+Phase 2 exposes the full `pkg/fleet/mcpclient.ResilienceConfig` (all 6
+duration fields, including this issue's new `DiscoverProbeTimeout`) via the
+Helm chart and each of the 8 services' Go config layer. It introduces a new
+`fleet.FleetResilienceConfig` DTO, a `mcpclient.ResilienceConfigFromFleet`
+conversion helper, and per-service chart/schema additions. It carries its
+own BR (next available `BR-INTEGRATION-XXX`, assigned at implementation
+time) and its own test scenarios (`UT-FLEET-CFG-00x`, IT wiring-manifest
+extensions, and `helm-unittest` coverage) — tracked in the implementation
+plan, not duplicated here, since it changes no business behavior of the
+Phase 1 fix above, only its configurability.

--- a/internal/kubernautagent/config/config_types.go
+++ b/internal/kubernautagent/config/config_types.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	internalconfig "github.com/jordigilh/kubernaut/internal/config"
+	"github.com/jordigilh/kubernaut/pkg/fleet"
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
 )
@@ -95,6 +96,12 @@ type FleetConfig struct {
 	GatewayType    string                `yaml:"gatewayType"`
 	OAuth2         FleetOAuth2           `yaml:"oauth2"`
 	AlignmentCheck *AlignmentCheckConfig `yaml:"alignmentCheck,omitempty"`
+
+	// Resilience overrides mcpclient.ResilienceConfig's backoff/timeout
+	// tuning (issue #2262 Phase 2). Zero value (the default when omitted)
+	// preserves KA's current hardcoded defaults unchanged.
+	// +optional
+	Resilience fleet.FleetResilienceConfig `yaml:"resilience,omitempty"`
 }
 
 // FleetOAuth2 holds OAuth2 client credentials for MCP Gateway authentication.

--- a/pkg/fleet/config.go
+++ b/pkg/fleet/config.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
 )
@@ -108,6 +109,47 @@ type FleetConfig struct {
 
 	// OAuth2 holds optional OAuth2 credentials for MCP Gateway authentication.
 	OAuth2 FleetOAuth2Config `yaml:"oauth2,omitempty"`
+
+	// Resilience overrides mcpclient.ResilienceConfig's backoff/timeout
+	// tuning (issue #2262 Phase 2). Zero value (the default when omitted)
+	// preserves every existing deployment's current hardcoded defaults
+	// unchanged -- see mcpclient.ResilienceConfigFromFleet.
+	// +optional
+	Resilience FleetResilienceConfig `yaml:"resilience,omitempty"`
+}
+
+// FleetResilienceConfig is a plain DTO mirroring the tunable fields of
+// pkg/fleet/mcpclient.ResilienceConfig. It is defined here, not in
+// mcpclient, to avoid an import cycle: pkg/fleet/mcpclient already imports
+// pkg/fleet (reader_factory.go), so pkg/fleet cannot import mcpclient back.
+// mcpclient.ResilienceConfigFromFleet converts this DTO into the real
+// ResilienceConfig, merging any non-zero field here over
+// mcpclient.DefaultResilienceConfig().
+//
+// All fields are omitempty and zero-value-safe: a zero value here always
+// means "use the mcpclient default for this field", never "explicitly set
+// to zero" -- so an existing deployment that doesn't set a `resilience:`
+// block at all keeps its pre-#2262 behavior unchanged.
+type FleetResilienceConfig struct {
+	// InitialInterval is the starting backoff interval for startup retries.
+	// +optional
+	InitialInterval time.Duration `yaml:"initialInterval,omitempty"`
+	// MaxInterval is the maximum backoff interval.
+	// +optional
+	MaxInterval time.Duration `yaml:"maxInterval,omitempty"`
+	// MaxElapsedTime is the total time before giving up on startup.
+	// +optional
+	MaxElapsedTime time.Duration `yaml:"maxElapsedTime,omitempty"`
+	// TokenRefreshTimeout bounds OAuth2 token refresh HTTP calls.
+	// +optional
+	TokenRefreshTimeout time.Duration `yaml:"tokenRefreshTimeout,omitempty"`
+	// ConnectTimeout bounds each individual MCP connect attempt.
+	// +optional
+	ConnectTimeout time.Duration `yaml:"connectTimeout,omitempty"`
+	// DiscoverProbeTimeout bounds the SEP-2575 "server/discover" probe
+	// independently of ConnectTimeout (issue #2262).
+	// +optional
+	DiscoverProbeTimeout time.Duration `yaml:"discoverProbeTimeout,omitempty"`
 }
 
 // FleetOAuth2Config holds OAuth2 credentials for MCP Gateway authentication.
@@ -138,6 +180,11 @@ type MCPGatewayConfig struct {
 	Endpoint    string `yaml:"endpoint"`
 	GatewayType string `yaml:"gatewayType"`
 	Namespace   string `yaml:"namespace"`
+
+	// Resilience overrides mcpclient.ResilienceConfig's backoff/timeout
+	// tuning (issue #2262 Phase 2). See FleetConfig.Resilience's doc comment.
+	// +optional
+	Resilience FleetResilienceConfig `yaml:"resilience,omitempty"`
 }
 
 // Validate checks that FleetConfig has all required fields when enabled.

--- a/pkg/fleet/fleet_test.go
+++ b/pkg/fleet/fleet_test.go
@@ -18,6 +18,7 @@ package fleet_test
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -625,5 +626,49 @@ var _ = Describe("FleetConfig FMC endpoint auto-derivation (BR-INTEGRATION-065)"
 		err := cfg.Validate()
 		Expect(err).To(HaveOccurred(),
 			"acm backend must still require explicit Endpoint")
+	})
+
+	// Issue #2262 Phase 2: FleetResilienceConfig is a plain DTO (no
+	// mcpclient dependency, to avoid the pkg/fleet <-> mcpclient import
+	// cycle) that carries operator/Helm-configured resilience overrides
+	// down to mcpclient.ResilienceConfigFromFleet.
+	It("UT-FLEET-CFG-090 [CM-6]: FleetResilienceConfig exposes all 6 tunable duration fields", func() {
+		cfg := fleet.FleetResilienceConfig{
+			InitialInterval:      1 * time.Second,
+			MaxInterval:          30 * time.Second,
+			MaxElapsedTime:       5 * time.Minute,
+			TokenRefreshTimeout:  10 * time.Second,
+			ConnectTimeout:       30 * time.Second,
+			DiscoverProbeTimeout: 5 * time.Second,
+		}
+
+		Expect(cfg.InitialInterval).To(Equal(1 * time.Second))
+		Expect(cfg.MaxInterval).To(Equal(30 * time.Second))
+		Expect(cfg.MaxElapsedTime).To(Equal(5 * time.Minute))
+		Expect(cfg.TokenRefreshTimeout).To(Equal(10 * time.Second))
+		Expect(cfg.ConnectTimeout).To(Equal(30 * time.Second))
+		Expect(cfg.DiscoverProbeTimeout).To(Equal(5 * time.Second))
+	})
+
+	It("UT-FLEET-CFG-091 [CM-6]: FleetResilienceConfig fields survive a YAML round-trip and omit when zero", func() {
+		cfg := fleet.FleetResilienceConfig{ConnectTimeout: 45 * time.Second}
+
+		data, err := yaml.Marshal(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring("connectTimeout"))
+		Expect(string(data)).ToNot(ContainSubstring("initialInterval"),
+			"zero-value fields must be omitted (omitempty) so an unset override never accidentally serializes as an explicit zero")
+
+		var roundTripped fleet.FleetResilienceConfig
+		Expect(yaml.Unmarshal(data, &roundTripped)).To(Succeed())
+		Expect(roundTripped.ConnectTimeout).To(Equal(45 * time.Second))
+	})
+
+	It("UT-FLEET-CFG-092 [CM-6]: FleetConfig and MCPGatewayConfig each carry a Resilience field of type FleetResilienceConfig", func() {
+		fc := fleet.FleetConfig{Resilience: fleet.FleetResilienceConfig{ConnectTimeout: 45 * time.Second}}
+		Expect(fc.Resilience.ConnectTimeout).To(Equal(45 * time.Second))
+
+		mc := fleet.MCPGatewayConfig{Resilience: fleet.FleetResilienceConfig{DiscoverProbeTimeout: 2 * time.Second}}
+		Expect(mc.Resilience.DiscoverProbeTimeout).To(Equal(2 * time.Second))
 	})
 })

--- a/pkg/fleet/mcpclient/client.go
+++ b/pkg/fleet/mcpclient/client.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 
@@ -68,6 +69,9 @@ func New(ctx context.Context, endpoint string, opts ...Option) (*Client, error) 
 	for _, opt := range opts {
 		opt(cfg)
 	}
+	if cfg.discoverProbeTimeout > 0 {
+		wrapTransportWithDiscoverProbe(cfg)
+	}
 
 	mcpClient := mcp.NewClient(
 		&mcp.Implementation{Name: "kubernaut-fleet-client", Version: "v0.1.0"},
@@ -85,6 +89,34 @@ func New(ctx context.Context, endpoint string, opts ...Option) (*Client, error) 
 	}
 
 	return &Client{session: session, clusterID: cfg.clusterID, toolPrefix: cfg.toolPrefix, scheme: cfg.resolvedScheme()}, nil
+}
+
+// wrapTransportWithDiscoverProbe wraps cfg.httpClient's transport with
+// discoverProbeRoundTripper as the outermost layer, applied after all
+// options have already been folded into cfg -- so it composes correctly
+// regardless of option ordering (e.g. on top of WithHTTPClient's OAuth2
+// transport). Creates a *http.Client if none was configured.
+func wrapTransportWithDiscoverProbe(cfg *clientConfig) {
+	wrapped := &discoverProbeRoundTripper{
+		next:    baseRoundTripper(cfg),
+		timeout: cfg.discoverProbeTimeout,
+		logger:  cfg.resolvedDiscoverProbeLogger(),
+	}
+	if cfg.httpClient == nil {
+		cfg.httpClient = &http.Client{Transport: wrapped}
+	} else {
+		cfg.httpClient.Transport = wrapped
+	}
+}
+
+// baseRoundTripper returns the transport already configured on cfg.httpClient
+// (e.g. an OAuth2 transport set by WithHTTPClient), or http.DefaultTransport
+// when none was configured.
+func baseRoundTripper(cfg *clientConfig) http.RoundTripper {
+	if cfg.httpClient != nil && cfg.httpClient.Transport != nil {
+		return cfg.httpClient.Transport
+	}
+	return http.DefaultTransport
 }
 
 // NewFromSession creates a Client from an existing MCP session, skipping the

--- a/pkg/fleet/mcpclient/discover_probe.go
+++ b/pkg/fleet/mcpclient/discover_probe.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// methodServerDiscover is go-sdk's SEP-2575 stateless discovery RPC method
+// name (the SDK's own `methodDiscover` constant is unexported; this is the
+// literal wire value it sends).
+const methodServerDiscover = "server/discover"
+
+// discoverProbeRoundTripper bounds the go-sdk v1.7.0+ "server/discover"
+// probe (SEP-2575) with its own short sub-timeout, independent of the
+// caller's request context deadline.
+//
+// go-sdk's Client.Connect falls back to the legacy "initialize" handshake
+// on ANY error from server/discover -- see mcp/client.go: "Per the spec,
+// fall back to the legacy initialize handshake on any non-modern error
+// from server/discover" -- and that fallback reuses the *original* Connect
+// context, not one derived from the discover attempt. Both steps,
+// nonetheless, share one context by default, so a gateway that hangs
+// (rather than erroring) on server/discover silently consumes the entire
+// shared ConnectTimeout budget before the fallback ever gets a chance to
+// run (issue #2262). Wrapping just this one HTTP request with its own
+// deadline lets a hung probe fail fast, leaving the rest of that budget for
+// the fallback.
+type discoverProbeRoundTripper struct {
+	next    http.RoundTripper
+	timeout time.Duration
+	logger  logr.Logger
+}
+
+// RoundTrip peeks the outgoing JSON-RPC request's "method" field. Request
+// bodies here are small, fully-buffered control messages (go-sdk's
+// streamable client transport always sends a bytes.Reader, never a
+// streaming body), so reading and restoring the body is cheap and safe.
+// Only "server/discover" requests get the sub-timeout; every other method
+// (initialize, notifications/*, tools/*, etc.) passes through unmodified.
+func (t *discoverProbeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	next := t.next
+	if next == nil {
+		next = http.DefaultTransport
+	}
+
+	if req.Body == nil || req.Method != http.MethodPost {
+		return next.RoundTrip(req)
+	}
+
+	body, readErr := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	if readErr != nil {
+		return next.RoundTrip(req)
+	}
+
+	var probe struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil || probe.Method != methodServerDiscover {
+		return next.RoundTrip(req)
+	}
+
+	subCtx, cancel := context.WithTimeout(req.Context(), t.timeout)
+	defer cancel()
+
+	start := time.Now()
+	resp, err := next.RoundTrip(req.WithContext(subCtx))
+	if err != nil && subCtx.Err() != nil {
+		t.logger.Info("mcpclient: server/discover probe did not respond within its sub-timeout, falling back to legacy initialize handshake",
+			"method", methodServerDiscover,
+			"endpoint", req.URL.String(),
+			"discoverProbeTimeout", t.timeout,
+			"elapsed", time.Since(start),
+		)
+	}
+	return resp, err
+}

--- a/pkg/fleet/mcpclient/options.go
+++ b/pkg/fleet/mcpclient/options.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -29,12 +30,24 @@ import (
 type Option func(*clientConfig)
 
 type clientConfig struct {
-	httpClient *http.Client
-	timeout    time.Duration
-	clusterID  string
-	toolPrefix string
-	reconnect  func(context.Context) error
-	scheme     *runtime.Scheme
+	httpClient           *http.Client
+	timeout              time.Duration
+	clusterID            string
+	toolPrefix           string
+	reconnect            func(context.Context) error
+	scheme               *runtime.Scheme
+	discoverProbeTimeout time.Duration
+	discoverProbeLogger  logr.Logger
+}
+
+// resolvedDiscoverProbeLogger returns cfg.discoverProbeLogger, defaulting to
+// a discard logger. Calling .Info() on a zero-value logr.Logger (nil sink)
+// panics, so New() must never wrap the transport with an unresolved logger.
+func (cfg *clientConfig) resolvedDiscoverProbeLogger() logr.Logger {
+	if cfg.discoverProbeLogger.GetSink() != nil {
+		return cfg.discoverProbeLogger
+	}
+	return logr.Discard()
 }
 
 // WithScheme sets the runtime.Scheme used to infer GroupVersionKind for
@@ -113,5 +126,30 @@ func WithTimeout(seconds int) Option {
 		} else {
 			cfg.httpClient.Timeout = cfg.timeout
 		}
+	}
+}
+
+// WithDiscoverProbeTimeout bounds go-sdk v1.7.0+'s SEP-2575 "server/discover"
+// probe with its own sub-timeout, independent of the caller's context
+// deadline (issue #2262). A zero (or unset) timeout disables this bound
+// entirely: New() leaves the transport untouched.
+//
+// See discoverProbeRoundTripper for why this exists: without it, a gateway
+// that hangs (rather than erroring) on server/discover can silently consume
+// the entire connect-attempt budget (ResilienceConfig.ConnectTimeout)
+// before go-sdk's own legacy "initialize" fallback ever gets a chance to
+// run.
+func WithDiscoverProbeTimeout(timeout time.Duration) Option {
+	return func(cfg *clientConfig) {
+		cfg.discoverProbeTimeout = timeout
+	}
+}
+
+// WithDiscoverProbeLogger sets the logger used to report a timed-out
+// server/discover probe (SOC2 CC7.2 diagnostic signal). Defaults to a
+// discard logger when not set, so New() never panics on a nil log sink.
+func WithDiscoverProbeLogger(logger logr.Logger) Option {
+	return func(cfg *clientConfig) {
+		cfg.discoverProbeLogger = logger
 	}
 }

--- a/pkg/fleet/mcpclient/resilience.go
+++ b/pkg/fleet/mcpclient/resilience.go
@@ -31,6 +31,8 @@ import (
 	"golang.org/x/sync/singleflight"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/jordigilh/kubernaut/pkg/fleet"
 )
 
 // Compile-time interface compliance.
@@ -54,6 +56,14 @@ type ResilienceConfig struct {
 	// service startup or reconnection -- forever, silently defeating
 	// MaxElapsedTime/MaxInterval.
 	ConnectTimeout time.Duration
+	// DiscoverProbeTimeout bounds go-sdk v1.7.0+'s SEP-2575 "server/discover"
+	// probe with its own sub-timeout, independent of ConnectTimeout. Without
+	// this, a gateway that hangs (rather than erroring) on server/discover
+	// can silently consume the entire ConnectTimeout budget before go-sdk's
+	// own legacy "initialize" fallback ever gets a chance to run (issue
+	// #2262) -- every connect attempt then fails identically, even though
+	// the fallback handshake itself works. Zero disables the bound.
+	DiscoverProbeTimeout time.Duration
 }
 
 // DefaultResilienceConfig returns production-ready defaults per Phase 6 plan.
@@ -66,7 +76,43 @@ func DefaultResilienceConfig() ResilienceConfig {
 		// Matches MaxInterval: a single attempt should never take longer
 		// than the max backoff interval we'd otherwise wait between attempts.
 		ConnectTimeout: 30 * time.Second,
+		// Generous relative to the manually-measured ~50ms round trip
+		// against a healthy gateway (issue #2262); operators can raise it
+		// via ResilienceConfig if a legitimately-slow-but-working gateway
+		// needs more headroom.
+		DiscoverProbeTimeout: 5 * time.Second,
 	}
+}
+
+// ResilienceConfigFromFleet converts a fleet.FleetResilienceConfig DTO
+// (populated from Helm-chart-rendered or operator-supplied Go config, issue
+// #2262 Phase 2) into a full ResilienceConfig, merging any non-zero field
+// in f over DefaultResilienceConfig(). A zero value in f always means "use
+// the default for this field" -- this is what makes adding this field to
+// existing config structs safe: an existing deployment with no
+// `resilience:` block set at all gets behavior identical to before this
+// field existed.
+func ResilienceConfigFromFleet(f fleet.FleetResilienceConfig) ResilienceConfig {
+	cfg := DefaultResilienceConfig()
+	if f.InitialInterval > 0 {
+		cfg.InitialInterval = f.InitialInterval
+	}
+	if f.MaxInterval > 0 {
+		cfg.MaxInterval = f.MaxInterval
+	}
+	if f.MaxElapsedTime > 0 {
+		cfg.MaxElapsedTime = f.MaxElapsedTime
+	}
+	if f.TokenRefreshTimeout > 0 {
+		cfg.TokenRefreshTimeout = f.TokenRefreshTimeout
+	}
+	if f.ConnectTimeout > 0 {
+		cfg.ConnectTimeout = f.ConnectTimeout
+	}
+	if f.DiscoverProbeTimeout > 0 {
+		cfg.DiscoverProbeTimeout = f.DiscoverProbeTimeout
+	}
+	return cfg
 }
 
 // ResilientClient wraps Client with reconnection, retry, and readiness semantics.
@@ -106,6 +152,16 @@ func NewResilient(ctx context.Context, endpoint string, cfg ResilienceConfig, lo
 // Ready returns true when the client has an active MCP session.
 func (rc *ResilientClient) Ready() bool {
 	return rc.ready.Load()
+}
+
+// ResilienceConfig returns the backoff/timeout configuration this client was
+// constructed with. Primarily for tests proving a chart-shaped
+// fleet.FleetResilienceConfig override (issue #2262 Phase 2) actually
+// reaches the real NewResilient call at each service's production wiring
+// point (e.g. cmd/gateway/main.go's registerAdapters), without relying on
+// timing-sensitive assertions against an unreachable/hanging endpoint.
+func (rc *ResilientClient) ResilienceConfig() ResilienceConfig {
+	return rc.config
 }
 
 // Get implements client.Reader with automatic reconnection on transient errors.
@@ -199,7 +255,7 @@ func (rc *ResilientClient) connectWithBackoff(ctx context.Context) error {
 
 		attemptCtx, cancel := context.WithTimeout(ctx, rc.config.ConnectTimeout)
 		defer cancel()
-		c, connErr := New(attemptCtx, rc.endpoint, rc.opts...)
+		c, connErr := New(attemptCtx, rc.endpoint, rc.connectOpts()...)
 		if connErr != nil {
 			lastErr = connErr
 			rc.logger.V(1).Info("Connection attempt failed, retrying",
@@ -258,7 +314,7 @@ func (rc *ResilientClient) doReconnect(ctx context.Context) error {
 
 	attemptCtx, cancel := context.WithTimeout(ctx, rc.config.ConnectTimeout)
 	defer cancel()
-	c, err := New(attemptCtx, rc.endpoint, rc.opts...)
+	c, err := New(attemptCtx, rc.endpoint, rc.connectOpts()...)
 	if err != nil {
 		rc.logger.Error(err, "Reconnection failed")
 		return err
@@ -268,6 +324,22 @@ func (rc *ResilientClient) doReconnect(ctx context.Context) error {
 	rc.ready.Store(true)
 	rc.logger.Info("Reconnected to MCP Gateway")
 	return nil
+}
+
+// connectOpts returns rc.opts with the DiscoverProbeTimeout bound and its
+// logger appended, so every New() call made by connectWithBackoff and
+// doReconnect gets the #2262 fix with zero changes required at any of the 8
+// cmd/*/main.go call sites that construct rc.opts. Appending (rather than
+// mutating rc.opts in place) is safe: since len(rc.opts) == cap(rc.opts) for
+// every slice built from a variadic ...Option parameter, append always
+// allocates a fresh backing array here, so concurrent callers (e.g. a
+// reconnect racing a readiness prober) never share or corrupt each other's
+// temporary slice.
+func (rc *ResilientClient) connectOpts() []Option {
+	return append(rc.opts,
+		WithDiscoverProbeTimeout(rc.config.DiscoverProbeTimeout),
+		WithDiscoverProbeLogger(rc.logger),
+	)
 }
 
 // findReloadableTransport walks the option chain to find a ReloadableOAuth2Transport.

--- a/pkg/fleet/mcpclient/resilience_test.go
+++ b/pkg/fleet/mcpclient/resilience_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mcpclient_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -29,10 +30,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-logr/logr/funcr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/jordigilh/kubernaut/pkg/fleet"
 	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
 )
 
@@ -49,6 +52,18 @@ import (
 // tolerated with spec-permitted non-2xx responses, matching how a
 // stateless real-world MCP Gateway would answer them.
 func newFakeMCPServer(onInitialize func(w http.ResponseWriter, r *http.Request, id json.RawMessage)) *httptest.Server {
+	return newFakeMCPServerWithDiscover(onInitialize, nil)
+}
+
+// newFakeMCPServerWithDiscover behaves like newFakeMCPServer but lets a
+// caller override how the server answers "server/discover" (issue #2262).
+// When onDiscover is nil, it falls back to newFakeMCPServer's original fast
+// "-32601 method not found" rejection, so every pre-#2262 caller of
+// newFakeMCPServer is unaffected.
+func newFakeMCPServerWithDiscover(
+	onInitialize func(w http.ResponseWriter, r *http.Request, id json.RawMessage),
+	onDiscover func(w http.ResponseWriter, r *http.Request, id json.RawMessage),
+) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
@@ -68,6 +83,10 @@ func newFakeMCPServer(onInitialize func(w http.ResponseWriter, r *http.Request, 
 
 		switch req.Method {
 		case "server/discover":
+			if onDiscover != nil {
+				onDiscover(w, r, req.ID)
+				return
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"error":{"code":-32601,"message":"method not found"}}`, req.ID)
 		case "notifications/initialized", "notifications/cancelled":
@@ -404,6 +423,151 @@ var _ = Describe("MCP Client Resilience (Phase 6)", func() {
 				Fail("Reconnect did not return within 1s: doReconnect's single connect attempt has no bound " +
 					"when the caller supplies no deadline (issue #1934)")
 			}
+		})
+	})
+
+	Context("UT-FLEET-RES-010 [CP-10, CC7.2]: New() bounds the server/discover probe independently of ConnectTimeout", func() {
+		It("falls back to a successful legacy initialize handshake -- and logs the timeout -- when server/discover hangs past its own sub-timeout (issue #2262)", func() {
+			server := newFakeMCPServerWithDiscover(
+				func(w http.ResponseWriter, _ *http.Request, id json.RawMessage) {
+					writeMCPInitializeResult(w, id)
+				},
+				func(_ http.ResponseWriter, r *http.Request, _ json.RawMessage) {
+					// Simulates the #2262-reported gateway: server/discover
+					// never responds. This must not consume the caller's
+					// (generous, 2s) context budget below -- only the
+					// short DiscoverProbeTimeout should bound it.
+					select {
+					case <-r.Context().Done():
+					case <-time.After(2 * time.Second):
+					}
+				},
+			)
+			defer server.Close()
+
+			var logBuf bytes.Buffer
+			captureLogger := funcr.New(func(prefix, args string) {
+				logBuf.WriteString(prefix + " " + args + "\n")
+			}, funcr.Options{})
+
+			type connectResult struct {
+				c   *mcpclient.Client
+				err error
+			}
+			done := make(chan connectResult, 1)
+			go func() {
+				c, err := mcpclient.New(context.Background(), server.URL+"/mcp",
+					mcpclient.WithDiscoverProbeTimeout(100*time.Millisecond),
+					mcpclient.WithDiscoverProbeLogger(captureLogger),
+				)
+				done <- connectResult{c, err}
+			}()
+
+			select {
+			case result := <-done:
+				Expect(result.err).ToNot(HaveOccurred(),
+					"New() should fall back to the legacy initialize handshake instead of hanging when server/discover never answers")
+				Expect(result.c).ToNot(BeNil())
+			case <-time.After(1 * time.Second):
+				Fail("New() did not return within 1s: the server/discover probe is not bounded by its own sub-timeout (issue #2262)")
+			}
+
+			Expect(logBuf.String()).To(ContainSubstring("server/discover"),
+				"a timed-out discover probe should be logged for operator visibility (SOC2 CC7.2)")
+		})
+	})
+
+	Context("UT-FLEET-RES-011 [CP-10]: NewResilient falls back through connectWithBackoff when server/discover hangs", func() {
+		It("succeeds via the production entry point against a gateway that hangs forever on server/discover but answers initialize immediately", func() {
+			server := newFakeMCPServerWithDiscover(
+				func(w http.ResponseWriter, _ *http.Request, id json.RawMessage) {
+					writeMCPInitializeResult(w, id)
+				},
+				func(_ http.ResponseWriter, r *http.Request, _ json.RawMessage) {
+					<-r.Context().Done()
+				},
+			)
+			defer server.Close()
+
+			cfg := mcpclient.DefaultResilienceConfig()
+			cfg.DiscoverProbeTimeout = 100 * time.Millisecond
+			cfg.ConnectTimeout = 5 * time.Second
+			cfg.InitialInterval = 50 * time.Millisecond
+			cfg.MaxInterval = 50 * time.Millisecond
+			cfg.MaxElapsedTime = 5 * time.Second
+
+			done := make(chan error, 1)
+			go func() {
+				_, err := mcpclient.NewResilient(context.Background(), server.URL+"/mcp", cfg, logger)
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				Expect(err).ToNot(HaveOccurred(),
+					"NewResilient should succeed via the legacy initialize fallback instead of exhausting ConnectTimeout on a hung server/discover probe")
+			case <-time.After(2 * time.Second):
+				Fail("NewResilient did not return within 2s: DiscoverProbeTimeout is not bounding server/discover independently of ConnectTimeout (issue #2262)")
+			}
+		})
+	})
+
+	Context("UT-FLEET-RES-012 [CP-10]: regression -- DiscoverProbeTimeout has no observable effect when server/discover answers quickly", func() {
+		It("still connects normally against the existing fixture default (fast -32601 rejection of server/discover)", func() {
+			server := newFakeMCPServer(func(w http.ResponseWriter, _ *http.Request, id json.RawMessage) {
+				writeMCPInitializeResult(w, id)
+			})
+			defer server.Close()
+
+			cfg := mcpclient.DefaultResilienceConfig()
+			cfg.MaxElapsedTime = 5 * time.Second
+
+			rc, err := mcpclient.NewResilient(context.Background(), server.URL+"/mcp", cfg, logger)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rc.Ready()).To(BeTrue())
+		})
+	})
+
+	Context("UT-FLEET-RES-013 [CM-6]: ResilienceConfigFromFleet -- zero-value fields pass through to defaults", func() {
+		It("returns DefaultResilienceConfig() unchanged when every fleet.FleetResilienceConfig field is zero", func() {
+			got := mcpclient.ResilienceConfigFromFleet(fleet.FleetResilienceConfig{})
+			Expect(got).To(Equal(mcpclient.DefaultResilienceConfig()),
+				"an unset resilience override (e.g. no Helm/operator resilience: block configured) must produce identical behavior to today's hardcoded defaults")
+		})
+	})
+
+	Context("UT-FLEET-RES-014 [CM-6]: ResilienceConfigFromFleet -- non-zero fields override, independently", func() {
+		It("overrides only the fields explicitly set, leaving the rest at their default value", func() {
+			got := mcpclient.ResilienceConfigFromFleet(fleet.FleetResilienceConfig{
+				InitialInterval:      2 * time.Second,
+				MaxInterval:          60 * time.Second,
+				MaxElapsedTime:       10 * time.Minute,
+				TokenRefreshTimeout:  20 * time.Second,
+				ConnectTimeout:       45 * time.Second,
+				DiscoverProbeTimeout: 7 * time.Second,
+			})
+
+			Expect(got.InitialInterval).To(Equal(2 * time.Second))
+			Expect(got.MaxInterval).To(Equal(60 * time.Second))
+			Expect(got.MaxElapsedTime).To(Equal(10 * time.Minute))
+			Expect(got.TokenRefreshTimeout).To(Equal(20 * time.Second))
+			Expect(got.ConnectTimeout).To(Equal(45 * time.Second))
+			Expect(got.DiscoverProbeTimeout).To(Equal(7 * time.Second))
+		})
+
+		It("overrides a single field while every other field keeps its default", func() {
+			defaults := mcpclient.DefaultResilienceConfig()
+
+			got := mcpclient.ResilienceConfigFromFleet(fleet.FleetResilienceConfig{
+				DiscoverProbeTimeout: 9 * time.Second,
+			})
+
+			Expect(got.DiscoverProbeTimeout).To(Equal(9 * time.Second))
+			Expect(got.InitialInterval).To(Equal(defaults.InitialInterval))
+			Expect(got.MaxInterval).To(Equal(defaults.MaxInterval))
+			Expect(got.MaxElapsedTime).To(Equal(defaults.MaxElapsedTime))
+			Expect(got.TokenRefreshTimeout).To(Equal(defaults.TokenRefreshTimeout))
+			Expect(got.ConnectTimeout).To(Equal(defaults.ConnectTimeout))
 		})
 	})
 })

--- a/pkg/signalprocessing/config/config.go
+++ b/pkg/signalprocessing/config/config.go
@@ -78,6 +78,12 @@ type FleetConfig struct {
 	// Namespace restricts the ClusterRegistry's CRD watch to a specific
 	// namespace. Empty means watch all namespaces (BR-FLEET-003, #1511).
 	Namespace string `yaml:"namespace,omitempty"`
+
+	// Resilience overrides mcpclient.ResilienceConfig's backoff/timeout
+	// tuning (issue #2262 Phase 2). Zero value (the default when omitted)
+	// preserves SP's current hardcoded defaults unchanged.
+	// +optional
+	Resilience fleet.FleetResilienceConfig `yaml:"resilience,omitempty"`
 }
 
 // FleetOAuth2 holds OAuth2 credentials for MCP Gateway authentication.

--- a/pkg/workflowexecution/config/config.go
+++ b/pkg/workflowexecution/config/config.go
@@ -36,6 +36,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	sharedconfig "github.com/jordigilh/kubernaut/internal/config"
+	"github.com/jordigilh/kubernaut/pkg/fleet"
 )
 
 // DefaultConfigPath is the standard Kubernetes ConfigMap mount path for this service.
@@ -69,6 +70,12 @@ type Config struct {
 type FleetConfig struct {
 	Endpoint string      `yaml:"endpoint"`
 	OAuth2   FleetOAuth2 `yaml:"oauth2"`
+
+	// Resilience overrides mcpclient.ResilienceConfig's backoff/timeout
+	// tuning (issue #2262 Phase 2). Zero value (the default when omitted)
+	// preserves WE's current hardcoded defaults unchanged.
+	// +optional
+	Resilience fleet.FleetResilienceConfig `yaml:"resilience,omitempty"`
 }
 
 // FleetOAuth2 holds OAuth2 credentials for MCP Gateway authentication.


### PR DESCRIPTION
## Summary

Fixes [#2262](https://github.com/jordigilh/kubernaut/issues/2262): `mcpclient.NewResilient()` could hang for its entire `ConnectTimeout` budget when the MCP Gateway hangs (rather than errors) on the SEP-2575 `server/discover` probe introduced in `go-sdk` v1.7.0, silently starving the legacy `initialize` handshake fallback of any remaining budget -- even though the legacy handshake works fine in isolation against the same gateway.

Two phases in this PR:

- **Phase 1 (bug fix)**: a new `discoverProbeRoundTripper` bounds just the `server/discover` request with its own independent sub-timeout (`DiscoverProbeTimeout`, default `5s`), leaving the rest of `ConnectTimeout`'s budget for the `initialize` fallback. Logs `method`/`endpoint`/`discoverProbeTimeout`/`elapsed` at `Info` level on timeout (SOC2 CC7.2 diagnostic visibility).
- **Phase 2 (config exposure)**: `pkg/fleet/mcpclient.ResilienceConfig` had **zero** Helm/CRD exposure before this -- every `cmd/*/main.go` call site hardcoded `mcpclient.DefaultResilienceConfig()`. This PR exposes the whole 6-field struct end-to-end via a new `fleet.FleetResilienceConfig` DTO + `mcpclient.ResilienceConfigFromFleet` converter, wired into all 8 fleet-aware services, and rendered through the Helm chart as `global.fleet.resilience` (shared baseline) with a per-service `<service>.fleet.resilience` override, deep-merged.

A follow-up issue for the operator-side (`v1alpha2` CRD) equivalent is filed separately: [jordigilh/kubernaut-operator#390](https://github.com/jordigilh/kubernaut-operator/issues/390).

## Commits

1. `docs(testing)`: test plan (RED/GREEN/REFACTOR sequence, FedRAMP CP-10/SOC2 CC7.2 mapping)
2. `fix(fleet)`: the actual bug fix (`discoverProbeRoundTripper`, `DiscoverProbeTimeout`, `FleetResilienceConfig` DTO, `ResilienceConfigFromFleet`)
3. `feat(fleet)`: wires the converter into all 8 services' real production entry points (`cmd/*/main.go`, `toolregistry.go`, `backend_deps.go`), extends each service's Fleet readiness/wiring IT tests to prove it
4. `feat(chart)`: exposes `global.fleet.resilience` / `<service>.fleet.resilience` via the Helm chart, with 19 new helm-unittest cases

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` -- 0 issues across all touched packages
- [x] `go test` -- all affected packages pass (UT + IT, including new `UT-FLEET-RES-*` cases and per-service Fleet readiness wiring IT tests proving the override reaches the real `mcpclient.NewResilient` call)
- [x] `helm unittest charts/kubernaut` -- 74 suites / 595 tests pass, including the new `fleet_resilience_config_test.yaml` (19 cases: default-omits, global-propagates, per-service-override-wins-with-inheritance)
- [x] See [docs/testing/2262/TEST_PLAN.md](docs/testing/2262/TEST_PLAN.md) for the full RED/GREEN/REFACTOR breakdown and FedRAMP CP-10/SOC2 CC7.2 mapping

Fixes #2262