### PR TITLE
fix(aianalysis,workflowexecution): CEL nullable-field self==oldSelf false-positive causing infinite reconcile loop (#2284)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -982,6 +982,70 @@ jobs:
       - name: Cleanup
         if: always()
         run: podman ps -a --filter "name=${{ matrix.service }}-" --format "{{.Names}}" | xargs -r podman rm -f
+
+  # ========================================
+  # Issue #2284 CEL nullable-field regression guard
+  #
+  # The integration-tests matrix above always resolves KUBEBUILDER_ASSETS via
+  # a floating, unpinned `setup-envtest use -p path` (currently K8s v1.36.x,
+  # derived from this repo's k8s.io/api go.mod pin) -- which does NOT
+  # reproduce the K8s v1.31.x CEL evaluator bug that caused #2284's infinite
+  # reconcile loop in production (OCP 4.18.44 / K8s v1.31.14). This
+  # dedicated job pins envtest to v1.31.0 and runs only the two regression
+  # specs added for this issue, so a future regression of the has()-guarded
+  # CEL rewrite is caught without duplicating the full aianalysis/
+  # workflowexecution IT suites at a second K8s version.
+  # ========================================
+  cel-immutability-regression:
+    name: CEL Immutability Regression (K8s v1.31.0, #2284)
+    needs: [detect-changes, unit-tests, build-images, build-infra-images]
+    if: needs.detect-changes.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      KUBERNAUT_CI_ARTIFACT_TAG: ${{ needs.build-images.outputs.tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          submodules: true
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.6'
+      - name: Install Podman
+        uses: ./.github/actions/install-podman
+      - name: Load pre-built images (artifact-based, no registry)
+        uses: ./.github/actions/load-ci-images
+      - name: Run CEL immutability regression guard (K8s v1.31.0 pinned)
+        run: |
+          make test-integration-cel-immutability-regression 2>&1 | tee cel-immutability-regression.log
+          exit ${PIPESTATUS[0]}
+      - name: Upload test log on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cel-immutability-regression-log-${{ github.run_id }}
+          path: cel-immutability-regression.log
+          retention-days: 14
+          if-no-files-found: ignore
+      - name: Collect must-gather logs on failure
+        if: failure() || cancelled()
+        run: |
+          if [ -d "/tmp/kubernaut-must-gather" ]; then
+            TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+            tar -czf must-gather-cel-immutability-regression-${TIMESTAMP}.tar.gz -C /tmp kubernaut-must-gather/
+          fi
+      - name: Upload must-gather logs as artifacts
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: must-gather-logs-cel-immutability-regression-${{ github.run_id }}
+          path: must-gather-*.tar.gz
+          retention-days: 14
+          if-no-files-found: warn
+      - name: Cleanup
+        if: always()
+        run: podman ps -a --filter "name=aianalysis-" --format "{{.Names}}" | xargs -r podman rm -f; podman ps -a --filter "name=workflowexecution-" --format "{{.Names}}" | xargs -r podman rm -f
+
   # ========================================
   # STAGE 4: E2E TESTS (PARALLEL)
   # Matrix job, 11 services in parallel (~30 min each)
@@ -2115,7 +2179,7 @@ jobs:
   # ========================================
   summary:
     name: Test Suite Summary
-    needs: [detect-changes, lint-go, unit-tests, build-images, build-infra-images, integration-tests, e2e-tests, helm-unittest, helm-smoke-test, must-gather-e2e-test]
+    needs: [detect-changes, lint-go, unit-tests, build-images, build-infra-images, integration-tests, cel-immutability-regression, e2e-tests, helm-unittest, helm-smoke-test, must-gather-e2e-test]
     if: always() && needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -2371,6 +2435,20 @@ jobs:
             exit 1
           fi
 
+          # Check for CEL immutability regression guard (Issue #2284)
+          if [ "${{ needs.cel-immutability-regression.result }}" == "failure" ]; then
+            echo ""
+            echo "❌ CEL immutability regression guard failed (Issue #2284) - K8s v1.31.0-pinned nullable-field check"
+            exit 1
+          elif [ "${{ needs.cel-immutability-regression.result }}" == "skipped" ]; then
+            echo ""
+            echo "⏭️  CEL immutability regression guard skipped (dependencies failed)"
+          elif [ "${{ needs.cel-immutability-regression.result }}" == "cancelled" ]; then
+            echo ""
+            echo "⚠️  CEL immutability regression guard cancelled"
+            exit 1
+          fi
+
           # Check for E2E tests (handle skipped if dependencies failed)
           if [ "${{ needs.e2e-tests.result }}" == "failure" ]; then
             echo ""
@@ -2419,6 +2497,7 @@ jobs:
           # Final result
           echo ""
           if [ "${{ needs.integration-tests.result }}" == "success" ] && \
+             [ "${{ needs.cel-immutability-regression.result }}" == "success" ] && \
              [ "${{ needs.e2e-tests.result }}" == "success" ] && \
              [ "${{ needs.helm-unittest.result }}" == "success" ] && \
              [ "${{ needs.helm-smoke-test.result }}" == "success" ]; then
@@ -2442,7 +2521,7 @@ jobs:
     if: always()
     needs: [detect-changes, lint-go, license-scan, unit-tests, build-images,
             build-infra-images,
-            integration-tests, e2e-tests, helm-unittest, helm-smoke-test,
+            integration-tests, cel-immutability-regression, e2e-tests, helm-unittest, helm-smoke-test,
             must-gather-e2e-test, summary]
     runs-on: ubuntu-latest
     steps:
@@ -2462,6 +2541,7 @@ jobs:
           echo "  build-images:         ${{ needs.build-images.result }}"
           echo "  build-infra:          ${{ needs.build-infra-images.result }}"
           echo "  integration-tests:    ${{ needs.integration-tests.result }}"
+          echo "  cel-immut-regression: ${{ needs.cel-immutability-regression.result }}"
           echo "  e2e-tests:            ${{ needs.e2e-tests.result }}"
           echo "  helm-unittest:        ${{ needs.helm-unittest.result }}"
           echo "  helm-smoke-test:      ${{ needs.helm-smoke-test.result }}"

--- a/Makefile
+++ b/Makefile
@@ -416,6 +416,28 @@ test-integration-%: generate ginkgo setup-envtest ensure-coverage-dirs ## Run in
 	fi
 
 
+# Issue #2284 CEL nullable-field regression guard (K8s v1.31.x pinned).
+#
+# ENVTEST_K8S_VERSION above floats with this repo's k8s.io/api go.mod pin
+# (currently derived as v1.36.x), which does NOT reproduce the K8s v1.31.x
+# CEL evaluator bug where whole-object "self == oldSelf" XValidation rules
+# spuriously reject identical objects when a nullable:true field
+# (WorkflowSnapshot.DeclaredParameterNames) holds nil on both sides. That
+# gap is exactly why CI never caught Issue #2284's infinite reconcile loop
+# before it reached production (OCP 4.18.44 / K8s v1.31.14). This target
+# pins envtest to v1.31.0 (the confirmed-affected production version) and
+# runs only the two dedicated regression specs (IT-AA-2284-001,
+# IT-WFE-2284-001) rather than the full IT suites, so CI catches any future
+# regression of the has()-guarded CEL rewrite without paying the cost of
+# running both full suites twice per version.
+.PHONY: test-integration-cel-immutability-regression
+test-integration-cel-immutability-regression: generate ginkgo setup-envtest ensure-coverage-dirs ## Issue #2284: K8s v1.31.0-pinned CEL nullable-field regression guard
+	@echo "════════════════════════════════════════════════════════════════════════"
+	@echo "🧪 Issue #2284 CEL nullable-field regression guard (pinned K8s v1.31.0)"
+	@echo "════════════════════════════════════════════════════════════════════════"
+	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use 1.31.0 -p path)" $(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_INTEGRATION) --focus='IT-AA-2284-001' ./test/integration/aianalysis/...
+	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use 1.31.0 -p path)" $(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_INTEGRATION) --focus='IT-WFE-2284-001' ./test/integration/workflowexecution/...
+
 # Kubernaut Agent integration tests: internal code lives at internal/kubernautagent/ (not internal/controller/)
 .PHONY: test-integration-kubernautagent
 test-integration-kubernautagent: generate ginkgo setup-envtest ensure-coverage-dirs ## Run kubernaut agent integration tests (coverpkg: pkg + internal/kubernautagent)

--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -783,7 +783,15 @@ type RemediationTarget struct {
 
 // SelectedWorkflow contains the AI-selected workflow for execution
 // DD-CONTRACT-002: Output format for RO to create WorkflowExecution
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.selectedAt) || self == oldSelf",message="selectedWorkflow is immutable once selectedAt is populated (Issue #1661, DD-WORKFLOW-018)"
+// Field-by-field per Issue #2284: on K8s v1.31.x, whole-object "self ==
+// oldSelf" spuriously evaluates false when a nullable:true field
+// (declaredParameterNames) holds nil on both sides, rejecting identical
+// idempotent resubmits and causing an infinite reconcile loop. engineConfig
+// is excluded from the comparison entirely: x-kubernetes-preserve-unknown-fields
+// makes it CEL-inaccessible ("undefined field 'engineConfig'" at compile
+// time) -- a documented, narrow trade-off (see EngineConfig's own doc
+// comment for the precedent of pushing that validation to the Go/RO layer).
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.selectedAt) || (self.workflowId == oldSelf.workflowId && self.workflowName == oldSelf.workflowName && self.actionType == oldSelf.actionType && self.version == oldSelf.version && self.executionBundle == oldSelf.executionBundle && self.confidence == oldSelf.confidence && self.rationale == oldSelf.rationale && (has(self.executionBundleDigest) == has(oldSelf.executionBundleDigest)) && (!has(self.executionBundleDigest) || self.executionBundleDigest == oldSelf.executionBundleDigest) && (has(self.executionEngine) == has(oldSelf.executionEngine)) && (!has(self.executionEngine) || self.executionEngine == oldSelf.executionEngine) && (has(self.serviceAccountName) == has(oldSelf.serviceAccountName)) && (!has(self.serviceAccountName) || self.serviceAccountName == oldSelf.serviceAccountName) && (has(self.dependencies) == has(oldSelf.dependencies)) && (!has(self.dependencies) || self.dependencies == oldSelf.dependencies) && (has(self.resources) == has(oldSelf.resources)) && (!has(self.resources) || self.resources == oldSelf.resources) && (has(self.parameters) == has(oldSelf.parameters)) && (!has(self.parameters) || self.parameters == oldSelf.parameters) && (has(self.selectedAt) == has(oldSelf.selectedAt)) && (!has(self.selectedAt) || self.selectedAt == oldSelf.selectedAt) && (has(self.declaredParameterNames) == has(oldSelf.declaredParameterNames)) && (!has(self.declaredParameterNames) || self.declaredParameterNames == oldSelf.declaredParameterNames))",message="selectedWorkflow is immutable once selectedAt is populated (Issue #1661, DD-WORKFLOW-018)"
 type SelectedWorkflow struct {
 	// WorkflowSnapshot is the catalog-resolved execution snapshot
 	// (WorkflowID/WorkflowName/ActionType/Version/ExecutionBundle/

--- a/api/workflowexecution/v1alpha1/workflowexecution_types.go
+++ b/api/workflowexecution/v1alpha1/workflowexecution_types.go
@@ -140,7 +140,18 @@ import (
 //
 // To change execution parameters, delete and recreate the WorkflowExecution.
 //
-// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec is immutable after creation (ADR-001)"
+// Field-by-field per Issue #2284: on K8s v1.31.x, whole-object "self ==
+// oldSelf" spuriously evaluates false when workflowRef.declaredParameterNames
+// (nullable:true) holds nil on both sides. Unlike AIAnalysis's
+// SelectedWorkflow rule, this one is unconditional (no selectedAt-style
+// guard), so the bug hit here on the very first post-create Update() call
+// (finalizer registration), preventing the WorkflowExecution from ever
+// progressing past creation. engineConfig is excluded from the comparison
+// entirely: x-kubernetes-preserve-unknown-fields makes it CEL-inaccessible
+// ("undefined field 'engineConfig'" at compile time) -- a documented,
+// narrow trade-off, mirrored from the same exclusion in
+// AIAnalysis.SelectedWorkflow's rule above.
+// +kubebuilder:validation:XValidation:rule="self.remediationRequestRef == oldSelf.remediationRequestRef && self.workflowRef.workflowId == oldSelf.workflowRef.workflowId && self.workflowRef.workflowName == oldSelf.workflowRef.workflowName && self.workflowRef.actionType == oldSelf.workflowRef.actionType && self.workflowRef.version == oldSelf.workflowRef.version && self.workflowRef.executionBundle == oldSelf.workflowRef.executionBundle && (has(self.workflowRef.executionBundleDigest) == has(oldSelf.workflowRef.executionBundleDigest)) && (!has(self.workflowRef.executionBundleDigest) || self.workflowRef.executionBundleDigest == oldSelf.workflowRef.executionBundleDigest) && (has(self.workflowRef.executionEngine) == has(oldSelf.workflowRef.executionEngine)) && (!has(self.workflowRef.executionEngine) || self.workflowRef.executionEngine == oldSelf.workflowRef.executionEngine) && (has(self.workflowRef.serviceAccountName) == has(oldSelf.workflowRef.serviceAccountName)) && (!has(self.workflowRef.serviceAccountName) || self.workflowRef.serviceAccountName == oldSelf.workflowRef.serviceAccountName) && (has(self.workflowRef.dependencies) == has(oldSelf.workflowRef.dependencies)) && (!has(self.workflowRef.dependencies) || self.workflowRef.dependencies == oldSelf.workflowRef.dependencies) && (has(self.workflowRef.resources) == has(oldSelf.workflowRef.resources)) && (!has(self.workflowRef.resources) || self.workflowRef.resources == oldSelf.workflowRef.resources) && (has(self.workflowRef.declaredParameterNames) == has(oldSelf.workflowRef.declaredParameterNames)) && (!has(self.workflowRef.declaredParameterNames) || self.workflowRef.declaredParameterNames == oldSelf.workflowRef.declaredParameterNames) && self.targetResource == oldSelf.targetResource && (has(self.clusterID) == has(oldSelf.clusterID)) && (!has(self.clusterID) || self.clusterID == oldSelf.clusterID) && (has(self.parameters) == has(oldSelf.parameters)) && (!has(self.parameters) || self.parameters == oldSelf.parameters) && (has(self.confidence) == has(oldSelf.confidence)) && (!has(self.confidence) || self.confidence == oldSelf.confidence) && (has(self.rationale) == has(oldSelf.rationale)) && (!has(self.rationale) || self.rationale == oldSelf.rationale) && (has(self.timesOutAt) == has(oldSelf.timesOutAt)) && (!has(self.timesOutAt) || self.timesOutAt == oldSelf.timesOutAt)",message="spec is immutable after creation (ADR-001)"
 type WorkflowExecutionSpec struct {
 	// RemediationRequestRef references the parent RemediationRequest CRD
 	RemediationRequestRef corev1.ObjectReference `json:"remediationRequestRef"`
@@ -206,9 +217,17 @@ type WorkflowExecutionSpec struct {
 // than two independently hand-copied field lists) makes it structurally
 // impossible for the two to drift again -- see git history: ActionType was
 // originally left off this list once, and WorkflowName was never wired at
-// all until Change 12 closed that gap. No per-field CEL rule is needed:
-// WorkflowExecutionSpec's existing "self == oldSelf" XValidation (ADR-001)
-// already covers WorkflowRef as a whole, including these fields.
+// all until Change 12 closed that gap.
+//
+// Correction (Issue #2284): the claim that WorkflowExecutionSpec's ADR-001
+// "self == oldSelf" rule covers WorkflowRef "as a whole" with no per-field
+// rule needed was true structurally but incomplete operationally -- a
+// whole-object CEL comparison is exactly what caused Issue #2284's infinite
+// reconcile loop (the K8s v1.31.x CEL nullable-field false-negative bug), so
+// ADR-001's rule was rewritten to the same has()-guarded field-by-field form
+// as AIAnalysis.SelectedWorkflow's rule above. WorkflowRef's own type
+// definition here is unchanged; only the enclosing spec's XValidation rule
+// changed.
 type WorkflowRef struct {
 	sharedtypes.WorkflowSnapshot `json:",inline"`
 }

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -1328,7 +1328,28 @@ spec:
                     x-kubernetes-validations:
                     - message: 'selectedWorkflow is immutable once selectedAt is populated
                         (Issue #1661, DD-WORKFLOW-018)'
-                      rule: '!has(oldSelf.selectedAt) || self == oldSelf'
+                      rule: '!has(oldSelf.selectedAt) || (self.workflowId == oldSelf.workflowId
+                        && self.workflowName == oldSelf.workflowName && self.actionType
+                        == oldSelf.actionType && self.version == oldSelf.version &&
+                        self.executionBundle == oldSelf.executionBundle && self.confidence
+                        == oldSelf.confidence && self.rationale == oldSelf.rationale
+                        && (has(self.executionBundleDigest) == has(oldSelf.executionBundleDigest))
+                        && (!has(self.executionBundleDigest) || self.executionBundleDigest
+                        == oldSelf.executionBundleDigest) && (has(self.executionEngine)
+                        == has(oldSelf.executionEngine)) && (!has(self.executionEngine)
+                        || self.executionEngine == oldSelf.executionEngine) && (has(self.serviceAccountName)
+                        == has(oldSelf.serviceAccountName)) && (!has(self.serviceAccountName)
+                        || self.serviceAccountName == oldSelf.serviceAccountName)
+                        && (has(self.dependencies) == has(oldSelf.dependencies)) &&
+                        (!has(self.dependencies) || self.dependencies == oldSelf.dependencies)
+                        && (has(self.resources) == has(oldSelf.resources)) && (!has(self.resources)
+                        || self.resources == oldSelf.resources) && (has(self.parameters)
+                        == has(oldSelf.parameters)) && (!has(self.parameters) || self.parameters
+                        == oldSelf.parameters) && (has(self.selectedAt) == has(oldSelf.selectedAt))
+                        && (!has(self.selectedAt) || self.selectedAt == oldSelf.selectedAt)
+                        && (has(self.declaredParameterNames) == has(oldSelf.declaredParameterNames))
+                        && (!has(self.declaredParameterNames) || self.declaredParameterNames
+                        == oldSelf.declaredParameterNames))'
                 type: object
               reason:
                 description: Reason provides the umbrella failure or completion category.

--- a/charts/kubernaut/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_workflowexecutions.yaml
@@ -75,6 +75,18 @@ spec:
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.
+
+              Field-by-field per Issue #2284: on K8s v1.31.x, whole-object "self ==
+              oldSelf" spuriously evaluates false when workflowRef.declaredParameterNames
+              (nullable:true) holds nil on both sides. Unlike AIAnalysis's
+              SelectedWorkflow rule, this one is unconditional (no selectedAt-style
+              guard), so the bug hit here on the very first post-create Update() call
+              (finalizer registration), preventing the WorkflowExecution from ever
+              progressing past creation. engineConfig is excluded from the comparison
+              entirely: x-kubernetes-preserve-unknown-fields makes it CEL-inaccessible
+              ("undefined field 'engineConfig'" at compile time) -- a documented,
+              narrow trade-off, mirrored from the same exclusion in
+              AIAnalysis.SelectedWorkflow's rule above.
             properties:
               clusterID:
                 description: |-
@@ -355,7 +367,35 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: spec is immutable after creation (ADR-001)
-              rule: self == oldSelf
+              rule: self.remediationRequestRef == oldSelf.remediationRequestRef &&
+                self.workflowRef.workflowId == oldSelf.workflowRef.workflowId && self.workflowRef.workflowName
+                == oldSelf.workflowRef.workflowName && self.workflowRef.actionType
+                == oldSelf.workflowRef.actionType && self.workflowRef.version == oldSelf.workflowRef.version
+                && self.workflowRef.executionBundle == oldSelf.workflowRef.executionBundle
+                && (has(self.workflowRef.executionBundleDigest) == has(oldSelf.workflowRef.executionBundleDigest))
+                && (!has(self.workflowRef.executionBundleDigest) || self.workflowRef.executionBundleDigest
+                == oldSelf.workflowRef.executionBundleDigest) && (has(self.workflowRef.executionEngine)
+                == has(oldSelf.workflowRef.executionEngine)) && (!has(self.workflowRef.executionEngine)
+                || self.workflowRef.executionEngine == oldSelf.workflowRef.executionEngine)
+                && (has(self.workflowRef.serviceAccountName) == has(oldSelf.workflowRef.serviceAccountName))
+                && (!has(self.workflowRef.serviceAccountName) || self.workflowRef.serviceAccountName
+                == oldSelf.workflowRef.serviceAccountName) && (has(self.workflowRef.dependencies)
+                == has(oldSelf.workflowRef.dependencies)) && (!has(self.workflowRef.dependencies)
+                || self.workflowRef.dependencies == oldSelf.workflowRef.dependencies)
+                && (has(self.workflowRef.resources) == has(oldSelf.workflowRef.resources))
+                && (!has(self.workflowRef.resources) || self.workflowRef.resources
+                == oldSelf.workflowRef.resources) && (has(self.workflowRef.declaredParameterNames)
+                == has(oldSelf.workflowRef.declaredParameterNames)) && (!has(self.workflowRef.declaredParameterNames)
+                || self.workflowRef.declaredParameterNames == oldSelf.workflowRef.declaredParameterNames)
+                && self.targetResource == oldSelf.targetResource && (has(self.clusterID)
+                == has(oldSelf.clusterID)) && (!has(self.clusterID) || self.clusterID
+                == oldSelf.clusterID) && (has(self.parameters) == has(oldSelf.parameters))
+                && (!has(self.parameters) || self.parameters == oldSelf.parameters)
+                && (has(self.confidence) == has(oldSelf.confidence)) && (!has(self.confidence)
+                || self.confidence == oldSelf.confidence) && (has(self.rationale)
+                == has(oldSelf.rationale)) && (!has(self.rationale) || self.rationale
+                == oldSelf.rationale) && (has(self.timesOutAt) == has(oldSelf.timesOutAt))
+                && (!has(self.timesOutAt) || self.timesOutAt == oldSelf.timesOutAt)
           status:
             description: |-
               WorkflowExecutionStatus defines the observed state

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -1328,7 +1328,28 @@ spec:
                     x-kubernetes-validations:
                     - message: 'selectedWorkflow is immutable once selectedAt is populated
                         (Issue #1661, DD-WORKFLOW-018)'
-                      rule: '!has(oldSelf.selectedAt) || self == oldSelf'
+                      rule: '!has(oldSelf.selectedAt) || (self.workflowId == oldSelf.workflowId
+                        && self.workflowName == oldSelf.workflowName && self.actionType
+                        == oldSelf.actionType && self.version == oldSelf.version &&
+                        self.executionBundle == oldSelf.executionBundle && self.confidence
+                        == oldSelf.confidence && self.rationale == oldSelf.rationale
+                        && (has(self.executionBundleDigest) == has(oldSelf.executionBundleDigest))
+                        && (!has(self.executionBundleDigest) || self.executionBundleDigest
+                        == oldSelf.executionBundleDigest) && (has(self.executionEngine)
+                        == has(oldSelf.executionEngine)) && (!has(self.executionEngine)
+                        || self.executionEngine == oldSelf.executionEngine) && (has(self.serviceAccountName)
+                        == has(oldSelf.serviceAccountName)) && (!has(self.serviceAccountName)
+                        || self.serviceAccountName == oldSelf.serviceAccountName)
+                        && (has(self.dependencies) == has(oldSelf.dependencies)) &&
+                        (!has(self.dependencies) || self.dependencies == oldSelf.dependencies)
+                        && (has(self.resources) == has(oldSelf.resources)) && (!has(self.resources)
+                        || self.resources == oldSelf.resources) && (has(self.parameters)
+                        == has(oldSelf.parameters)) && (!has(self.parameters) || self.parameters
+                        == oldSelf.parameters) && (has(self.selectedAt) == has(oldSelf.selectedAt))
+                        && (!has(self.selectedAt) || self.selectedAt == oldSelf.selectedAt)
+                        && (has(self.declaredParameterNames) == has(oldSelf.declaredParameterNames))
+                        && (!has(self.declaredParameterNames) || self.declaredParameterNames
+                        == oldSelf.declaredParameterNames))'
                 type: object
               reason:
                 description: Reason provides the umbrella failure or completion category.

--- a/charts/kubernaut/files/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_workflowexecutions.yaml
@@ -75,6 +75,18 @@ spec:
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.
+
+              Field-by-field per Issue #2284: on K8s v1.31.x, whole-object "self ==
+              oldSelf" spuriously evaluates false when workflowRef.declaredParameterNames
+              (nullable:true) holds nil on both sides. Unlike AIAnalysis's
+              SelectedWorkflow rule, this one is unconditional (no selectedAt-style
+              guard), so the bug hit here on the very first post-create Update() call
+              (finalizer registration), preventing the WorkflowExecution from ever
+              progressing past creation. engineConfig is excluded from the comparison
+              entirely: x-kubernetes-preserve-unknown-fields makes it CEL-inaccessible
+              ("undefined field 'engineConfig'" at compile time) -- a documented,
+              narrow trade-off, mirrored from the same exclusion in
+              AIAnalysis.SelectedWorkflow's rule above.
             properties:
               clusterID:
                 description: |-
@@ -355,7 +367,35 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: spec is immutable after creation (ADR-001)
-              rule: self == oldSelf
+              rule: self.remediationRequestRef == oldSelf.remediationRequestRef &&
+                self.workflowRef.workflowId == oldSelf.workflowRef.workflowId && self.workflowRef.workflowName
+                == oldSelf.workflowRef.workflowName && self.workflowRef.actionType
+                == oldSelf.workflowRef.actionType && self.workflowRef.version == oldSelf.workflowRef.version
+                && self.workflowRef.executionBundle == oldSelf.workflowRef.executionBundle
+                && (has(self.workflowRef.executionBundleDigest) == has(oldSelf.workflowRef.executionBundleDigest))
+                && (!has(self.workflowRef.executionBundleDigest) || self.workflowRef.executionBundleDigest
+                == oldSelf.workflowRef.executionBundleDigest) && (has(self.workflowRef.executionEngine)
+                == has(oldSelf.workflowRef.executionEngine)) && (!has(self.workflowRef.executionEngine)
+                || self.workflowRef.executionEngine == oldSelf.workflowRef.executionEngine)
+                && (has(self.workflowRef.serviceAccountName) == has(oldSelf.workflowRef.serviceAccountName))
+                && (!has(self.workflowRef.serviceAccountName) || self.workflowRef.serviceAccountName
+                == oldSelf.workflowRef.serviceAccountName) && (has(self.workflowRef.dependencies)
+                == has(oldSelf.workflowRef.dependencies)) && (!has(self.workflowRef.dependencies)
+                || self.workflowRef.dependencies == oldSelf.workflowRef.dependencies)
+                && (has(self.workflowRef.resources) == has(oldSelf.workflowRef.resources))
+                && (!has(self.workflowRef.resources) || self.workflowRef.resources
+                == oldSelf.workflowRef.resources) && (has(self.workflowRef.declaredParameterNames)
+                == has(oldSelf.workflowRef.declaredParameterNames)) && (!has(self.workflowRef.declaredParameterNames)
+                || self.workflowRef.declaredParameterNames == oldSelf.workflowRef.declaredParameterNames)
+                && self.targetResource == oldSelf.targetResource && (has(self.clusterID)
+                == has(oldSelf.clusterID)) && (!has(self.clusterID) || self.clusterID
+                == oldSelf.clusterID) && (has(self.parameters) == has(oldSelf.parameters))
+                && (!has(self.parameters) || self.parameters == oldSelf.parameters)
+                && (has(self.confidence) == has(oldSelf.confidence)) && (!has(self.confidence)
+                || self.confidence == oldSelf.confidence) && (has(self.rationale)
+                == has(oldSelf.rationale)) && (!has(self.rationale) || self.rationale
+                == oldSelf.rationale) && (has(self.timesOutAt) == has(oldSelf.timesOutAt))
+                && (!has(self.timesOutAt) || self.timesOutAt == oldSelf.timesOutAt)
           status:
             description: |-
               WorkflowExecutionStatus defines the observed state

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -1328,7 +1328,28 @@ spec:
                     x-kubernetes-validations:
                     - message: 'selectedWorkflow is immutable once selectedAt is populated
                         (Issue #1661, DD-WORKFLOW-018)'
-                      rule: '!has(oldSelf.selectedAt) || self == oldSelf'
+                      rule: '!has(oldSelf.selectedAt) || (self.workflowId == oldSelf.workflowId
+                        && self.workflowName == oldSelf.workflowName && self.actionType
+                        == oldSelf.actionType && self.version == oldSelf.version &&
+                        self.executionBundle == oldSelf.executionBundle && self.confidence
+                        == oldSelf.confidence && self.rationale == oldSelf.rationale
+                        && (has(self.executionBundleDigest) == has(oldSelf.executionBundleDigest))
+                        && (!has(self.executionBundleDigest) || self.executionBundleDigest
+                        == oldSelf.executionBundleDigest) && (has(self.executionEngine)
+                        == has(oldSelf.executionEngine)) && (!has(self.executionEngine)
+                        || self.executionEngine == oldSelf.executionEngine) && (has(self.serviceAccountName)
+                        == has(oldSelf.serviceAccountName)) && (!has(self.serviceAccountName)
+                        || self.serviceAccountName == oldSelf.serviceAccountName)
+                        && (has(self.dependencies) == has(oldSelf.dependencies)) &&
+                        (!has(self.dependencies) || self.dependencies == oldSelf.dependencies)
+                        && (has(self.resources) == has(oldSelf.resources)) && (!has(self.resources)
+                        || self.resources == oldSelf.resources) && (has(self.parameters)
+                        == has(oldSelf.parameters)) && (!has(self.parameters) || self.parameters
+                        == oldSelf.parameters) && (has(self.selectedAt) == has(oldSelf.selectedAt))
+                        && (!has(self.selectedAt) || self.selectedAt == oldSelf.selectedAt)
+                        && (has(self.declaredParameterNames) == has(oldSelf.declaredParameterNames))
+                        && (!has(self.declaredParameterNames) || self.declaredParameterNames
+                        == oldSelf.declaredParameterNames))'
                 type: object
               reason:
                 description: Reason provides the umbrella failure or completion category.

--- a/config/crd/bases/kubernaut.ai_workflowexecutions.yaml
+++ b/config/crd/bases/kubernaut.ai_workflowexecutions.yaml
@@ -75,6 +75,18 @@ spec:
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.
+
+              Field-by-field per Issue #2284: on K8s v1.31.x, whole-object "self ==
+              oldSelf" spuriously evaluates false when workflowRef.declaredParameterNames
+              (nullable:true) holds nil on both sides. Unlike AIAnalysis's
+              SelectedWorkflow rule, this one is unconditional (no selectedAt-style
+              guard), so the bug hit here on the very first post-create Update() call
+              (finalizer registration), preventing the WorkflowExecution from ever
+              progressing past creation. engineConfig is excluded from the comparison
+              entirely: x-kubernetes-preserve-unknown-fields makes it CEL-inaccessible
+              ("undefined field 'engineConfig'" at compile time) -- a documented,
+              narrow trade-off, mirrored from the same exclusion in
+              AIAnalysis.SelectedWorkflow's rule above.
             properties:
               clusterID:
                 description: |-
@@ -355,7 +367,35 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: spec is immutable after creation (ADR-001)
-              rule: self == oldSelf
+              rule: self.remediationRequestRef == oldSelf.remediationRequestRef &&
+                self.workflowRef.workflowId == oldSelf.workflowRef.workflowId && self.workflowRef.workflowName
+                == oldSelf.workflowRef.workflowName && self.workflowRef.actionType
+                == oldSelf.workflowRef.actionType && self.workflowRef.version == oldSelf.workflowRef.version
+                && self.workflowRef.executionBundle == oldSelf.workflowRef.executionBundle
+                && (has(self.workflowRef.executionBundleDigest) == has(oldSelf.workflowRef.executionBundleDigest))
+                && (!has(self.workflowRef.executionBundleDigest) || self.workflowRef.executionBundleDigest
+                == oldSelf.workflowRef.executionBundleDigest) && (has(self.workflowRef.executionEngine)
+                == has(oldSelf.workflowRef.executionEngine)) && (!has(self.workflowRef.executionEngine)
+                || self.workflowRef.executionEngine == oldSelf.workflowRef.executionEngine)
+                && (has(self.workflowRef.serviceAccountName) == has(oldSelf.workflowRef.serviceAccountName))
+                && (!has(self.workflowRef.serviceAccountName) || self.workflowRef.serviceAccountName
+                == oldSelf.workflowRef.serviceAccountName) && (has(self.workflowRef.dependencies)
+                == has(oldSelf.workflowRef.dependencies)) && (!has(self.workflowRef.dependencies)
+                || self.workflowRef.dependencies == oldSelf.workflowRef.dependencies)
+                && (has(self.workflowRef.resources) == has(oldSelf.workflowRef.resources))
+                && (!has(self.workflowRef.resources) || self.workflowRef.resources
+                == oldSelf.workflowRef.resources) && (has(self.workflowRef.declaredParameterNames)
+                == has(oldSelf.workflowRef.declaredParameterNames)) && (!has(self.workflowRef.declaredParameterNames)
+                || self.workflowRef.declaredParameterNames == oldSelf.workflowRef.declaredParameterNames)
+                && self.targetResource == oldSelf.targetResource && (has(self.clusterID)
+                == has(oldSelf.clusterID)) && (!has(self.clusterID) || self.clusterID
+                == oldSelf.clusterID) && (has(self.parameters) == has(oldSelf.parameters))
+                && (!has(self.parameters) || self.parameters == oldSelf.parameters)
+                && (has(self.confidence) == has(oldSelf.confidence)) && (!has(self.confidence)
+                || self.confidence == oldSelf.confidence) && (has(self.rationale)
+                == has(oldSelf.rationale)) && (!has(self.rationale) || self.rationale
+                == oldSelf.rationale) && (has(self.timesOutAt) == has(oldSelf.timesOutAt))
+                && (!has(self.timesOutAt) || self.timesOutAt == oldSelf.timesOutAt)
           status:
             description: |-
               WorkflowExecutionStatus defines the observed state

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -1328,7 +1328,28 @@ spec:
                     x-kubernetes-validations:
                     - message: 'selectedWorkflow is immutable once selectedAt is populated
                         (Issue #1661, DD-WORKFLOW-018)'
-                      rule: '!has(oldSelf.selectedAt) || self == oldSelf'
+                      rule: '!has(oldSelf.selectedAt) || (self.workflowId == oldSelf.workflowId
+                        && self.workflowName == oldSelf.workflowName && self.actionType
+                        == oldSelf.actionType && self.version == oldSelf.version &&
+                        self.executionBundle == oldSelf.executionBundle && self.confidence
+                        == oldSelf.confidence && self.rationale == oldSelf.rationale
+                        && (has(self.executionBundleDigest) == has(oldSelf.executionBundleDigest))
+                        && (!has(self.executionBundleDigest) || self.executionBundleDigest
+                        == oldSelf.executionBundleDigest) && (has(self.executionEngine)
+                        == has(oldSelf.executionEngine)) && (!has(self.executionEngine)
+                        || self.executionEngine == oldSelf.executionEngine) && (has(self.serviceAccountName)
+                        == has(oldSelf.serviceAccountName)) && (!has(self.serviceAccountName)
+                        || self.serviceAccountName == oldSelf.serviceAccountName)
+                        && (has(self.dependencies) == has(oldSelf.dependencies)) &&
+                        (!has(self.dependencies) || self.dependencies == oldSelf.dependencies)
+                        && (has(self.resources) == has(oldSelf.resources)) && (!has(self.resources)
+                        || self.resources == oldSelf.resources) && (has(self.parameters)
+                        == has(oldSelf.parameters)) && (!has(self.parameters) || self.parameters
+                        == oldSelf.parameters) && (has(self.selectedAt) == has(oldSelf.selectedAt))
+                        && (!has(self.selectedAt) || self.selectedAt == oldSelf.selectedAt)
+                        && (has(self.declaredParameterNames) == has(oldSelf.declaredParameterNames))
+                        && (!has(self.declaredParameterNames) || self.declaredParameterNames
+                        == oldSelf.declaredParameterNames))'
                 type: object
               reason:
                 description: Reason provides the umbrella failure or completion category.

--- a/pkg/shared/assets/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_workflowexecutions.yaml
@@ -75,6 +75,18 @@ spec:
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.
+
+              Field-by-field per Issue #2284: on K8s v1.31.x, whole-object "self ==
+              oldSelf" spuriously evaluates false when workflowRef.declaredParameterNames
+              (nullable:true) holds nil on both sides. Unlike AIAnalysis's
+              SelectedWorkflow rule, this one is unconditional (no selectedAt-style
+              guard), so the bug hit here on the very first post-create Update() call
+              (finalizer registration), preventing the WorkflowExecution from ever
+              progressing past creation. engineConfig is excluded from the comparison
+              entirely: x-kubernetes-preserve-unknown-fields makes it CEL-inaccessible
+              ("undefined field 'engineConfig'" at compile time) -- a documented,
+              narrow trade-off, mirrored from the same exclusion in
+              AIAnalysis.SelectedWorkflow's rule above.
             properties:
               clusterID:
                 description: |-
@@ -355,7 +367,35 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: spec is immutable after creation (ADR-001)
-              rule: self == oldSelf
+              rule: self.remediationRequestRef == oldSelf.remediationRequestRef &&
+                self.workflowRef.workflowId == oldSelf.workflowRef.workflowId && self.workflowRef.workflowName
+                == oldSelf.workflowRef.workflowName && self.workflowRef.actionType
+                == oldSelf.workflowRef.actionType && self.workflowRef.version == oldSelf.workflowRef.version
+                && self.workflowRef.executionBundle == oldSelf.workflowRef.executionBundle
+                && (has(self.workflowRef.executionBundleDigest) == has(oldSelf.workflowRef.executionBundleDigest))
+                && (!has(self.workflowRef.executionBundleDigest) || self.workflowRef.executionBundleDigest
+                == oldSelf.workflowRef.executionBundleDigest) && (has(self.workflowRef.executionEngine)
+                == has(oldSelf.workflowRef.executionEngine)) && (!has(self.workflowRef.executionEngine)
+                || self.workflowRef.executionEngine == oldSelf.workflowRef.executionEngine)
+                && (has(self.workflowRef.serviceAccountName) == has(oldSelf.workflowRef.serviceAccountName))
+                && (!has(self.workflowRef.serviceAccountName) || self.workflowRef.serviceAccountName
+                == oldSelf.workflowRef.serviceAccountName) && (has(self.workflowRef.dependencies)
+                == has(oldSelf.workflowRef.dependencies)) && (!has(self.workflowRef.dependencies)
+                || self.workflowRef.dependencies == oldSelf.workflowRef.dependencies)
+                && (has(self.workflowRef.resources) == has(oldSelf.workflowRef.resources))
+                && (!has(self.workflowRef.resources) || self.workflowRef.resources
+                == oldSelf.workflowRef.resources) && (has(self.workflowRef.declaredParameterNames)
+                == has(oldSelf.workflowRef.declaredParameterNames)) && (!has(self.workflowRef.declaredParameterNames)
+                || self.workflowRef.declaredParameterNames == oldSelf.workflowRef.declaredParameterNames)
+                && self.targetResource == oldSelf.targetResource && (has(self.clusterID)
+                == has(oldSelf.clusterID)) && (!has(self.clusterID) || self.clusterID
+                == oldSelf.clusterID) && (has(self.parameters) == has(oldSelf.parameters))
+                && (!has(self.parameters) || self.parameters == oldSelf.parameters)
+                && (has(self.confidence) == has(oldSelf.confidence)) && (!has(self.confidence)
+                || self.confidence == oldSelf.confidence) && (has(self.rationale)
+                == has(oldSelf.rationale)) && (!has(self.rationale) || self.rationale
+                == oldSelf.rationale) && (has(self.timesOutAt) == has(oldSelf.timesOutAt))
+                && (!has(self.timesOutAt) || self.timesOutAt == oldSelf.timesOutAt)
           status:
             description: |-
               WorkflowExecutionStatus defines the observed state

--- a/test/integration/aianalysis/selectedworkflow_immutability_test.go
+++ b/test/integration/aianalysis/selectedworkflow_immutability_test.go
@@ -200,4 +200,69 @@ var _ = Describe("SelectedWorkflow write-once immutability (Issue #1661 Change 1
 			return k8sClient.Status().Update(ctx, &latest)
 		}, timeout, interval).Should(Succeed(), "an update with an unchanged SelectedWorkflow value must not be rejected by the write-once CEL guard")
 	})
+
+	// ========================================
+	// IT-AA-2284-001 (Issue #2284)
+	// ========================================
+	// Authority: Issue #2284. Distinct from IT-AA-344-001 above: that test's
+	// "idempotent resubmit" step exercises a *populated* DeclaredParameterNames
+	// map (TARGET_NAMESPACE/REPLICAS). This test exercises DeclaredParameterNames
+	// == nil -- a legitimate, meaningful value (see WorkflowSnapshot's own doc
+	// comment: nil "no schema, no filtering" vs an empty map "strip
+	// everything" are distinct). On K8s v1.31.x, the CEL evaluator's
+	// "self == oldSelf" spuriously returns false when a nullable:true field
+	// holds nil on both sides, so identical-value resubmits of a
+	// nil-DeclaredParameterNames SelectedWorkflow were incorrectly rejected,
+	// causing AIAnalysisReconciler to retry forever (#2030 Part A's bounded
+	// retry-then-escalate never durably advances its counter either, since
+	// *that* write is rejected by the same bug -- see #2284/#2287 comments).
+	It("IT-AA-2284-001: tolerates idempotent resubmit when DeclaredParameterNames is nil, while still rejecting real tampering", func() {
+		defer func() {
+			_ = k8sClient.Delete(ctx, analysis)
+		}()
+
+		By("Creating the AIAnalysis CRD")
+		Expect(k8sClient.Create(ctx, analysis)).To(Succeed())
+
+		By("First status write: setting SelectedWorkflow with nil DeclaredParameterNames must succeed")
+		now := metav1.Now()
+		firstSW := newSelectedWorkflow(&now, nil)
+		Eventually(func() error {
+			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis); err != nil {
+				return err
+			}
+			analysis.Status.EnsureRCAResult().SelectedWorkflow = firstSW
+			return k8sClient.Status().Update(ctx, analysis)
+		}, timeout, interval).Should(Succeed(), "first write with nil DeclaredParameterNames must be accepted")
+
+		By("Re-reading the persisted SelectedWorkflow")
+		var persisted aianalysisv1.AIAnalysis
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &persisted)).To(Succeed())
+		Expect(persisted.Status.GetRCAResult().SelectedWorkflow).ToNot(BeNil())
+		Expect(persisted.Status.GetRCAResult().SelectedWorkflow.DeclaredParameterNames).To(BeNil())
+
+		By("Resubmitting an identical value (nil DeclaredParameterNames) must succeed (Issue #2284 regression)")
+		// This is the exact incident-reproducing step: on the pre-fix CEL
+		// rule, this identical-value resubmit was rejected as Invalid,
+		// creating the infinite reconcile loop reported in #2284.
+		Eventually(func() error {
+			var latest aianalysisv1.AIAnalysis
+			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &latest); err != nil {
+				return err
+			}
+			return k8sClient.Status().Update(ctx, &latest)
+		}, timeout, interval).Should(Succeed(), "an update with an unchanged nil-DeclaredParameterNames SelectedWorkflow must not be rejected (Issue #2284)")
+
+		By("Tampering DeclaredParameterNames from nil to a populated map must still be rejected")
+		var lastErr error
+		Eventually(func() bool {
+			var latest aianalysisv1.AIAnalysis
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &latest)).To(Succeed())
+			latest.Status.RCAResult.SelectedWorkflow.DeclaredParameterNames = map[string]bool{"INJECTED": true}
+			lastErr = k8sClient.Status().Update(ctx, &latest)
+			return lastErr == nil || !apierrors.IsConflict(lastErr)
+		}, timeout, interval).Should(BeTrue(), "gave up waiting for a definitive (non-conflict) write result")
+		Expect(lastErr).To(HaveOccurred(), "real tampering (nil -> populated) must still be rejected by the write-once guard")
+		Expect(apierrors.IsInvalid(lastErr)).To(BeTrue(), "expected an Invalid admission error, got: %v", lastErr)
+	})
 })

