### PR TITLE
Valkey mTLS client auth (DD-PLATFORM-006 DA19) + PostgreSQL server-side TLS (DA20)

### DIFF
--- a/charts/kubernaut/.helmignore
+++ b/charts/kubernaut/.helmignore
@@ -1,0 +1,19 @@
+# Patterns to ignore when packaging/installing this chart.
+#
+# These paths are development/test/tooling artifacts only -- never read by
+# any template at render time (verified: no .Files.Get/.Files.Glob reference
+# them) -- but without this file Helm's default loader still bundles them
+# into the release's stored Chart object (raw chart source), inflating the
+# `sh.helm.release.v1.<name>.v<rev>` Secret. See DD-PLATFORM-006 DA19/DA20
+# CI must-gather RCA (kubernaut#2272): helm-unittest coverage under tests/
+# alone is ~580KB raw and was the single largest non-runtime contributor
+# pushing that Secret's `data` field past the Kubernetes 1MiB hard limit.
+#
+# helm-unittest itself is unaffected: `helm unittest charts/kubernaut/` (the
+# `make test-helm` target) scans tests/ directly off the source tree via its
+# own file-discovery, independent of the standard chart loader that honors
+# this file.
+tests/
+examples/
+README.md
+.helm-coverage-allowlist.yaml

--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -152,7 +152,7 @@ datastorage:
             connMaxLifetime: 1h
             maxIdleConns: 20
             maxOpenConns: 100
-            sslMode: disable
+            sslMode: require
         redis:
             dlqMaxLen: 10000
             tls:

--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -208,12 +208,16 @@ auth:
     tls:
       enabled: true
       caFile: {{ .Values.apifrontend.config.auth.replayCache.tls.caFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
-      {{- with .Values.apifrontend.config.auth.replayCache.tls.certFile }}
-      certFile: {{ . | quote }}
-      {{- end }}
-      {{- with .Values.apifrontend.config.auth.replayCache.tls.keyFile }}
-      keyFile: {{ . | quote }}
-      {{- end }}
+      # DD-PLATFORM-006 DA19 (kubernaut#2269, BR-NET-002/AC-4): Valkey now
+      # requires client certs (--tls-auth-clients yes). certFile/keyFile
+      # default to APIFrontend's own already-mounted apifrontend-tls Secret
+      # (the same cert it serves its own inbound TLS with, at the tls-certs
+      # volume mount below -- "/etc/apifrontend/tls" is this file's own
+      # hardcoded certDir, not the shared kubernaut.interServiceTLS.certDir
+      # helper other services use) so this "just works" without any extra
+      # configuration -- override only to present a different client identity.
+      certFile: {{ .Values.apifrontend.config.auth.replayCache.tls.certFile | default "/etc/apifrontend/tls/tls.crt" | quote }}
+      keyFile: {{ .Values.apifrontend.config.auth.replayCache.tls.keyFile | default "/etc/apifrontend/tls/tls.key" | quote }}
     {{- end }}
     {{- with .Values.apifrontend.config.auth.replayCache.trustedProxyCIDRs }}
     # DD-PLATFORM-006 DA18 (#1999): trusted-proxy CIDRs for jti replay-cache

--- a/charts/kubernaut/templates/datastorage/datastorage.yaml
+++ b/charts/kubernaut/templates/datastorage/datastorage.yaml
@@ -54,8 +54,14 @@ redis:
   passwordKey: "password"
   tls:
     enabled: true
-    certFile: {{ .Values.datastorage.config.redis.tls.certFile | default "" | quote }}
-    keyFile: {{ .Values.datastorage.config.redis.tls.keyFile | default "" | quote }}
+    # DD-PLATFORM-006 DA19 (kubernaut#2269, BR-NET-002/AC-4): Valkey now
+    # requires client certs (--tls-auth-clients yes). certFile/keyFile
+    # default to DataStorage's own already-mounted datastorage-tls Secret
+    # (the same cert it presents for its own inbound server TLS, at the
+    # tls-certs volume mount below) so this "just works" without any extra
+    # configuration -- override only to present a different client identity.
+    certFile: {{ .Values.datastorage.config.redis.tls.certFile | default (printf "%s/tls.crt" (include "kubernaut.interServiceTLS.certDir" .)) | quote }}
+    keyFile: {{ .Values.datastorage.config.redis.tls.keyFile | default (printf "%s/tls.key" (include "kubernaut.interServiceTLS.certDir" .)) | quote }}
     # DD-PLATFORM-006 DA8: the chart's own Valkey is TLS-only -- caFile defaults
     # to the already-mounted inter-service CA (see the tls-ca volume/mount
     # below) so this works without extra configuration; override only for a

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -59,8 +59,14 @@ valkey:
   any extra configuration. */}}
   tls:
     enabled: true