--- a/test/integration/workflowexecution/workflowref_snapshot_immutability_test.go
+++ b/test/integration/workflowexecution/workflowref_snapshot_immutability_test.go
@@ -140,4 +140,50 @@ var _ = Describe("WorkflowRef CRD-embedded execution snapshot immutability (Issu
 			return k8sClient.Update(ctx, identical)
 		})).To(Succeed())
 	})
+
+	// ========================================
+	// IT-WFE-2284-001 (Issue #2284)
+	// ========================================
+	// Authority: Issue #2284. IT-WFE-340-001 above only exercises a
+	// *populated* DeclaredParameterNames map, so it never caught this bug.
+	// On K8s v1.31.x, ADR-001's unconditional "self == oldSelf" spuriously
+	// returns false when comparing two structurally-identical
+	// WorkflowExecutionSpec objects whose nullable:true
+	// WorkflowRef.DeclaredParameterNames field is nil on both sides. Unlike
+	// AIAnalysis's SelectedWorkflow rule (guarded by
+	// "!has(oldSelf.selectedAt) ||"), ADR-001 applies to every Update()
+	// unconditionally -- so the very first post-create write (finalizer
+	// registration) can be rejected, preventing the WorkflowExecution from
+	// ever progressing past creation.
+	It("IT-WFE-2284-001: tolerates a finalizer-add update when DeclaredParameterNames is nil, while still rejecting real tampering", func() {
+		name := fmt.Sprintf("wfref-2284-%d", time.Now().UnixNano())
+		wfe := newWFE(name)
+		wfe.Spec.WorkflowRef.DeclaredParameterNames = nil
+
+		By("creating a WorkflowExecution with nil DeclaredParameterNames")
+		Expect(k8sClient.Create(ctx, wfe)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, wfe) }()
+
+		By("the first post-create update (finalizer registration, no spec change) must succeed (Issue #2284)")
+		fetched := &workflowexecutionv1alpha1.WorkflowExecution{}
+		Expect(k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: DefaultNamespace}, fetched); err != nil {
+				return err
+			}
+			fetched.Finalizers = append(fetched.Finalizers, "kubernaut.ai/test-finalizer-2284")
+			return k8sClient.Update(ctx, fetched)
+		})).To(Succeed(), "a finalizer-add update must not be rejected by ADR-001 just because DeclaredParameterNames is nil on both sides")
+
+		By("tampering DeclaredParameterNames from nil to a populated map must still be rejected")
+		tampered := &workflowexecutionv1alpha1.WorkflowExecution{}
+		err := k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+			if getErr := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: DefaultNamespace}, tampered); getErr != nil {
+				return getErr
+			}
+			tampered.Spec.WorkflowRef.DeclaredParameterNames = map[string]bool{"INJECTED": true}
+			return k8sClient.Update(ctx, tampered)
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "real tampering (nil -> populated) must still be rejected, expected an Invalid admission error, got: %v", err)
+	})
 })