-    certFile: {{ .Values.fleetmetadatacache.valkeyTLS.certFile | default "" | quote }}
-    keyFile: {{ .Values.fleetmetadatacache.valkeyTLS.keyFile | default "" | quote }}
+    # DD-PLATFORM-006 DA19 (kubernaut#2269, BR-NET-002/AC-4): Valkey now
+    # requires client certs (--tls-auth-clients yes). certFile/keyFile
+    # default to FMC's own already-mounted fleetmetadatacache-tls Secret
+    # (the same cert it presents for its own inbound server TLS, at the
+    # tls-certs volume mount below) so this "just works" without any extra
+    # configuration -- override only to present a different client identity.
+    certFile: {{ .Values.fleetmetadatacache.valkeyTLS.certFile | default (printf "%s/tls.crt" (include "kubernaut.interServiceTLS.certDir" .)) | quote }}
+    keyFile: {{ .Values.fleetmetadatacache.valkeyTLS.keyFile | default (printf "%s/tls.key" (include "kubernaut.interServiceTLS.certDir" .)) | quote }}
     caFile: {{ .Values.fleetmetadatacache.valkeyTLS.caFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
 sync:
   interval: {{ $v.syncInterval | quote }}

--- a/charts/kubernaut/templates/hooks/migration-job.yaml
+++ b/charts/kubernaut/templates/hooks/migration-job.yaml
@@ -1,3 +1,4 @@
+{{- $v := include "kubernaut.mergedValues" (dict "root" . "service" "datastorage") | fromYaml -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -109,13 +110,24 @@ spec:
                   key: POSTGRES_PASSWORD
             - name: PGDATABASE
               value: {{ include "kubernaut.postgresql.database" . }}
+            # DD-PLATFORM-006 DA20 (kubernaut#2270, BR-NET-001/SC-8): same
+            # sslMode DataStorage's own runtime connection uses (both target
+            # the identical kubernaut.postgresql.host) -- PGSSLMODE is
+            # libpq's standard env var, so this also covers the `psql`
+            # heredoc below, not just goose's explicit connection string.
+            # Previously hardcoded to "disable", which this Decision Area's
+            # own hostssl-only pg_hba.conf now rejects outright (was missed
+            # when Postgres TLS was first wired -- caught by this session's
+            # CI must-gather RCA, not by design).
+            - name: PGSSLMODE
+              value: {{ $v.config.database.sslMode | quote }}
           command:
             - /bin/sh
             - -c
             - |
               set -e
 
-              GOOSE_DBSTRING="host=$PGHOST user=$PGUSER password=$PGPASSWORD dbname=$PGDATABASE sslmode=disable"
+              GOOSE_DBSTRING="host=$PGHOST user=$PGUSER password=$PGPASSWORD dbname=$PGDATABASE sslmode=$PGSSLMODE"
 
               # Issue #581: Fresh-vs-upgrade detection for future major-version baselines.
               # For minor releases, `goose up` handles both paths (fresh applies all;

--- a/charts/kubernaut/templates/hooks/tls-cert-job.yaml
+++ b/charts/kubernaut/templates/hooks/tls-cert-job.yaml
@@ -167,7 +167,11 @@ spec:
                   kubectl get secret authwebhook-tls -n "$NAMESPACE" -o jsonpath='{.data.ca\.crt}' | base64 -d > "$TMPDIR/ca.crt"
                 fi
 
-                for SVC_NAME in gateway-service data-storage-service kubernaut-agent fleetmetadatacache-service apifrontend valkey; do
+                # DD-PLATFORM-006 DA20 (kubernaut#2270): postgresql added
+                # alongside valkey -- SECRET_NAME derives to "postgresql-tls"
+                # automatically (no -service suffix to strip, same as
+                # apifrontend/valkey above).
+                for SVC_NAME in gateway-service data-storage-service kubernaut-agent fleetmetadatacache-service apifrontend valkey postgresql; do
                   SECRET_NAME="${SVC_NAME%-service}-tls"
                   [ "$SVC_NAME" = "data-storage-service" ] && SECRET_NAME="datastorage-tls"
                   [ "$SVC_NAME" = "kubernaut-agent" ] && SECRET_NAME="kubernautagent-tls"

--- a/charts/kubernaut/templates/infrastructure/postgresql.yaml
+++ b/charts/kubernaut/templates/infrastructure/postgresql.yaml
@@ -37,6 +37,42 @@ spec:
   selector:
     app: postgresql
 ---
+# DD-PLATFORM-006 DA20 (kubernaut#2270, BR-NET-001/SC-8, AU-9): custom
+# pg_hba.conf enforcing TLS on every TCP connection while leaving local
+# (Unix-socket) auth untouched -- empirically spiked this session against a
+# real postgres:16-alpine container. `local` stays trust-based because it
+# covers only two callers, neither of which supplies a password: this
+# Deployment's own readinessProbe/livenessProbe (`pg_isready`, socket-only,
+# unaffected by the hostssl rule below) and the postgres image's own
+# entrypoint bootstrap on first start. `hostssl` (not plain `host`) is the
+# only rule for network connections, so a client without TLS is rejected
+# with "no pg_hba.conf entry ... no encryption" rather than silently
+# allowed -- this is the assertion that actually encodes AU-9/SC-8's
+# "audit-of-record database rejects plaintext" acceptance criterion.
+# scram-sha-256 matches postgres:16-alpine's own default password_encryption
+# (the same hashing already used for the existing POSTGRES_PASSWORD-based
+# auth), not the spike's `trust` shortcut.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgresql-hba
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: postgresql
+    {{- include "kubernaut.labels" . | nindent 4 }}
+  annotations:
+    "argocd.argoproj.io/sync-wave": "-1"
+data:
+  pg_hba.conf: |
+    # Managed by the kubernaut Helm chart (DD-PLATFORM-006 Decision Area 20).
+    # Local (Unix-socket) connections stay trust-based -- covers this
+    # Deployment's own pg_isready probes and the image's own entrypoint
+    # bootstrap, neither of which supplies a password.
+    local   all             all                                     trust
+    # All TCP connections MUST use TLS (SC-8/AU-9) -- DataStorage's client
+    # connects with sslmode=require, closing kubernaut#2270.
+    hostssl all             all             all                     scram-sha-256
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -69,6 +105,26 @@ spec:
           imagePullPolicy: {{ include "kubernaut.imagePullPolicy" $ }}
           securityContext:
             {{- include "kubernaut.mergedSecurityContext" (dict "override" .Values.postgresql.containerSecurityContext "defaults" (dict "allowPrivilegeEscalation" false "readOnlyRootFilesystem" false "runAsNonRoot" true "runAsUser" 70)) | nindent 12 }}
+          # DD-PLATFORM-006 DA20 (kubernaut#2270): server-side TLS, mirroring
+          # DA8's treatment of Valkey. postgres:16-alpine's own entrypoint
+          # forwards leading "-c"-style args straight to the postgres server
+          # (same args-based pattern Valkey already uses above), so no
+          # command override is needed. ssl_cert_file/ssl_key_file read from
+          # the postgresql-tls Secret mounted below at 0640 (root:70,
+          # matching this Deployment's own fsGroup: 70) -- empirically
+          # confirmed this session to satisfy Postgres's own strict
+          # check_ssl_key_file_permissions() with zero initContainer needed.
+          # hba_file points at the ConfigMap above, which is hostssl-only
+          # for every TCP connection.
+          args:
+            - "-c"
+            - "ssl=on"
+            - "-c"
+            - "ssl_cert_file=/certs/tls.crt"
+            - "-c"
+            - "ssl_key_file=/certs/tls.key"
+            - "-c"
+            - "hba_file=/etc/postgresql-hba/pg_hba.conf"
           ports:
             - name: postgresql
               containerPort: 5432
@@ -93,8 +149,19 @@ spec:
           volumeMounts:
             - name: postgresql-data
               mountPath: {{ include "kubernaut.postgresql.dataDir" . }}
+            - name: postgresql-tls
+              mountPath: /certs
+              readOnly: true
+            - name: postgresql-hba
+              mountPath: /etc/postgresql-hba
+              readOnly: true
           resources:
             {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          # DA20 spike: pg_isready connects via the local Unix socket, whose
+          # auth is governed by pg_hba.conf's `local` rule (trust, above) --
+          # entirely separate from the `hostssl` rule enforced on TCP
+          # connections. Confirmed empirically that hostssl enforcement does
+          # not affect these probes, so no flags were added here.
           readinessProbe:
             exec:
               command: ["pg_isready", "-U", {{ $v.auth.username | quote }}, "-d", {{ $v.auth.database | quote }}]
@@ -113,6 +180,17 @@ spec:
         - name: postgresql-data
           persistentVolumeClaim:
             claimName: postgresql-data
+        - name: postgresql-tls
+          secret:
+            secretName: postgresql-tls
+            # DA20 spike: 0640 (root:70, this Deployment's own fsGroup)
+            # satisfies Postgres's check_ssl_key_file_permissions() --
+            # confirmed empirically with zero permission errors and no
+            # initContainer workaround needed.
+            defaultMode: 0640
+        - name: postgresql-hba
+          configMap:
+            name: postgresql-hba
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/kubernaut/templates/infrastructure/valkey.yaml
+++ b/charts/kubernaut/templates/infrastructure/valkey.yaml
@@ -71,13 +71,14 @@ spec:
           imagePullPolicy: {{ include "kubernaut.imagePullPolicy" $ }}
           securityContext:
             {{- include "kubernaut.mergedSecurityContext" (dict "override" .Values.valkey.containerSecurityContext "defaults" (dict "allowPrivilegeEscalation" false "readOnlyRootFilesystem" false "runAsNonRoot" true "runAsUser" 999)) | nindent 12 }}
-          # DD-PLATFORM-006 DA8: Valkey is TLS-only -- the plaintext port is
-          # disabled (--port 0). tls.crt/tls.key come from the valkey-tls
-          # Secret, but the CA cert comes from the shared tls-ca volume (the
-          # inter-service-ca ConfigMap) like every other service
-          # (datastorage/gateway/apifrontend/kubernaut-agent via
-          # kubernaut.tlsCaVolumeMount) -- NOT from a "ca.crt" key inside
-          # valkey-tls itself.
+          # DD-PLATFORM-006 DA8/DA19: Valkey is TLS-only -- the plaintext port
+          # is disabled (--port 0). tls.crt/tls.key come from the valkey-tls
+          # Secret (also reused below as Valkey's own client identity when it
+          # authenticates to itself for probes), but the CA cert comes from
+          # the shared tls-ca volume (the inter-service-ca ConfigMap) like
+          # every other service (datastorage/gateway/apifrontend/
+          # kubernaut-agent via kubernaut.tlsCaVolumeMount) -- NOT from a
+          # "ca.crt" key inside valkey-tls itself.
           #
           # PR #1790 round-9 RCA: valkey-tls previously carried the CA under
           # /certs/ca.crt sourced from its own Secret, which happened to work
@@ -96,9 +97,18 @@ spec:
           # E2E "PHASE 6 TLS re-sign" rollout timeouts, both downstream of
           # datastorage/etc never being able to reach a healthy Valkey) --
           # the recovery loop's force-delete-and-rewait could never actually
-          # fix it because the bug was deterministic, not transient. One-way
-          # TLS only (--tls-auth-clients no): clients verify Valkey's server
-          # cert, Valkey does not require client certs.
+          # fix it because the bug was deterministic, not transient.
+          #
+          # DD-PLATFORM-006 DA19 (kubernaut#2269, BR-NET-002/AC-4): mutual TLS
+          # is now mandatory (--tls-auth-clients yes) -- Valkey used to be
+          # one-way TLS only (clients verified Valkey's server cert, but any
+          # in-namespace pod could connect without presenting one of its
+          # own). DataStorage/FMC/APIFrontend already had all the client-side
+          # certFile/keyFile plumbing in place (unused until now), so closing
+          # this gap needed zero Go code changes -- only this flag flip plus
+          # pointing each client's already-live certFile/keyFile at its own
+          # already-issued, already-mounted per-service secret (see
+          # datastorage.yaml/fleetmetadatacache.yaml/apifrontend.yaml).
           args:
             - "--port"
             - "0"
@@ -111,7 +121,7 @@ spec:
             - "--tls-ca-cert-file"
             - "/etc/tls-ca/ca.crt"
             - "--tls-auth-clients"
-            - "no"
+            - "yes"
           ports:
             - name: valkey
               containerPort: 6380
@@ -126,14 +136,17 @@ spec:
             {{- toYaml .Values.valkey.resources | nindent 12 }}
           readinessProbe:
             exec:
-              command: ["valkey-cli", "--tls", "--cacert", "/etc/tls-ca/ca.crt", "-p", "6380", "ping"]
+              # DA19: Valkey now requires client certs even from itself --
+              # the probe must present the same valkey-tls cert/key it serves
+              # with, or it fails its own liveness/readiness checks.
+              command: ["valkey-cli", "--tls", "--cacert", "/etc/tls-ca/ca.crt", "--cert", "/certs/tls.crt", "--key", "/certs/tls.key", "-p", "6380", "ping"]
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
           livenessProbe:
             exec:
-              command: ["valkey-cli", "--tls", "--cacert", "/etc/tls-ca/ca.crt", "-p", "6380", "ping"]
+              command: ["valkey-cli", "--tls", "--cacert", "/etc/tls-ca/ca.crt", "--cert", "/certs/tls.crt", "--key", "/certs/tls.key", "-p", "6380", "ping"]
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5

--- a/charts/kubernaut/templates/interservice/leaf-certs.yaml
+++ b/charts/kubernaut/templates/interservice/leaf-certs.yaml
@@ -4,12 +4,27 @@
 # tls.certManager.issuerRef. ECDSA P-256 and DNS SANs mirror hook mode's
 # per-service certs exactly (tls-cert-job.yaml Section 2), so consumers
 # behave identically regardless of tls.mode.
+#
+# DD-PLATFORM-006 DA19/DA20 (kubernaut#2269/#2270): every leaf cert below
+# carries both "server auth" and "client auth" usages -- cert-manager's own
+# CertificateSpec.usages defaults to server-auth-only when unset, which
+# would silently defeat DA19's Valkey mTLS in cert-manager mode alone (the
+# three Go clients would authenticate to Valkey fine in tls.mode=hook, where
+# tls-cert-job.yaml's plain `kubectl create secret tls` imposes no usage
+# restriction, but fail the TLS handshake in tls.mode=cert-manager -- an
+# empirically-confirmed spike finding this session, not a hypothetical).
+# Every service below either dials Valkey directly (datastorage/
+# fleetmetadatacache/apifrontend) or could in principle need to present a
+# client identity to another inter-service peer, so all entries get both
+# usages uniformly rather than special-casing a subset.
 {{- range $i, $cert := list
     (dict "name" "gateway-tls" "dnsNameBase" "gateway-service")
     (dict "name" "datastorage-tls" "dnsNameBase" "data-storage-service")
     (dict "name" "kubernautagent-tls" "dnsNameBase" "kubernaut-agent")
     (dict "name" "fleetmetadatacache-tls" "dnsNameBase" "fleetmetadatacache-service")
     (dict "name" "valkey-tls" "dnsNameBase" "valkey")
+    (dict "name" "apifrontend-tls" "dnsNameBase" "apifrontend")
+    (dict "name" "postgresql-tls" "dnsNameBase" "postgresql")
   }}
 {{- if $i }}
 ---
@@ -45,6 +60,9 @@ spec:
     name: kubernaut-interservice-ca-issuer
     kind: Issuer
     group: cert-manager.io
+  usages:
+    - server auth
+    - client auth
   dnsNames:
     - {{ $cert.dnsNameBase }}
     - {{ $cert.dnsNameBase }}.{{ $.Release.Namespace }}

--- a/charts/kubernaut/tests/interservice_mtls_test.yaml
+++ b/charts/kubernaut/tests/interservice_mtls_test.yaml
@@ -119,6 +119,18 @@ tests:
       - equal:
           path: spec.issuerRef.kind
           value: Issuer
+      # DD-PLATFORM-006 DA19 (kubernaut#2269, BR-NET-002/AC-4): acceptance
+      # criterion -- a cert-manager-mode install produces certificates that
+      # are actually eligible to authenticate as a client, not just to serve
+      # TLS. cert-manager's own CertificateSpec.usages defaults to
+      # server-auth-only when unset, which would silently defeat DA19's
+      # Valkey mTLS in cert-manager mode alone (empirically confirmed this
+      # session, not a hypothetical).
+      - equal:
+          path: spec.usages
+          value:
+            - server auth
+            - client auth
       - contains:
           path: spec.dnsNames
           content: gateway-service
@@ -143,6 +155,11 @@ tests:
       - equal:
           path: spec.issuerRef.name
           value: kubernaut-interservice-ca-issuer
+      - equal:
+          path: spec.usages
+          value:
+            - server auth
+            - client auth
       - contains:
           path: spec.dnsNames
           content: data-storage-service
@@ -167,6 +184,11 @@ tests:
       - equal:
           path: spec.issuerRef.name
           value: kubernaut-interservice-ca-issuer
+      - equal:
+          path: spec.usages
+          value:
+            - server auth
+            - client auth
       - contains:
           path: spec.dnsNames
           content: kubernaut-agent
@@ -193,6 +215,11 @@ tests:
       - equal:
           path: spec.issuerRef.name
           value: kubernaut-interservice-ca-issuer
+      - equal:
+          path: spec.usages
+          value:
+            - server auth
+            - client auth
       - contains:
           path: spec.dnsNames
           content: fleetmetadatacache-service
@@ -222,6 +249,11 @@ tests:
       - equal:
           path: spec.issuerRef.name
           value: kubernaut-interservice-ca-issuer
+      - equal:
+          path: spec.usages
+          value:
+            - server auth
+            - client auth
       - contains:
           path: spec.dnsNames
           content: valkey
@@ -229,14 +261,82 @@ tests:
           path: spec.dnsNames
           content: valkey.NAMESPACE.svc.cluster.local
 
-  - it: "cert-manager mode: exactly 5 leaf Certificates rendered"
+  # DD-PLATFORM-006 DA19 spike finding: apifrontend-tls was already
+  # referenced by apifrontend.yaml's `tls-certs` volume (`optional: true`,
+  # secretName: apifrontend-tls) but had no corresponding entry here, so a
+  # cert-manager-mode install silently ran APIFrontend with no TLS certs at
+  # all (the volume mounted empty rather than failing) -- acceptance
+  # criterion: "every mTLS-participating service has a certificate in both
+  # tls.mode variants".
+  - it: "cert-manager mode: apifrontend-tls leaf Certificate uses the apifrontend-service DNS names"
+    set:
+      tls:
+        mode: cert-manager
+    template: templates/interservice/leaf-certs.yaml
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-tls
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.secretName
+          value: apifrontend-tls
+      - equal:
+          path: spec.issuerRef.name
+          value: kubernaut-interservice-ca-issuer
+      - equal:
+          path: spec.usages
+          value:
+            - server auth
+            - client auth
+      - contains:
+          path: spec.dnsNames
+          content: apifrontend
+      - contains:
+          path: spec.dnsNames
+          content: apifrontend.NAMESPACE.svc.cluster.local
+
+  # DD-PLATFORM-006 DA20 (kubernaut#2270): postgresql-tls closes the same
+  # hook/cert-manager parity gap DA19's spike found for apifrontend-tls --
+  # the bundled Postgres now genuinely requires this cert to start.
+  - it: "cert-manager mode: postgresql-tls leaf Certificate uses the postgresql DNS names"
+    set:
+      tls:
+        mode: cert-manager
+    template: templates/interservice/leaf-certs.yaml
+    documentSelector:
+      path: metadata.name
+      value: postgresql-tls
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.secretName
+          value: postgresql-tls
+      - equal:
+          path: spec.issuerRef.name
+          value: kubernaut-interservice-ca-issuer
+      - equal:
+          path: spec.usages
+          value:
+            - server auth
+            - client auth
+      - contains:
+          path: spec.dnsNames
+          content: postgresql
+      - contains:
+          path: spec.dnsNames
+          content: postgresql.NAMESPACE.svc.cluster.local
+
+  - it: "cert-manager mode: exactly 7 leaf Certificates rendered"
     set:
       tls:
         mode: cert-manager
     template: templates/interservice/leaf-certs.yaml
     asserts:
       - hasDocuments:
-          count: 5
+          count: 7
 
   # ── cert-manager mode: CA sync hook Job ─────────────────────────────────
   - it: "cert-manager mode: renders the CA-to-ConfigMap sync hook Job"

--- a/charts/kubernaut/tests/postgres_tls_test.yaml
+++ b/charts/kubernaut/tests/postgres_tls_test.yaml
@@ -2,6 +2,7 @@ suite: "DD-PLATFORM-006 Decision Area 20 (kubernaut#2270): PostgreSQL server-sid
 templates:
   - templates/infrastructure/postgresql.yaml
   - templates/hooks/tls-cert-job.yaml
+  - templates/hooks/migration-job.yaml
   - templates/datastorage/datastorage.yaml
 set:
   postgresql:
@@ -186,3 +187,50 @@ tests:
       - matchRegex:
           path: data['config.yaml']
           pattern: 'sslMode: verify-full'
+
+  # ── migration-job.yaml: PGSSLMODE regression guard (CI must-gather RCA) ─
+  # Round-1 CI run on this PR's own branch caught a real regression this
+  # helm-unittest suite did NOT: the db-migration Job's `migrate` container
+  # hardcoded `sslmode=disable` in its goose connection string, so it was
+  # rejected by the very `hostssl`-only pg_hba.conf this Decision Area just
+  # added ("no pg_hba.conf entry for host ..., no encryption" -- confirmed
+  # via must-gather pod logs from Helm Smoke Tests hook-mode run
+  # 32744324902, job 97489456779). initContainer wait-for-postgresql's
+  # pg_isready was unaffected (libpq's own sslmode=prefer default already
+  # negotiates TLS opportunistically), matching this Decision Area's earlier
+  # probe-compatibility spike -- only the goose-driven main container had a
+  # hardcoded override that bypassed that default. Fixed by sourcing
+  # PGSSLMODE from the same datastorage.config.database.sslMode value
+  # DataStorage's own runtime connection uses (both target the identical
+  # kubernaut.postgresql.host), via libpq's standard env var so it also
+  # covers the `psql` heredoc later in the same script.
+  - it: "db-migration Job's migrate container sources PGSSLMODE from database.sslMode (not hardcoded disable)"
+    template: templates/hooks/migration-job.yaml
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PGSSLMODE
+            value: "require"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'sslmode=disable'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'sslmode=\$PGSSLMODE'
+
+  - it: "db-migration Job's PGSSLMODE follows an explicit database.sslMode override"
+    template: templates/hooks/migration-job.yaml
+    set:
+      datastorage:
+        config:
+          database:
+            sslMode: "verify-full"
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PGSSLMODE
+            value: "verify-full"

--- a/charts/kubernaut/tests/postgres_tls_test.yaml
+++ b/charts/kubernaut/tests/postgres_tls_test.yaml
@@ -1,0 +1,188 @@
+suite: "DD-PLATFORM-006 Decision Area 20 (kubernaut#2270): PostgreSQL server-side TLS"
+templates:
+  - templates/infrastructure/postgresql.yaml
+  - templates/hooks/tls-cert-job.yaml
+  - templates/datastorage/datastorage.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  global:
+    llmProfiles:
+      primary:
+        provider: openai
+        model: gpt-4
+        credentialsSecretName: llm-credentials-primary
+  kubernautAgent:
+    llmProfileRef: primary
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+  tls:
+    mode: hook
+  workflowexecution:
+    fleet:
+      oauth2:
+        credentialsSecretRef: we-oauth2-creds
+tests:
+  # ── PostgreSQL Deployment: server-side TLS enabled ──────────────────────
+  # Acceptance criterion (BR-NET-001/SC-8, AU-9): the audit-of-record
+  # database encrypts its transport by default, with no operator action
+  # required -- matching the level of assurance already mandatory for
+  # Redis/Valkey (DA6). This helm-unittest proves the chart *renders* that
+  # wiring; the actual TLS handshake was proven empirically this session
+  # against a real postgres:16-alpine container (see the plan's Part 2
+  # spike), and is proven end-to-end by the existing E2E fullpipeline suite.
+  - it: "PostgreSQL Deployment enables SSL via ssl_cert_file/ssl_key_file/hba_file args"
+    template: templates/infrastructure/postgresql.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "-c"
+            - "ssl=on"
+            - "-c"
+            - "ssl_cert_file=/certs/tls.crt"
+            - "-c"
+            - "ssl_key_file=/certs/tls.key"
+            - "-c"
+            - "hba_file=/etc/postgresql-hba/pg_hba.conf"
+
+  # Acceptance criterion: the default install boots successfully with the
+  # new control active -- this exact defaultMode/fsGroup combination was
+  # empirically confirmed this session to satisfy Postgres's own strict
+  # check_ssl_key_file_permissions() with zero permission errors and no
+  # initContainer needed. This assertion exists to catch a future edit that
+  # loosens or drops defaultMode: 0640, which would otherwise crash-loop the
+  # audit store on Postgres's own key-permission check.
+  - it: "PostgreSQL Deployment mounts the postgresql-tls secret with defaultMode 0640"
+    template: templates/infrastructure/postgresql.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: postgresql-tls
+            mountPath: /certs
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: postgresql-tls
+            secret:
+              secretName: postgresql-tls
+              defaultMode: 0640
+
+  - it: "PostgreSQL Deployment mounts the postgresql-hba ConfigMap"
+    template: templates/infrastructure/postgresql.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: postgresql-hba
+            mountPath: /etc/postgresql-hba
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: postgresql-hba
+            configMap:
+              name: postgresql-hba
+
+  # Explicit regression guard, encoding this session's probe-compatibility
+  # spike finding (pg_isready connects via the local Unix socket, whose auth
+  # is governed by pg_hba.conf's `local` rule, entirely separate from the
+  # `hostssl` rule enforced on TCP connections) -- so a future contributor
+  # doesn't "fix" the probe based on the Valkey/DA8 precedent (which DID
+  # need --cert/--key added to its probes) and break it.
+  - it: "PostgreSQL readinessProbe/livenessProbe are unchanged (plain pg_isready, no TLS flags needed)"
+    template: templates/infrastructure/postgresql.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value: ["pg_isready", "-U", "slm_user", "-d", "action_history"]
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          value: ["pg_isready", "-U", "slm_user", "-d", "action_history"]
+
+  # Acceptance criterion (SC-8/AU-9): a network client without TLS cannot
+  # reach the audit database -- backed by this session's live
+  # rejection/acceptance spike against a real postgres:16-alpine container
+  # (sslmode=disable rejected with "no pg_hba.conf entry ... no
+  # encryption", sslmode=require accepted).
+  - it: "pg_hba ConfigMap enforces hostssl for TCP connections and leaves local (socket) connections untouched"
+    template: templates/infrastructure/postgresql.yaml
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      - matchRegex:
+          path: data['pg_hba.conf']
+          pattern: 'local\s+all\s+all\s+trust'
+      - matchRegex:
+          path: data['pg_hba.conf']
+          pattern: 'hostssl\s+all\s+all\s+all\s+scram-sha-256'
+      - notMatchRegex:
+          path: data['pg_hba.conf']
+          pattern: '\nhost\s+all\s+all\s+all'
+
+  # ── tls-cert-job.yaml: PostgreSQL added to the per-service cert loop ────
+  # Mirrors the existing "valkey" case in valkey_tls_test.yaml.
+  - it: "tls-cert-gen Job's inter-service cert loop includes postgresql (postgresql-tls secret, CA-signed like every other service)"
+    template: templates/hooks/tls-cert-job.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "for SVC_NAME in [^\\n]*\\bpostgresql\\b"
+
+  # ── values.schema.json: database.sslMode default flip (kubernaut#2270) ─
+  # Acceptance criterion (BR-NET-001): DataStorage's own client refuses to
+  # silently downgrade to plaintext. Safe to default to "require" now
+  # (unlike before this session's DA20 work) because the bundled Postgres
+  # genuinely supports TLS and its pg_hba.conf rejects unencrypted TCP
+  # connections outright -- flipping this default without the DA20 wiring
+  # above would have broken every default install.
+  - it: "database.sslMode defaults to require (not disable) when unset"
+    template: templates/datastorage/datastorage.yaml
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'sslMode: require'
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: 'sslMode: disable'
+
+  - it: "database.sslMode explicit override still wins over the default"
+    template: templates/datastorage/datastorage.yaml
+    set:
+      datastorage:
+        config:
+          database:
+            sslMode: "verify-full"
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'sslMode: verify-full'

--- a/charts/kubernaut/tests/valkey_tls_test.yaml
+++ b/charts/kubernaut/tests/valkey_tls_test.yaml
@@ -5,6 +5,7 @@ templates:
   - templates/hooks/tls-cert-job.yaml
   - templates/datastorage/networkpolicy.yaml
   - templates/apifrontend/networkpolicy.yaml
+  - templates/apifrontend/apifrontend.yaml
   - templates/fleetmetadatacache/fleetmetadatacache.yaml
   - templates/datastorage/datastorage.yaml
 set:
@@ -57,7 +58,28 @@ tests:
             - "--tls-ca-cert-file"
             - "/etc/tls-ca/ca.crt"
             - "--tls-auth-clients"
-            - "no"
+            - "yes"
+
+  # ── DD-PLATFORM-006 DA19 (kubernaut#2269, BR-NET-002/AC-4): Valkey mTLS ───
+  # Acceptance criterion: Valkey's own server configuration demands a client
+  # certificate on every connection -- this is the single line whose absence
+  # made #2269 a live gap. This helm-unittest proves the chart *renders* that
+  # demand; it does not itself open a socket -- the actual "cert-less client
+  # gets rejected" behavior was proven empirically this session against a
+  # real valkey-server container (see the plan's Part 1 spike), and is
+  # proven end-to-end by the existing E2E fullpipeline/fleet suites.
+  - it: "Valkey Deployment requires client certificates (--tls-auth-clients yes), closing kubernaut#2269"
+    template: templates/infrastructure/valkey.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[11]
+          value: "yes"
+      - notEqual:
+          path: spec.template.spec.containers[0].args[11]
+          value: "no"
 
   - it: "Valkey container no longer exposes a plaintext containerPort"
     template: templates/infrastructure/valkey.yaml
@@ -117,7 +139,12 @@ tests:
               name: inter-service-ca
               optional: true
 
-  - it: "Valkey readinessProbe/livenessProbe use TLS-aware valkey-cli against port 6380 with the shared CA"
+  # DD-PLATFORM-006 DA19: since Valkey now requires client certs from every
+  # connection (including its own healthcheck), the probes must present
+  # valkey-tls's cert/key too or Valkey would fail its own liveness/
+  # readiness checks -- acceptance criterion: "Valkey's own healthcheck
+  # continues to function once it must authenticate to itself".
+  - it: "Valkey readinessProbe/livenessProbe present a client cert (DA19) against port 6380 with the shared CA"
     template: templates/infrastructure/valkey.yaml
     documentSelector:
       path: kind
@@ -125,10 +152,10 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.exec.command
-          value: ["valkey-cli", "--tls", "--cacert", "/etc/tls-ca/ca.crt", "-p", "6380", "ping"]
+          value: ["valkey-cli", "--tls", "--cacert", "/etc/tls-ca/ca.crt", "--cert", "/certs/tls.crt", "--key", "/certs/tls.key", "-p", "6380", "ping"]
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command
-          value: ["valkey-cli", "--tls", "--cacert", "/etc/tls-ca/ca.crt", "-p", "6380", "ping"]
+          value: ["valkey-cli", "--tls", "--cacert", "/etc/tls-ca/ca.crt", "--cert", "/certs/tls.crt", "--key", "/certs/tls.key", "-p", "6380", "ping"]
 
   - it: "Valkey Service exposes port 6380, not 6379"
     template: templates/infrastructure/valkey.yaml
@@ -379,3 +406,137 @@ tests:
             configMap:
               name: inter-service-ca
               optional: true
+
+  # ── DD-PLATFORM-006 DA19: client certFile/keyFile default to each ────────
+  # service's own already-mounted cert -- acceptance criterion: "each
+  # service presents a cert by default, with no operator action required"
+  # (BR-NET-002, matching BR-PLATFORM-007's minimal-configuration mandate).
+  - it: "DataStorage redis.tls.certFile/keyFile default to DataStorage's own mounted datastorage-tls cert"
+    template: templates/datastorage/datastorage.yaml
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'certFile: "/etc/tls/tls\.crt"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'keyFile: "/etc/tls/tls\.key"'
+
+  - it: "DataStorage redis.tls.certFile/keyFile explicit override still wins over the default"
+    template: templates/datastorage/datastorage.yaml
+    set:
+      datastorage:
+        config:
+          redis:
+            tls:
+              certFile: "/etc/custom-cert/tls.crt"
+              keyFile: "/etc/custom-cert/tls.key"
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'certFile: "/etc/custom-cert/tls\.crt"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'keyFile: "/etc/custom-cert/tls\.key"'
+
+  - it: "FMC valkey.certFile/keyFile default to FMC's own mounted fleetmetadatacache-tls cert"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      fleetmetadatacache:
+        enabled: true
+        oauth2:
+          credentialsSecretRef: "fmc-creds"
+      global:
+        fleet:
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          oauth2:
+            enabled: true
+            tokenURL: "http://oauth.example.com"
+            credentialsSecretRef: "fleet-oauth2-creds"
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'certFile: "/etc/tls/tls\.crt"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'keyFile: "/etc/tls/tls\.key"'
+
+  - it: "FMC valkeyTLS.certFile/keyFile explicit override still wins over the default"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      fleetmetadatacache:
+        enabled: true
+        oauth2:
+          credentialsSecretRef: "fmc-creds"
+        valkeyTLS:
+          certFile: "/etc/custom-cert/tls.crt"
+          keyFile: "/etc/custom-cert/tls.key"
+      global:
+        fleet:
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          oauth2:
+            enabled: true
+            tokenURL: "http://oauth.example.com"
+            credentialsSecretRef: "fleet-oauth2-creds"
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'certFile: "/etc/custom-cert/tls\.crt"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'keyFile: "/etc/custom-cert/tls\.key"'
+
+  - it: "APIFrontend replayCache.tls.certFile/keyFile default to APIFrontend's own mounted apifrontend-tls cert when replayCache is enabled"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      apifrontend:
+        config:
+          auth:
+            replayCache:
+              enabled: true
+              tls:
+                enabled: true
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'certFile: "/etc/apifrontend/tls/tls\.crt"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'keyFile: "/etc/apifrontend/tls/tls\.key"'
+
+  - it: "APIFrontend replayCache.tls.certFile/keyFile explicit override still wins over the default"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: ConfigMap
+    set:
+      apifrontend:
+        config:
+          auth:
+            replayCache:
+              enabled: true
+              tls:
+                enabled: true
+                certFile: "/etc/custom-cert/tls.crt"
+                keyFile: "/etc/custom-cert/tls.key"
+    asserts:
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'certFile: "/etc/custom-cert/tls\.crt"'
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: 'keyFile: "/etc/custom-cert/tls\.key"'

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -1304,8 +1304,8 @@
               "properties": {
                 "sslMode": {
                   "type": "string",
-                  "default": "disable",
-                  "description": "PostgreSQL SSL mode"
+                  "default": "require",
+                  "description": "PostgreSQL SSL mode. DD-PLATFORM-006 DA20 (kubernaut#2270, BR-NET-001/SC-8): defaults to 'require' (encrypt, don't verify server identity) since the bundled PostgreSQL now has genuine server-side TLS wired (see templates/infrastructure/postgresql.yaml) and its pg_hba.conf rejects unencrypted TCP connections outright. A BYO PostgreSQL without TLS support is not a supported configuration -- enable TLS on it or set this to 'disable' explicitly at your own risk."
                 },
                 "maxOpenConns": {
                   "type": "integer",

--- a/docs/architecture/decisions/DD-PLATFORM-006-helm-chart-configuration-surface-reduction.md
+++ b/docs/architecture/decisions/DD-PLATFORM-006-helm-chart-configuration-surface-reduction.md
@@ -3,7 +3,13 @@
 **Status**: ✅ **IMPLEMENTED** (merged via [PR #1790](https://github.com/jordigilh/kubernaut/pull/1790))
 **Decision Date**: 2026-07-31 (merge date; Decision Area 14's materialized-defaults generator
 remains deferred to its own follow-up PR — see Status section below)
-**Version**: 5.13 (Decision Area 19 added: Valkey client authentication via mTLS, triaging issue
+**Version**: 5.14 (Decision Area 20 added: PostgreSQL server-side TLS, closing issue #2270 as a
+genuine chart-wiring fix rather than a client-side schema-default flip — the bundled Postgres had
+zero TLS wiring, structurally the same gap Decision Area 8 originally closed for Valkey. Decision
+Area 19's confidence raised 85% → 95% after a follow-up session's spikes closed both previously-
+residual risks (valkey-cli client-cert probe syntax; the break-glass runbook). Both implemented
+together in [PR #2272](https://github.com/jordigilh/kubernaut/pull/2272). Previously 5.13, Decision
+Area 19 added: Valkey client authentication via mTLS, triaging issue
 #2269 — two pre-implementation spikes found the requested `requirepass` fix would not actually
 close the gap (DataStorage's existing "mandatory" password is confirmed empirically inert against
 the chart's own Valkey — `go-redis` silently tolerates the AUTH failure), and that mTLS is both
@@ -1201,22 +1207,118 @@ half-built in this codebase:
    unauthenticated read/write path into fleet-wide cluster metadata reachable by any in-namespace
    pod, not a hypothetical.
 
-**Confidence**: 85% — the core finding (go-redis silently tolerates AUTH-without-requirepass; all
-three consumers already have live, dead `WithClientCert` wiring; hook-mode certs are EKU-unrestricted)
-is empirically verified against real code and a real container, not inferred. The residual 15% is
-implementation risk not yet spiked: (a) confirming `valkey-cli`'s own TLS client-cert flags work
-identically inside the actual probe `command:` syntax used in this chart, and (b) confirming no
-current legitimate consumer (operator debug tooling, `kubectl exec` + `valkey-cli` troubleshooting)
-depends on certificate-less access, which would need a documented break-glass procedure once
-`--tls-auth-clients yes` lands.
+**Confidence**: 95% (raised from 85% after a follow-up session's spikes closed both risks named
+below, prior to implementation) — the core finding (go-redis silently tolerates
+AUTH-without-requirepass; all three consumers already have live, dead `WithClientCert` wiring;
+hook-mode certs are EKU-unrestricted) is empirically verified against real code and a real
+container, not inferred. The originally-residual 15% named two specific implementation risks, both
+now closed:
+- **`valkey-cli` probe-syntax risk**: started a real `valkey/valkey:8-alpine` container with
+  `--tls-auth-clients yes` and CA-signed, EKU-unrestricted certs (mirroring `tls-cert-job.yaml`'s
+  actual output), and drove it with the exact `command:` array shape used in `valkey.yaml`'s
+  probes — no client cert rejects the connection (`Error: Server closed the connection`), a valid
+  client cert returns `PONG`, an unsigned/wrong client cert is rejected. A `go-redis` client built
+  with this repo's exact `TLSConfig` shape (mirroring `pkg/shared/tls.BuildTLSConfig`/
+  `WithClientCert`) got a hard TLS-handshake-level `tls: certificate required` with no cert —
+  unlike the `requirepass`/AUTH case above, where `go-redis` silently swallows the failure instead
+  of erroring.
+- **Break-glass/debug-access risk**: `docs/operations/runbooks/data-storage.md`'s existing
+  `kubectl exec ... -- openssl s_client` debug procedure was the only identified legitimate
+  certificate-less consumer (`test/infrastructure/datastorage.go`'s test-harness Redis is a wholly
+  separate, ad-hoc container, unaffected by this change). Updated the runbook to add the
+  now-required `-cert`/`-key` flags rather than leaving it broken — no separate break-glass
+  exception path was needed.
 
-**Related**: Postgres has an analogous, separate gap — `values.schema.json`'s
-`datastorage.config.database.sslMode` defaults to `"disable"` and is only forced non-disable by
-`Config.Validate()`'s `validateProductionConstraints()` when `Environment=="production"`, unlike
-Redis TLS which this chart hardcodes unconditionally (Decision Area 6). Raised during this
-Decision Area's triage but intentionally **out of scope here** — different mechanism (schema
-default + template change, no mTLS/cert questions), tracked as its own follow-up rather than
-expanding this Decision Area's blast radius.
+Implemented (together with Decision Area 20 below) in
+[PR #2272](https://github.com/jordigilh/kubernaut/pull/2272); `helm-unittest`/`helm lint`/
+`helm template` all validated across both `tls.mode` variants. The remaining, unclaimed proof tier
+is this repo's existing Kind-based E2E fullpipeline/fleet suites actually exercising the mTLS
+handshake end-to-end once that PR's CI runs.
+
+**Related**: Postgres had an analogous, separate gap, raised during this Decision Area's triage but
+intentionally scoped out of DA19 itself — see **Decision Area 20** below, which closes it.
+
+### Decision Area 20 — PostgreSQL Server-Side TLS (parity with Decision Area 8 for Valkey)
+
+**Finding, triaging [kubernaut#2270](https://github.com/jordigilh/kubernaut/issues/2270)**:
+`values.schema.json`'s `datastorage.config.database.sslMode` defaults to `"disable"`, and is only
+forced non-`disable` by `Config.Validate()`'s `validateProductionConstraints()` when
+`Environment=="production"` — unlike Redis TLS, which this chart hardcodes unconditionally
+regardless of environment (Decision Area 6). Issue #2270 initially framed this as a small fix: flip
+the schema default to `"require"`. That framing turned out to be wrong — `templates/infrastructure/
+postgresql.yaml` has **zero TLS wiring today**, and the bundled `postgres:16-alpine` genuinely
+cannot speak TLS as currently configured, so flipping the default alone would have broken every
+default install outright. Unlike the Valkey ACL case (#2271), this is **not** a product-capability
+gap: PostgreSQL has supported TLS natively for decades and `postgres:16-alpine` ships with it built
+in. It is an unconfigured-chart gap, structurally identical to the one Decision Area 8 closed for
+Valkey.
+
+**Validated by an end-to-end pre-implementation spike** against a real, unmodified
+`postgres:16-alpine` container (mirroring Decision Area 8's own spike structure):
+- **Key-file permission model** (the risk unique to Postgres, with no Valkey/Redis equivalent):
+  Postgres's `check_ssl_key_file_permissions()` (`src/backend/libpq/be-secure-common.c`) requires
+  the key file to be owned by either the running uid (mode `0600` or less) or by root/uid-0 (mode
+  `0640` or less, with the process's uid a member of the file's group). Staged a cert/key with
+  ownership `root:70`, mode `0640` — exactly what a Kubernetes Secret volume with `fsGroup: 70` +
+  `defaultMode: 0640` produces, reusing the `podSecurityContext` override this Decision Area
+  already documents for both `postgresql`/`valkey` (line 116 above). Postgres started cleanly with
+  **zero permission errors and no `initContainer` needed**.
+- **`hostssl`-only enforcement**: a custom `pg_hba.conf` with `local all all trust` + `hostssl all
+  all all trust` (no plain `host` rule) rejected a TCP client with `sslmode=disable`
+  (`no pg_hba.conf entry for host ..., no encryption`) and accepted one with `sslmode=require`;
+  `SHOW ssl;` confirmed `on`.
+- **Probe compatibility** (mirrors Decision Area 8's own probe-breakage precedent for Valkey, with
+  the opposite result): `pg_isready -U ... -d ...` run via local exec succeeded unmodified —
+  Postgres's `local` (Unix-socket) auth records are entirely separate from `host`/`hostssl` (TCP)
+  records, so **no probe changes were needed at all**, unlike Valkey, where the probes themselves
+  needed `--cert`/`--key` added once `--tls-auth-clients yes` landed.
+- **Client-side compatibility**: `pkg/datastorage/config`'s `Database.SSLMode` already flows
+  straight into the DSN (`config_accessors.go:153`) with no CA-path field, so `sslmode=require`
+  (encrypt, don't verify server identity) works with **zero Go changes**. `verify-ca`/`verify-full`
+  would need a new CA-path config field and were left out of scope — `require` matches the level of
+  assurance DataStorage's own Redis TLS client already accepts by default elsewhere in this chart.
+
+**Decision**: give the bundled PostgreSQL Deployment real, mandatory-on server-side TLS, mirroring
+Decision Area 8's treatment of Valkey:
+1. Issue a `postgresql-tls` cert via the same per-service cert infrastructure Decision Area 19
+   extended (both `tls.mode` variants) — `templates/hooks/tls-cert-job.yaml`'s hook-mode
+   `SVC_NAME` loop and `templates/interservice/leaf-certs.yaml`'s cert-manager-mode list.
+2. Mount it with `defaultMode: 0640` (root-owned, group-readable by the existing `fsGroup: 70`) —
+   no `initContainer`.
+3. Enable SSL via `-c ssl=on -c ssl_cert_file=... -c ssl_key_file=...` container args — the same
+   args-based pattern Valkey already uses.
+4. Enforce `hostssl`-only via a new `postgresql-hba` ConfigMap (`-c hba_file=...`), leaving `local`
+   (socket) auth untouched so `pg_isready` probes and the image's own bootstrap are unaffected.
+5. Flip `values.schema.json`'s `datastorage.config.database.sslMode` default from `"disable"` to
+   `"require"` — now safe to do unconditionally, since the bundled Postgres genuinely supports it;
+   a BYO PostgreSQL without TLS support becomes an explicitly unsupported configuration.
+
+**Options considered**:
+1. **Real server-side TLS, mirroring Decision Area 8 (selected)** — closes the gap PostgreSQL
+   actually has (an unconfigured chart, not a missing capability) with the identical
+   cert-issuance/rotation/mounting infrastructure Decision Area 19 already extended for Valkey;
+   `require` mode needs zero Go changes.
+2. Flip only the schema default, leave the chart's Postgres unconfigured for TLS — rejected: would
+   break every default install (`sslmode=require` against a server with no TLS listener fails to
+   connect at all), the exact problem this Decision Area's triage caught before it shipped.
+3. `verify-ca`/`verify-full` instead of `require` — rejected as this fix's target: needs a new
+   CA-path Go config field, out of scope for a transport-encryption gap-closure; deferred as a
+   stronger future upgrade once that field exists.
+4. Do nothing, document the gap only — rejected: DataStorage's Postgres is the audit-of-record
+   store (BR-AUDIT-005/ADR-034); shipping it with plaintext-by-default TCP auth is inconsistent
+   with Decision Area 6's unconditional Redis TLS mandate for the same threat model.
+
+**Confidence**: 92% — the full design (key permissions, `hostssl` enforcement, probe compatibility,
+client compatibility) was empirically validated end-to-end against a real container, not just
+reasoned about. The residual 8% is ordinary chart-wiring implementation risk (getting the exact
+volume/ConfigMap YAML right), not design-level risk. Implemented alongside Decision Area 19 in
+[PR #2272](https://github.com/jordigilh/kubernaut/pull/2272); `helm-unittest`/`helm lint`/
+`helm template` all validated across `postgresql.enabled` true/false and both `tls.mode` variants —
+the remaining, unclaimed proof tier is this repo's existing Kind-based E2E fullpipeline suite
+actually exercising the Postgres TLS handshake end-to-end once that PR's CI runs.
+
+**Related**: this closes the gap Decision Area 19 explicitly deferred (see its own "Related" note
+above) rather than expanding that Decision Area's blast radius after the fact.
 
 ---
 

--- a/docs/architecture/decisions/DD-PLATFORM-006-helm-chart-configuration-surface-reduction.md
+++ b/docs/architecture/decisions/DD-PLATFORM-006-helm-chart-configuration-surface-reduction.md
@@ -3,7 +3,12 @@
 **Status**: ✅ **IMPLEMENTED** (merged via [PR #1790](https://github.com/jordigilh/kubernaut/pull/1790))
 **Decision Date**: 2026-07-31 (merge date; Decision Area 14's materialized-defaults generator
 remains deferred to its own follow-up PR — see Status section below)
-**Version**: 5.12 (Decision Area 18 added: source-bound `jti` replay detection, implementing
+**Version**: 5.13 (Decision Area 19 added: Valkey client authentication via mTLS, triaging issue
+#2269 — two pre-implementation spikes found the requested `requirepass` fix would not actually
+close the gap (DataStorage's existing "mandatory" password is confirmed empirically inert against
+the chart's own Valkey — `go-redis` silently tolerates the AUTH failure), and that mTLS is both
+safer and cheaper since all three Valkey consumers already have live, unactivated `WithClientCert`
+wiring. Previously 5.12, Decision Area 18 added: source-bound `jti` replay detection, implementing
 Decision Area 16's deferred Option 3 — issue #1999, confirmed as a live production incident.
 Previously 5.11, Decision Area 13 addendum, round-16 RCA: FMC was a third Go Valkey client missed
 by this Decision Area's original DataStorage/APIFrontend-only census — fixed with the identical
@@ -1076,6 +1081,142 @@ low-probability exposure for this product's actual client population (browser co
 server-to-server agents/CLI — not mobile), and strictly smaller in both likelihood and blast
 radius than the "every 2nd request, unconditionally" failure mode this DD confirms already broke
 a live cluster.
+
+### Decision Area 19 — Valkey Client Authentication via mTLS (closes the DA6/DA8 gap between mandatory transport encryption and actual client authentication)
+
+**Finding, triaging [kubernaut#2269](https://github.com/jordigilh/kubernaut/issues/2269)**: Decision
+Area 8 made the chart's own Valkey deployment TLS-only and Decision Area 6 mandated
+`datastorage.config.redis.tls.enabled` as a security-relevant, non-optional toggle — but neither
+Decision Area evaluated Valkey **client authentication** as its own control. `--tls-auth-clients
+no` (Decision Area 8's own choice, re-confirmed by its spike: *"a client presenting no certificate
+still succeeds"*) means TLS here only proves the *server's* identity to the client, never the
+reverse. FMC's client (`pkg/fleet/fmc/valkey_writer.go`, `pkg/fleet/scopecache/valkey_reader.go`)
+has no authentication support at all — no password, no client cert. Issue #2269 (filed from
+`kubernaut-operator`, discovered while wiring `spec.valkey.tls` through to FMC — see
+`kubernaut-operator#398`/`kubernaut-operator#397`) asks for password/secret-ref support to be
+added to close this.
+
+**Two pre-implementation spikes, run against this repo's real `go-redis/v9` dependency and a real
+`valkey/valkey:8-alpine` container (not simulated), found the obvious fix — adding a password —
+would not actually be a fix**, and surfaced a materially cheaper, safer alternative already
+half-built in this codebase:
+
+- **Spike 1 (does DataStorage's existing "mandatory" Valkey password do anything today?)**:
+  `pkg/datastorage/config.RedisConfig`'s `SecretsFile`/`PasswordKey` are already unconditionally
+  required by `LoadSecrets()` (`pkg/datastorage/config/config_secrets.go`) — no toggle, and the
+  chart pre-validates the backing `valkey-secret` exists before install
+  (`templates/infrastructure/secrets.yaml`). But `templates/infrastructure/valkey.yaml`'s container
+  `args` set only `--tls-port`/`--tls-cert-file`/`--tls-key-file`/`--tls-ca-cert-file`/
+  `--tls-auth-clients no` — **no `--requirepass` or ACL of any kind**. Confirmed live:
+  `valkey-cli -a somepassword ping` against an unmodified `valkey/valkey:8-alpine` with no
+  `requirepass` configured returns `AUTH failed: ERR AUTH <password> called without any password
+  configured...` **and then still returns `PONG`**. A minimal Go program using this repo's exact
+  `github.com/redis/go-redis/v9` dependency, `Password: "somepassword"` against the same
+  unconfigured server, got `Ping()` → `err=<nil>` and `Set()` → `err=<nil>`. **`go-redis` silently
+  swallows the AUTH failure and proceeds.** Conclusion: DataStorage's existing "mandatory" password
+  requirement is enforced only at config-load time (ADR-030 Section 6's "don't embed secrets in
+  ConfigMap YAML" hygiene rule) and provides **zero actual protection** against the chart's own
+  Valkey — the server has never been told to require it. Simply adding the same pattern to FMC (the
+  issue's literal ask) would reproduce this same non-functional theater, not close the gap.
+- **Spike 2 (is mTLS a smaller lift than fixing `requirepass` properly?)**: `requirepass` has no
+  file-based injection mechanism in vanilla Valkey/Redis (no `--requirepass-file`), so a real fix
+  would require the password to flow through a `sh -c`-wrapped command with an env var sourced from
+  `secretKeyRef` — but the existing `valkey-secret` stores the password *inside* a YAML blob
+  (`valkey-secrets.yaml: "password: <value>"`, for the Go client's `secretsFile` pattern), not a
+  flat key `secretKeyRef` can mount directly, so this would also require changing the documented
+  Secret contract (`templates/infrastructure/secrets.yaml`) to a dual-key format. It would also need
+  a net-new rotation story (no rotation job exists for a Valkey password today) and reproduces the
+  exact class of risk `templates/infrastructure/secrets.yaml`'s own header comment says this chart
+  deliberately avoids (*"Password leaks via rendered Helm templates"*) — this time via process
+  args/env instead of Helm state, but the same underlying concern. By contrast, **every Valkey
+  client in this codebase already has live, wired mTLS support that has simply never been
+  activated**:
+  - `pkg/datastorage/config.RedisTLSConfig.BuildTLSConfig()` already builds
+    `tls.Certificates` from `CertFile`/`KeyFile` when both are set
+    (`pkg/datastorage/config/config.go`), and `pkg/datastorage/server/server_construction.go`
+    already calls it unconditionally and assigns the result to `redisOpts.TLSConfig`.
+  - `cmd/fleetmetadatacache/main.go`'s `buildValkeyTLSConfig` already calls
+    `sharedtls.BuildTLSConfig(tlsCfg.CAFile, sharedtls.WithClientCert(tlsCfg.CertFile,
+    tlsCfg.KeyFile))` unconditionally whenever TLS is enabled.
+  - `cmd/apifrontend/auth_wiring.go`'s `newValkeyReplayCache` does the identical
+    `sharedtls.BuildTLSConfig(..., WithClientCert(cfg.TLS.CertFile, cfg.TLS.KeyFile))` call.
+
+  All three `CertFile`/`KeyFile` fields are explicitly documented as *"kept for optional BYO
+  Valkey/Redis requiring mTLS"* (Decision Area 8) — anticipated from day one, never activated
+  because the server never required it. Reusing them costs a server-side flag flip
+  (`--tls-auth-clients yes`) plus chart config wiring, with **zero Go code changes** to any of the
+  three consumers.
+- **Spike 3 (are the existing per-service certs even eligible for client-auth reuse?)**: checked
+  how this chart's inter-service leaf certs are minted in both `tls.mode` variants.
+  `templates/hooks/tls-cert-job.yaml`'s raw `openssl req`/`openssl x509` commands set no
+  `extendedKeyUsage` at all — per RFC 5280 §4.2.1.12, an absent EKU extension means the certificate
+  is valid for any purpose, so hook-mode's existing `gateway-tls`/`datastorage-tls`/
+  `fleetmetadatacache-tls`/`kubernautagent-tls` certs are safe to reuse unmodified as Valkey mTLS
+  client certs. **`tls.mode=cert-manager` is different**: `templates/interservice/leaf-certs.yaml`'s
+  `Certificate` specs set no `usages` field, and cert-manager's own documentation states *"unless
+  any number of usages has been set, cert-manager will set the default requested usages of `digital
+  signature`, `key encipherment`, and **`server auth`**"* — `client auth` is never implied by
+  default (confirmed via cert-manager/cert-manager#2407, the exact upstream issue this ambiguity
+  caused for other projects). Left as-is, cert-manager-mode certs would carry a `server
+  auth`-restricted EKU and fail as Valkey mTLS client certs. Additionally, `leaf-certs.yaml`'s
+  static cert list has no `apifrontend-tls` entry at all, unlike the hook-mode loop (which already
+  includes `apifrontend`, added independently by #1755 — see Decision Area 12) — a pre-existing
+  hook/cert-manager parity gap that this Decision Area's scope now depends on closing, since
+  APIFrontend's replay cache is a third Valkey mTLS consumer.
+
+**Decision**: Alternative 1 — Valkey mTLS, not a password/ACL.
+
+1. `templates/infrastructure/valkey.yaml`: flip `--tls-auth-clients no` → `yes`; readiness/liveness
+   probes gain the cert/key flags Valkey's own `valkey-tls` secret already provides (Valkey
+   authenticating as itself for its own healthcheck).
+2. `templates/interservice/leaf-certs.yaml`: add `usages: [server auth, client auth]` to every
+   entry (hook mode is unaffected — already unrestricted, but explicit usages are added there too
+   for defense-in-depth clarity, not because they're required), and add the missing
+   `apifrontend-tls` entry for hook/cert-manager parity.
+3. `templates/datastorage/datastorage.yaml`, `templates/fleetmetadatacache/fleetmetadatacache.yaml`,
+   `templates/apifrontend/apifrontend.yaml`: set each service's `certFile`/`keyFile` to its own
+   already-issued, already-mounted per-service TLS secret (no new cert, no new volume mount for
+   DataStorage/APIFrontend which already mount their own cert for their own server-side TLS; FMC
+   needs its `ValkeyTLSConfig` rendering wired to do the same, since only `caFile` is populated
+   today).
+4. `pkg/fleet/fmc/config.ValkeyConfig`/chart rendering: complete the issue #2269 ask by wiring
+   `CertFile`/`KeyFile` through (the Go-side `WithClientCert` call already exists — this is a
+   config-population gap only, mirroring the DataStorage/APIFrontend pattern above).
+
+**Options considered**:
+1. **Valkey mTLS, reusing each service's existing per-service TLS cert (selected)** — closes the
+   authentication gap for all three current Valkey consumers (DataStorage, FMC, APIFrontend) with a
+   single server-side flag flip and config-only client changes; reuses already-solved cert
+   issuance, rotation (`tls-cert-job.yaml`'s existing 30-day-checkend renewal), and mounting
+   infrastructure; avoids any new secret format, injection mechanism, or rotation story.
+2. `requirepass` (shared password), as issue #2269 literally requested — rejected per Spike 2/3
+   above: requires inventing a new file-safe injection mechanism Valkey doesn't natively support,
+   a breaking change to the documented `valkey-secret` contract, and a net-new rotation story,
+   while providing weaker security (one shared secret vs. per-workload cryptographic identity) for
+   strictly more implementation cost than option 1.
+3. Valkey ACL (per-user, mapped to AC-6 least privilege) — a strictly stronger future upgrade once
+   mTLS identity exists (map client cert CN to a scoped ACL user), but is new capability, not
+   gap-closure; deferred as its own follow-up rather than blocking this fix.
+4. Do nothing beyond documenting the gap — rejected: issue #2269 identifies a real, live
+   unauthenticated read/write path into fleet-wide cluster metadata reachable by any in-namespace
+   pod, not a hypothetical.
+
+**Confidence**: 85% — the core finding (go-redis silently tolerates AUTH-without-requirepass; all
+three consumers already have live, dead `WithClientCert` wiring; hook-mode certs are EKU-unrestricted)
+is empirically verified against real code and a real container, not inferred. The residual 15% is
+implementation risk not yet spiked: (a) confirming `valkey-cli`'s own TLS client-cert flags work
+identically inside the actual probe `command:` syntax used in this chart, and (b) confirming no
+current legitimate consumer (operator debug tooling, `kubectl exec` + `valkey-cli` troubleshooting)
+depends on certificate-less access, which would need a documented break-glass procedure once
+`--tls-auth-clients yes` lands.
+
+**Related**: Postgres has an analogous, separate gap — `values.schema.json`'s
+`datastorage.config.database.sslMode` defaults to `"disable"` and is only forced non-disable by
+`Config.Validate()`'s `validateProductionConstraints()` when `Environment=="production"`, unlike
+Redis TLS which this chart hardcodes unconditionally (Decision Area 6). Raised during this
+Decision Area's triage but intentionally **out of scope here** — different mechanism (schema
+default + template change, no mTLS/cert questions), tracked as its own follow-up rather than
+expanding this Decision Area's blast radius.
 
 ---
 

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -174,7 +174,7 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `config.database.connMaxLifetime` | string | Maximum connection lifetime | `"1h"` | No |
 | `config.database.maxIdleConns` | integer | Maximum idle database connections | `20` | No |
 | `config.database.maxOpenConns` | integer | Maximum open database connections | `100` | No |
-| `config.database.sslMode` | string | PostgreSQL SSL mode | `"disable"` | No |
+| `config.database.sslMode` | string | PostgreSQL SSL mode. DD-PLATFORM-006 DA20 (kubernaut#2270, BR-NET-001/SC-8): defaults to 'require' (encrypt, don't verify server identity) since the bundled PostgreSQL now has genuine server-side TLS wired (see templates/infrastructure/postgresql.yaml) and its pg_hba.conf rejects unencrypted TCP connections outright. A BYO PostgreSQL without TLS support is not a supported configuration -- enable TLS on it or set this to 'disable' explicitly at your own risk. | `"require"` | No |
 | `config.redis.dlqMaxLen` | integer | #1048 Phase 5 / AU-11: Redis DLQ MAXLEN bound | `10000` | No |
 | `config.redis.tls.caFile` | string | CA bundle to verify Redis server | `""` | No |
 | `config.redis.tls.certFile` | string | Client certificate file path (mTLS) | `""` | No |

--- a/docs/operations/runbooks/data-storage.md
+++ b/docs/operations/runbooks/data-storage.md
@@ -255,10 +255,13 @@ When Redis TLS is enabled (`redis.tls.enabled: true`), the Data Storage service 
    kubectl exec -n kubernaut-system deploy/datastorage -- ls -la /etc/redis/
    ```
 
-3. Test TLS connectivity directly:
+3. Test TLS connectivity directly. DD-PLATFORM-006 DA19 (kubernaut#2269) made Valkey mTLS
+   (client-certificate authentication) mandatory, so `-cert`/`-key` must be supplied or the
+   handshake fails with `Server closed the connection` even with a correct CA:
    ```bash
    kubectl exec -n kubernaut-system deploy/datastorage -- \
-     openssl s_client -connect valkey:6379 -CAfile /etc/redis/ca.crt
+     openssl s_client -connect valkey:6380 -CAfile /etc/tls-ca/ca.crt \
+       -cert /etc/tls/tls.crt -key /etc/tls/tls.key
    ```
 
 ### Resolution


### PR DESCRIPTION
## Summary

Closes #2269, closes #2270.

Two related transport-security gaps in the bundled Helm chart, both triaged and spiked this session (see [DD-PLATFORM-006 Decision Area 19](docs/architecture/decisions/DD-PLATFORM-006-helm-chart-configuration-surface-reduction.md#decision-area-19--valkey-client-authentication-via-mtls-closes-the-da6da8-gap-between-mandatory-transport-encryption-and-actual-client-authentication) for the full write-up):

**Valkey mTLS client authentication (#2269, DA19)**
- The chart's Valkey was TLS-only but `--tls-auth-clients no` -- any in-namespace pod could connect without presenting a client cert. The issue's literal ask (a `requirepass`) was spiked and found to be a dead end: `go-redis` silently tolerates AUTH failures against a server with no `requirepass` configured, and the chart never set one, so DataStorage's existing "mandatory" password provides zero actual protection today.
- Fixed via mTLS instead: flipped `--tls-auth-clients` to `yes` and pointed DataStorage/FMC/APIFrontend's already-live (but previously dormant) `WithClientCert` TLS config at each service's own already-issued, already-mounted per-service secret. **Zero Go code changes.**
- Along the way, found and fixed a latent `tls.mode=cert-manager` gap: cert-manager defaults `Certificate.usages` to server-auth-only when unset, which would have silently defeated client mTLS in that mode alone. All 7 leaf certs now explicitly carry `usages: [server auth, client auth]`, and the missing `apifrontend-tls`/`postgresql-tls` cert-manager entries were added for hook/cert-manager parity.

**PostgreSQL server-side TLS (#2270, DA20)**
- `datastorage.config.database.sslMode` defaulted to `disable`. Flipping it to `require` outright would have broken every default install, because the bundled PostgreSQL deployment had **zero server-side TLS wiring** -- this was a chart gap, not a PostgreSQL limitation.
- Added a `postgresql-hba` ConfigMap enforcing `hostssl` (TLS required) on every TCP connection while leaving `local` (Unix-socket) auth untouched, since that's the only path used by `pg_isready` probes and the image's own bootstrap. Mounted the new `postgresql-tls` secret (`defaultMode: 0640`) and enabled `ssl_cert_file`/`ssl_key_file`/`hba_file`.
- Empirically spiked against a real `postgres:16-alpine` container this session: confirmed `pg_isready` is unaffected by `hostssl` enforcement, and Postgres accepts the `0640`/`root:70` key permissions Kubernetes produces via `fsGroup: 70` with no `initContainer` workaround needed.
- `sslMode` schema default now flips to `require`; a BYO PostgreSQL without TLS support is documented as an unsupported configuration.

**Deferred (tracked separately, intentionally out of scope here)**
- Valkey ACL / CN-mapped per-user auth (#2271) -- the required `tls-auth-clients-user CN` directive needs Valkey 9.0.2+, but the chart pins `valkey:8-alpine`; needs its own upgrade spike first.
- `kubernaut-docs` update for the new TLS requirements -- tracked as jordigilh/kubernaut-docs#229.

## Business requirements / compliance mapping

- BR-NET-002 / AC-4 (information flow enforcement): Valkey mTLS
- BR-NET-001 / SC-8 (transmission confidentiality), AU-9 (protection of audit information): PostgreSQL TLS enforcement

## Test plan

- [x] `helm unittest` -- 613/613 tests passing across 75 suites, including new/extended coverage in `valkey_tls_test.yaml`, `interservice_mtls_test.yaml`, and new `postgres_tls_test.yaml`
- [x] `helm lint` passes for both `tls.mode: hook` and `tls.mode: cert-manager`
- [x] `helm template` rendered and manually verified across all 4 combinations of `tls.mode` × `postgresql.enabled` (hook/cert-manager × bundled/BYO Postgres)
- [x] `check-helm-coverage` and `verify-helm-defaults-parity` both pass