### PR DESCRIPTION
## Summary

Closes #2284 (v1.6 mainline; v1.5 impact tracked separately in #2287).

**Root cause**: on K8s v1.31.x, the CEL evaluator's whole-object `self == oldSelf` comparison spuriously returns `false` when a `nullable: true` field (`WorkflowSnapshot.DeclaredParameterNames`) holds `nil` on both sides, even though the two objects are otherwise identical.

- `AIAnalysis.Status.RCAResult.SelectedWorkflow`: idempotent status resubmits were rejected as `Invalid`, driving `AIAnalysisReconciler` into an infinite reconcile loop (the reported symptom).
- `WorkflowExecution.Spec` (via `WorkflowRef`): ADR-001's immutability rule has no `selectedAt`-style guard, so the very first post-create `Update()` (finalizer registration) could be rejected, preventing the `WorkflowExecution` from ever progressing past creation — confirmed by `IT-WFE-2284-001` hitting the real controller's `Failed to add finalizer` path, not just a test artifact.

This repo's default `ENVTEST_K8S_VERSION` floats to v1.36.x (derived from `k8s.io/api`), which does not reproduce this bug — exactly why CI never caught it before it hit production (OCP 4.18.44 / K8s v1.31.14).

## Changes

- Rewrite both `XValidation` rules field-by-field using the `has()`-guarded idiom from the [K8s CRD immutability guide](https://kubernetes.io/blog/2022/09/29/enforce-immutability-using-cel/), instead of whole-object `self == oldSelf`.
- `engineConfig` is excluded from both rules: `x-kubernetes-preserve-unknown-fields` makes it CEL-inaccessible (`undefined field 'engineConfig'` at compile time) — a documented, narrow trade-off, mirroring existing precedent for pushing that validation to the Go/RO layer.
- Correct a now-stale `WorkflowRef` doc comment claiming no per-field CEL rule would ever be needed.
- Add `IT-AA-2284-001` / `IT-WFE-2284-001` regression tests, validated failing pre-fix and passing post-fix against a K8s v1.31.0-pinned envtest (full suites: 62/62 AIAnalysis, 112/112 WorkflowExecution specs pass, no regressions).
- Add `make test-integration-cel-immutability-regression` (pinned to v1.31.0) and wire it into `ci-pipeline.yml` as a new job required by `merge-gate`, closing the CI version gap that let this bug reach production undetected.

## Test plan

- [x] `IT-AA-2284-001` and `IT-WFE-2284-001` fail on pre-fix CEL rules (K8s v1.31.0 pinned envtest)
- [x] Both pass post-fix; full `aianalysis` (62/62) and `workflowexecution` (112/112) IT suites pass with no regressions (K8s v1.31.0 pinned)
- [x] `go build ./...` and `golangci-lint run` clean
- [x] New `make test-integration-cel-immutability-regression` Makefile target validated (dry-run + live run)
- [ ] CI green on this PR (includes the new `cel-immutability-regression` job)