### PR TITLE
fix(apifrontend): fail closed on SignalInteractive exhaustion + #2265 flake/doc cleanup

### DIFF
--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -1936,6 +1936,7 @@ components:
             - $ref: '#/components/schemas/ApifrontendSeverityTriageFailedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigReloadedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigRejectedPayload'
+            - $ref: '#/components/schemas/ApifrontendInteractiveSignalFailedPayload'
             - $ref: '#/components/schemas/DatastorageRatelimitDeniedPayload'
             - $ref: '#/components/schemas/GatewayConfigReloadedPayload'
             - $ref: '#/components/schemas/GatewayConfigRejectedPayload'
@@ -2105,6 +2106,7 @@ components:
               'apifrontend.severity_triage.failed': '#/components/schemas/ApifrontendSeverityTriageFailedPayload'
               'apifrontend.config.reloaded': '#/components/schemas/ApifrontendConfigReloadedPayload'
               'apifrontend.config.rejected': '#/components/schemas/ApifrontendConfigRejectedPayload'
+              'apifrontend.interactive_signal.failed': '#/components/schemas/ApifrontendInteractiveSignalFailedPayload'
               # Issue #2285: CA hot-reload audit-trail parity (GAP-11 onReload
               # callback wired into the 8 remaining StartCAFileWatcher callers;
               # gateway.config.{reloaded,rejected} and
@@ -7356,4 +7358,20 @@ components:
         config_version:
           type: string
           description: Rejected configuration version or hash
+
+    ApifrontendInteractiveSignalFailedPayload:
+      type: object
+      required: [event_type, rr_id, error]
+      description: Interactive signal failed event payload (apifrontend.interactive_signal.failed) — SignalInteractive (IS CRD creation) failed after exhausting bounded retries and the caller failed closed; consent-gating (DD-INTERACTIVE-002, BR-INTERACTIVE-010) could not be established for this RR (SOC2 CC7.2, AU-2/AU-3, Issue #2289)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.interactive_signal.failed']
+          description: Event type for discriminator (matches parent event_type)
+        rr_id:
+          type: string
+          description: RemediationRequest name the interactive signal was attempted for
+        error:
+          type: string
+          description: Final error returned by SignalInteractive after exhausting retries
 

--- a/docs/architecture/decisions/DD-INTERACTIVE-002-dynamic-takeover-model.md
+++ b/docs/architecture/decisions/DD-INTERACTIVE-002-dynamic-takeover-model.md
@@ -1,20 +1,21 @@
 # DD-INTERACTIVE-002: Dynamic Takeover Model
 
-**Status**: ✅ Accepted
+**Status**: ⚠️ Accepted, Partially Amended (see [Post-Decision Amendment](#post-decision-amendment-2026-08-24) below)
 **Decision Date**: 2026-04-29
-**Version**: 1.1
-**Confidence**: 95%
+**Version**: 1.2
+**Confidence**: 95% (original decision); see amendment for current-state confidence
 **Deciders**: Architecture Team
 **Applies To**: kubernaut-agent, aianalysis-controller, remediation-orchestrator
 
 **Related Business Requirements**:
 - BR-INTERACTIVE-001: Interactive investigation sessions
-- BR-INTERACTIVE-004: Dynamic takeover of autonomous investigations
+- BR-INTERACTIVE-004: Dynamic takeover of autonomous investigations (success criteria amended 2026-08-24 — see below)
 - BR-INTERACTIVE-005: Session lifecycle and timeout management
 - BR-INTERACTIVE-006: Cross-session visibility via audit trail
 
 **Related Design Decisions**:
 - DD-INTERACTIVE-001: Interactive mode CRD placement and timeouts (**SUPERSEDED by this document**)
+- DD-AA-KA-001 (2026-08-17): AgentSession CRD replacing AA↔KA HTTP polling — **supersedes the IS-CRD/HTTP mechanics described in this document's Architecture section**; the takeover *concept* below remains current, the CRD/transport details do not
 - DD-AUTH-MCP-001: MCP endpoint security and user impersonation
 - DD-AUDIT-003: Service audit trace requirements
 - ADR-038: Async buffered audit ingestion
@@ -27,6 +28,42 @@
 |---------|------|--------|---------|
 | 1.0 | 2026-04-29 | AI-assisted | Initial design. Supersedes DD-INTERACTIVE-001. |
 | 1.1 | 2026-05-15 | AI-assisted | Clarified v1.5 takeover-abandon semantics: no autonomous resume on disconnect. Added SEC-TAKEOVER-001 security rationale. Updated connection flow diagram. |
+| 1.2 | 2026-08-24 | AI-assisted | **Post-decision amendment** (see dedicated section below): (1) documents that Alternative C's chosen "cancel+reconstruct" mechanism was replaced in production by "upgrade-in-place" per issue #1390 (2026-06-09) to eliminate wasteful cancel-and-resubmit LLM token cycles — this doc was never updated at the time; (2) corrects the `action: takeover` API example, which predates `kubernaut_takeover`'s consolidation into `kubernaut_investigate` (#1332) and the current auto-detected `joinMode`; (3) cross-references DD-AA-KA-001, which has since replaced the IS-CRD/AA↔KA-HTTP mechanics described here; (4) documents the previously-undocumented "same-turn autonomous-then-attach" pattern (issue #2265 investigation). |
+
+---
+
+## Post-Decision Amendment (2026-08-24)
+
+> **Why this section exists instead of a silent rewrite**: the sections below (Context, Alternatives, Decision, Architecture) are preserved as the historical record of the reasoning that was actually applied on 2026-04-29/05-15. Three material facts changed after that reasoning was accepted, without this document being updated. This section states the current ground truth and points at the evidence; it does not retroactively edit the narrative below.
+
+### 1. Cancel+Reconstruct → Upgrade-in-Place (issue #1390, 2026-06-09)
+
+The chosen mechanism in [Decision](#decision) below — cancel the autonomous goroutine, then reconstruct a **new** session from DS audit events — was replaced in production about six weeks after this DD's v1.1 update:
+
+> `feat(aa): simplify takeover to upgrade-in-place (#1390)` — "Change AA's `checkISMismatchAndCancel` to set `Interactive=true` and call `SetActivePhase` **instead of cancelling** the KA session when an IS CRD appears for an autonomous session. This preserves the running session and **avoids wasteful cancel-and-resubmit cycles**."
+
+Root cause: issue #1390 documented a production incident where a duplicate investigation submission spawned a "ghost" investigation racing the original, burning an entire re-run of RCA's LLM tokens and leaving the remediation stuck in `Analyzing`. Cancel+reconstruct's per-transition token cost (documented as an accepted "Negative Consequence" below) turned out to be worse in practice than the original alternatives analysis assumed, once a second concrete failure mode (duplicate-submission races) was observed on top of the expected human-takeover case.
+
+**Current mechanism** (KA side, `internal/kubernautagent/session/manager_interactive.go`'s `UpgradeToInteractive` → `interactiveUpgrade` atomic flag → `InteractiveHold` checked at `checkRCAEarlyReturn`, tagged `BR-INTERACTIVE-004, #1390` in `internal/kubernautagent/session/event_sink.go`): the **same** running KA session is flagged interactive in place. No cancellation, no new session ID, no DS-reconstruction query. If the flag lands before the next `checkRCAEarlyReturn` checkpoint, the autonomous workflow short-circuits and the caller drives from there; if the investigation has already progressed past all checkpoints, the flag has no effect (see item 4 below).
+
+This means the "Identity Transitions in Audit Trail" example, the `sess-KA-03` NEW-session illustration, and Positive/Negative Consequences #3–#4 (cancel+reconstruct simplicity / token cost) in the sections below describe a mechanism that is **no longer how takeover works**. They remain useful as historical rationale for why cancel+reconstruct was *originally* chosen over Alternative B (suspend/resume), but do not describe current behavior.
+
+### 2. `action: takeover` is not a caller-supplied parameter
+
+The [Explicit Takeover Requirement](#explicit-takeover-requirement) section's JSON example (`"action": "takeover"`) predates two changes:
+
+- Issue #1332 consolidated the standalone `kubernaut_takeover` tool into `kubernaut_investigate` (commit `1b33cbc5e`). There is no separate takeover tool or explicit `action` enum value in the current AF-facing contract.
+- The current implementation (`pkg/apifrontend/tools/ka_investigate_mcp.go`) auto-detects takeover: `isAutonomousInvestigation(ctx, client, namespace, rrID)` checks whether an active `AIAnalysis` already has a session ID assigned, and derives `joinMode := "takeover"` internally — the caller only ever supplies `kubernaut_investigate(rr_id=...)`, identical to a fresh `start` call. This is deliberate LLM-ergonomics: two explicit tools/params for what should be one intent (see DD-AF-004's rationale for the same pattern applied elsewhere) were rejected in favor of backend detection.
+
+### 3. IS-CRD / AA↔KA-HTTP mechanics superseded by DD-AA-KA-001
+
+This document's Architecture section (Observer/Driver Model, CRD Impact, Identity Transitions) was written against an architecture where AA polls KA over HTTP and infers `Interactive` from `InvestigationSession` (IS) CRD existence. **DD-AA-KA-001** (accepted 2026-08-17) replaced AA↔KA HTTP polling with a K8s-native `AgentSession` CRD (watch+lease), and explicitly plans to delete `checkISMismatchAndCancel` — the very function item 1 above described. AA has since stopped reading/writing `InvestigationSession` entirely. Read DD-AA-KA-001 as the current source of truth for AA↔KA transport and CRD mechanics; this document's takeover *concept* (dynamic, no creation-time prediction, single-driver Lease, one-way door per SEC-TAKEOVER-001) remains valid, but its CRD/transport implementation detail does not.
+
+### 4. Previously-undocumented pattern: same-turn autonomous-then-attach (issue #2265)
+
+None of Alternative C's narrative, BR-INTERACTIVE-004, or `docs/services/apifrontend/design/ARCHITECTURE.md`'s three flows document a fourth real, intentional use of the same `joinMode=takeover` code path: a **single chat turn/session** calling `kubernaut_remediate` (fully autonomous, no observability) immediately followed by `kubernaut_investigate(rr_id=<same RR>)` to attach a chat-visible session to the RR it *just* created, typically ending in the same turn with `kubernaut_complete`.
+
+This does not match this document's SRE-joins-mid-flight framing (a *separate* actor arriving later to actively redirect an in-flight investigation) nor `ARCHITECTURE.md`'s "Flow 3: Remediation Approver Takeover" (a human reviewing an *already-paused*, `AwaitingApproval` RR after autonomous investigation has finished). It is a best-effort **observability attach to an already-committed autonomous decision**, not a consent veto: `kubernaut_remediate` has already committed the RR to autonomous execution before `kubernaut_investigate(rr_id)` is ever called, so there is an inherent, accepted race between the attach call and the autonomous investigation completing (see `E2E-FP-1912-001`/`E2E-FP-1918-001` for the test-side handling of this race, and the corrected RCA on issue #2265 for the full mechanism trace). See `docs/services/apifrontend/design/ARCHITECTURE.md` §"Flow 4" for the sequence diagram.
 
 ---
 
@@ -132,6 +169,8 @@ Real-world operations don't work this way. An SRE sees an ongoing autonomous inv
 
 ### Chosen: Alternative C -- Dynamic Takeover with Cancel+Reconstruct
 
+> ⚠️ **Superseded by issue #1390 (2026-06-09) — see [Post-Decision Amendment §1](#1-cancelreconstruct--upgrade-in-place-issue-1390-2026-06-09)**. Production replaced cancel+reconstruct with in-place session upgrade shortly after this section was written. The narrative below is preserved as the historical rationale for choosing Alternative C over Alternative B; it does not describe current behavior.
+
 All remediations start autonomous (KA SA drives). A human user can take over at any time by connecting via MCP and sending explicit `action: takeover`. The autonomous investigation is cancelled (after completing its current LLM turn) and the user drives. On disconnect, a NEW autonomous session reconstructs the full conversation from DS audit events.
 
 ### Architecture
@@ -191,6 +230,8 @@ Time →
 Multiple observers can connect simultaneously. Only one driver at a time (Lease enforces).
 
 #### Explicit Takeover Requirement
+
+> ⚠️ **Superseded — see [Post-Decision Amendment §2](#2-action-takeover-is-not-a-caller-supplied-parameter)**. There is no separate `action` field or `kubernaut_takeover` tool in the current contract; `joinMode` is auto-detected server-side from `kubernaut_investigate(rr_id=...)` alone.
 
 A user's first regular message does **NOT** trigger takeover. The `action: takeover` parameter is required:
 
@@ -343,5 +384,5 @@ No spec changes. No annotation changes. Every RR is takeover-capable by default.
 
 ---
 
-**Document Version**: 1.1
-**Last Updated**: 2026-05-15
+**Document Version**: 1.2
+**Last Updated**: 2026-08-24

--- a/docs/requirements/BR-INTERACTIVE.md
+++ b/docs/requirements/BR-INTERACTIVE.md
@@ -4,7 +4,7 @@
 **Priority**: P1 (HIGH) - Core v1.5 Feature
 **Target Version**: v1.5
 **Status**: Proposed
-**Date**: April 29, 2026 (Updated: May 15, 2026 — SEC-TAKEOVER-001 clarification on BR-INTERACTIVE-004 #5)
+**Date**: April 29, 2026 (Updated: May 15, 2026 — SEC-TAKEOVER-001 clarification on BR-INTERACTIVE-004 #5; Updated: August 24, 2026 — BR-INTERACTIVE-004 #2/#3 corrected to match production's in-place upgrade mechanism, see DD-INTERACTIVE-002 v1.2 amendment)
 **Related ADRs**: ADR-038 (Async Buffered Audit Ingestion)
 **Related DDs**: DD-AUTH-MCP-001 (MCP Endpoint Security), DD-INTERACTIVE-002 (Dynamic Takeover Model)
 **GitHub Issue**: [#703](https://github.com/jordigilh/kubernaut/issues/703)
@@ -84,12 +84,13 @@ SREs must be able to take over an ongoing autonomous investigation at any point 
 ### Success Criteria
 
 1. Every RemediationRequest is takeover-capable by default (no spec field, no annotation)
-2. Takeover requires explicit `action: takeover` (not implicit on first message)
-3. Autonomous investigation completes current LLM turn before being cancelled (no lost work)
-4. User's LLM context is auto-injected with autonomous findings from DS audit events
-5. **v1.5**: Takeover is a **one-way door** — autonomous investigation is cancelled permanently and does NOT resume on disconnect. If the user abandons the session, the inactivity timeout releases the Lease, the AA phase times out on the RO side, and the Gateway creates a fresh RemediationRequest. See SEC-TAKEOVER-001 in DD-INTERACTIVE-002 for security rationale.
+2. **[Corrected 2026-08-24]** Takeover is auto-detected server-side (`isAutonomousInvestigation` checks for an active `AIAnalysis` with a session already assigned) from a plain `kubernaut_investigate(rr_id=...)` call — not an explicit `action: takeover` parameter. There is no separate `kubernaut_takeover` tool (consolidated into `kubernaut_investigate` per #1332); the caller cannot distinguish a fresh start from a takeover at the API layer, by design (LLM-ergonomics, mirrors the two-explicit-tools rationale in DD-AF-004).
+3. **[Corrected 2026-08-24]** The autonomous investigation is **upgraded in place**, not cancelled — the same running KA session is flagged interactive (`UpgradeToInteractive` → `InteractiveHold`, checked at the next `checkRCAEarlyReturn` checkpoint) and the user continues driving it. No new session is created, no work is lost, and no DS-reconstruction query is needed for this path. (Original v1.0/v1.1 design specified cancel + reconstruct-from-audit-trail into a *new* session; issue #1390 (2026-06-09) replaced this in production after a duplicate-submission race showed cancel+reconstruct wasting an entire re-run of RCA's LLM tokens. See DD-INTERACTIVE-002 v1.2's Post-Decision Amendment for the full trace.)
+4. If the `InteractiveHold` flag arrives after all `checkRCAEarlyReturn` checkpoints have already passed (investigation already complete / workflow already selected), takeover has no effect on that investigation — this is an accepted best-effort race, not a consent veto (see item 8 below)
+5. **v1.5**: Once upgraded, takeover is a **one-way door** — the session does NOT revert to autonomous on disconnect. If the user abandons the session, the inactivity timeout releases the Lease, the AA phase times out on the RO side, and the Gateway creates a fresh RemediationRequest. See SEC-TAKEOVER-001 in DD-INTERACTIVE-002 for security rationale.
 6. **v1.6+ (deferred)**: Resume-on-disconnect may be revisited once alignment grounding review can verify the user's interactive turns did not introduce unsafe directives
 7. Single-driver guarantee via K8s Lease (concurrent drivers rejected)
+8. **[Added 2026-08-24]** A single chat turn/session MAY call `kubernaut_remediate` then immediately `kubernaut_investigate(rr_id=<same RR>)` to attach observability to the RR it just autonomously committed. This is a best-effort observability attach to an already-committed decision, not a consent veto — `kubernaut_remediate` has already committed the RR to autonomous execution before the attach call happens. See DD-INTERACTIVE-002 v1.2 §4 and `docs/services/apifrontend/design/ARCHITECTURE.md` Flow 4.
 
 ---
 

--- a/docs/services/apifrontend/design/ARCHITECTURE.md
+++ b/docs/services/apifrontend/design/ARCHITECTURE.md
@@ -426,6 +426,55 @@ sequenceDiagram
     AF->>Approver: SSE: approval_request_resolved event
 ```
 
+### Flow 4: Autonomous-Then-Attach (Same-Turn Takeover)
+
+A single chat turn/session chains `kubernaut_remediate` (autonomous mode) immediately
+followed by `kubernaut_investigate(rr_id=<same RR>)` to attach a chat-visible session to
+the RR it *just* committed to autonomous execution — typically ending in the same turn
+with `kubernaut_complete`. This is a distinct pattern from Flow 3 (a *separate* approver
+reviewing an *already-paused* `AwaitingApproval` RR) and from DD-INTERACTIVE-002's SRE
+mid-flight framing (a separate actor arriving later to actively redirect an in-flight
+investigation). See DD-INTERACTIVE-002 v1.2 §4 for the full writeup (added 2026-08-24,
+issue #2265 investigation).
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant AF as API Frontend
+    participant K8s as K8s API
+    participant KA as Kubernaut Agent
+
+    User->>AF: tasks/send "fix payment-api, and let me watch"
+    AF->>AF: LLM: kubernaut_remediate only (autonomous mode, no IS/observability)
+    AF->>K8s: Create RemediationRequest (autonomous)
+    Note over K8s,KA: AA/RO/WFE pipeline begins investigating immediately
+
+    AF->>AF: LLM: kubernaut_investigate(rr_id) — same turn, same RR
+    AF->>K8s: isAutonomousInvestigation(rr_id) → true (active AIA with session already assigned)
+    AF->>AF: signalInteractiveSession: joinMode = "takeover" (auto-detected, no explicit action param)
+    AF->>K8s: Create InvestigationSession CRD (best-effort; failure does NOT block the RR)
+    AF->>KA: UpgradeToInteractive(sessionID) — flags the SAME running KA session interactive in place (no cancel, #1390)
+
+    alt InteractiveHold lands before next checkRCAEarlyReturn checkpoint
+        KA->>KA: Short-circuits autonomous flow, yields findings to attached session
+        AF->>User: SSE: RCA/progress relayed from the now-attached session
+    else Autonomous investigation already past all checkpoints (already complete / workflow already selected)
+        Note over KA: Attach has no effect on this investigation — accepted race, not a consent veto
+        AF->>User: SSE: best-effort attach; may observe only the tail end or nothing before terminal state
+    end
+
+    AF->>AF: LLM: kubernaut_complete — ends the driver/chat session
+```
+
+**Key distinctions from Flow 3**:
+
+| Aspect | Flow 3 (Approver Takeover) | Flow 4 (Autonomous-Then-Attach) |
+|--------|----------------------------|----------------------------------|
+| Trigger | Separate actor, later, on an `AwaitingApproval` RR | Same turn/session, immediately after creating the RR |
+| RR state at attach | Investigation already finished, paused for approval | Investigation actively in-flight, racing to complete |
+| Purpose | Human decision gate (approve/reject) | Best-effort observability attach, no veto power |
+| Failure mode if attach loses the race | N/A (RR is already paused, can't "finish" further) | Session observes nothing new; RR completes autonomously regardless — this is intended, not a bug |
+
 > **Note (#1415)**: The LLM agent does NOT have access to `kubernaut_approve`.
 > Approval is performed exclusively via the Console UI → MCP endpoint path.
 > See [DD-AF-006](../../architecture/decisions/DD-AF-006-approval-consent-guard.md).

--- a/pkg/apifrontend/audit/audit.go
+++ b/pkg/apifrontend/audit/audit.go
@@ -73,6 +73,15 @@ const (
 	EventKAResultReceived     EventType = "ka.result_received"
 	EventUserDecision         EventType = "user.decision"
 	EventInvestigationTimeout EventType = "investigation.timeout"
+
+	// EventInteractiveSignalFailed (#2289, AU-2/AU-3) fires when
+	// SignalInteractive (IS CRD creation) still fails after exhausting
+	// bounded retries and the caller fails closed -- neither the new RR
+	// (buildPreCreateISHooks) nor the interactive attach
+	// (signalInteractiveSession) is allowed to proceed without the
+	// consent-gating guarantee IS CRD creation is meant to provide
+	// (DD-INTERACTIVE-002, BR-INTERACTIVE-010).
+	EventInteractiveSignalFailed EventType = "interactive_signal.failed"
 )
 
 // Event represents a SOC2-compatible audit event.

--- a/pkg/apifrontend/audit/store_adapter.go
+++ b/pkg/apifrontend/audit/store_adapter.go
@@ -142,6 +142,7 @@ var typedPayloadEvents = map[EventType]bool{
 	EventAuthAccessDenied:        true,
 	EventToolExecuted:            true,
 	EventWorkflowDiscovery:       true,
+	EventInteractiveSignalFailed: true,
 }
 
 func hasTypedPayload(t EventType) bool {
@@ -159,6 +160,7 @@ var failureEvents = map[EventType]bool{
 	EventCircuitBreakerTrip:      true,
 	EventSessionAutoCancelled:    true,
 	EventSessionRetentionDeleted: true,
+	EventInteractiveSignalFailed: true,
 }
 
 func eventOutcome(t EventType) ogenclient.AuditEventRequestEventOutcome {
@@ -202,6 +204,7 @@ var actionMap = map[EventType]string{
 	EventUserDecision:            "decided",
 	EventAgentCardAccessed:       "accessed",
 	EventInvestigationTimeout:    "timed_out",
+	EventInteractiveSignalFailed: "failed",
 }
 
 func eventAction(t EventType) string {
@@ -248,6 +251,7 @@ var eventDataBuilders = map[EventType]eventDataBuilder{
 	EventAuthAccessDenied:        buildAuthAccessDeniedPayload,
 	EventToolExecuted:            buildToolExecutedPayload,
 	EventWorkflowDiscovery:       buildWorkflowDiscoveryPayload,
+	EventInteractiveSignalFailed: buildInteractiveSignalFailedPayload,
 }
 
 func buildEventData(e *Event) ogenclient.AuditEventRequestEventData {
@@ -438,6 +442,15 @@ func buildConfigRejectedPayload(e *Event) ogenclient.AuditEventRequestEventData 
 	return ogenclient.NewApifrontendConfigRejectedPayloadAuditEventRequestEventData(ogenclient.ApifrontendConfigRejectedPayload{
 		EventType:       ogenclient.ApifrontendConfigRejectedPayloadEventTypeApifrontendConfigRejected,
 		RejectionReason: detailStr(d, "rejection_reason"),
+	})
+}
+
+func buildInteractiveSignalFailedPayload(e *Event) ogenclient.AuditEventRequestEventData {
+	d := e.Detail
+	return ogenclient.NewApifrontendInteractiveSignalFailedPayloadAuditEventRequestEventData(ogenclient.ApifrontendInteractiveSignalFailedPayload{
+		EventType: ogenclient.ApifrontendInteractiveSignalFailedPayloadEventTypeApifrontendInteractiveSignalFailed,
+		RrID:      detailStr(d, "rr_id"),
+		Error:     detailStr(d, "error"),
 	})
 }
 

--- a/pkg/apifrontend/audit/store_adapter_test.go
+++ b/pkg/apifrontend/audit/store_adapter_test.go
@@ -94,6 +94,7 @@ var _ = Describe("StoreAdapter", func() {
 		{"UT-AF-1156-029", audit.EventAuthAccessDenied, map[string]string{"tool_name": "kubectl_exec", "user_role": "viewer", "endpoint": "a2a"}, "apifrontend.auth.access_denied"},
 		{"UT-AF-1156-030", audit.EventToolExecuted, map[string]string{"session_id": "sess-1", "tool_name": "kubectl_get", "execution_duration_ms": "100", "tool_outcome": "success"}, "apifrontend.tool.executed"},
 		{"UT-AF-1923-001", audit.EventWorkflowDiscovery, map[string]string{"rr_id": "rr-1", "workflow_count": "2"}, "apifrontend.workflow.discovery"},
+		{"UT-AF-2289-030", audit.EventInteractiveSignalFailed, map[string]string{"rr_id": "rr-1", "error": "etcd unavailable"}, "apifrontend.interactive_signal.failed"},
 	}
 
 	Describe("Event type mapping", func() {
@@ -186,6 +187,7 @@ var _ = Describe("StoreAdapter", func() {
 			audit.EventAuthFailure, audit.EventA2ATaskFailed, audit.EventMCPToolFailed,
 			audit.EventSeverityTriageFailed, audit.EventConfigRejected,
 			audit.EventAuthAccessDenied, audit.EventRateLimitDenied, audit.EventCircuitBreakerTrip,
+			audit.EventInteractiveSignalFailed,
 		}
 		for _, et := range failureEvents {
 			et := et

--- a/pkg/apifrontend/tools/export_test.go
+++ b/pkg/apifrontend/tools/export_test.go
@@ -12,3 +12,16 @@ var MapReasonToPhase = mapReasonToPhase
 // await/signal machinery (which requires a real MCP/HTTP transport to test
 // meaningfully — that wiring is proven separately at the IT tier).
 var ResolveInvestigationRR = resolveInvestigationRR
+
+// SignalInteractiveWithRetry exposes signalInteractiveWithRetry for external
+// test packages (#2289's bounded-retry unit tests), decoupled from the full
+// HandleInvestigationMCPWithRegistry/HandleCreateRRWithHooks machinery.
+var SignalInteractiveWithRetry = signalInteractiveWithRetry
+
+// SignalInteractiveRequest exposes signalInteractiveRequest for external
+// test packages calling SignalInteractiveWithRetry (#2289).
+type SignalInteractiveRequest = signalInteractiveRequest
+
+// SignalInteractiveMaxAttempts exposes signalInteractiveMaxAttempts for
+// external test packages asserting exact retry-exhaustion counts (#2289).
+const SignalInteractiveMaxAttempts = signalInteractiveMaxAttempts

--- a/pkg/apifrontend/tools/ka_investigate_intent_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_intent_test.go
@@ -756,6 +756,12 @@ type recordingISSignaler struct {
 	// (before returning) so a test can probe co-temporal state (#2265's
 	// ordering proof: is the RR visible yet?).
 	onSignal func(ctx context.Context, rrNamespace, rrName string)
+	// signalErrFn, when set, is invoked with the 1-based call number
+	// (across ALL SignalInteractive invocations for this recorder,
+	// including retries -- #2289) and returns the error to fail that
+	// specific call with, or nil to succeed. Lets tests simulate
+	// "fail N times then succeed" or "always fail" without a real signaler.
+	signalErrFn func(callNum int) error
 }
 
 type signalCall struct {
@@ -780,6 +786,11 @@ func (r *recordingISSignaler) SignalInteractive(ctx context.Context, rrNamespace
 		rrNamespace: rrNamespace, rrName: rrName, taskID: taskID,
 		username: username, groups: groups, joinMode: joinMode,
 	})
+	if r.signalErrFn != nil {
+		if err := r.signalErrFn(len(r.signalCalls)); err != nil {
+			return "", err
+		}
+	}
 	return fmt.Sprintf("is-%s", rrName), nil
 }
 

--- a/pkg/apifrontend/tools/ka_investigate_intent_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_intent_test.go
@@ -732,11 +732,16 @@ var _ = Describe("kubernaut_investigate intent-based enhancement (#1332)", func(
 	})
 })
 
-func newTypedClientForInvestigateWithUIDAssignment(objects ...crclient.Object) crclient.Client {
+// newTypedClientForInvestigateWithUIDAssignment builds a fake client whose
+// Create interceptor assigns a UID (mirrors real apiserver behavior) for
+// tests that need to observe a persisted RR's UID (e.g. backfill
+// assertions). Unlike its sibling newTypedClientForInvestigate, this
+// variant never receives seed objects at any call site -- the UID
+// interceptor and pre-seeded objects are never needed together -- so it
+// intentionally takes no objects parameter (unparam, #2291).
+func newTypedClientForInvestigateWithUIDAssignment() crclient.Client {
 	return fake.NewClientBuilder().
 		WithScheme(investigateTestScheme()).
-		WithObjects(objects...).
-		WithStatusSubresource(objects...).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, c crclient.WithWatch, obj crclient.Object, opts ...crclient.CreateOption) error {
 				if obj.GetUID() == "" {

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -42,6 +42,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/validate"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 	"github.com/jordigilh/kubernaut/pkg/remediationrequest"
+	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
 	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
 
@@ -79,6 +80,99 @@ func extractRRIDFromContext(ctx context.Context) string {
 // takeoverISPhaseTimeout is used for the takeover path where AA must cancel
 // the autonomous session and re-submit before setting IS phase=Active.
 const takeoverISPhaseTimeout = 15 * time.Second
+
+// signalInteractiveMaxAttempts bounds the retry budget for transient
+// SignalInteractive (IS CRD creation) failures (#2289) before falling back
+// to fail-open with a surfaced warning. Short/bounded (max ~2.1s across 3
+// attempts with signalInteractiveRetryBackoff below) because this runs
+// synchronously inside a single kubernaut_investigate MCP tool call, well
+// within the takeoverISPhaseTimeout/isPhaseActivePollTimeout budgets
+// downstream.
+const signalInteractiveMaxAttempts = 3
+
+// signalInteractiveRetryBackoff configures the exponential backoff between
+// SignalInteractive retry attempts (pkg/shared/backoff, DD-SHARED-001).
+// Tuning mirrors pkg/shared/transport.DefaultRetryConfig(), the existing
+// in-repo precedent for short, bounded, synchronous in-request retries.
+var signalInteractiveRetryBackoff = backoff.Config{
+	BasePeriod:    100 * time.Millisecond,
+	MaxPeriod:     1 * time.Second,
+	Multiplier:    2.0,
+	JitterPercent: 20,
+}
+
+// signalInteractiveRequest groups the arguments threaded through
+// signalInteractiveWithRetry. Extracted per AGENTS.md's 8+-param
+// Options-pattern rule.
+type signalInteractiveRequest struct {
+	RRNamespace string
+	RRName      string
+	TaskID      string
+	Username    string
+	Groups      []string
+	JoinMode    string
+}
+
+// signalInteractiveWithRetry wraps signaler.SignalInteractive with a bounded
+// exponential-backoff retry (#2289, fixing the fail-open-on-first-error bug
+// reported against #2265) for transient failures. A "session_active"
+// conflict is a legitimate single-driver rejection from KA, never a
+// transient failure, so it is returned immediately without retrying.
+func signalInteractiveWithRetry(ctx context.Context, signaler ISSignaler, req signalInteractiveRequest) (string, error) {
+	var lastErr error
+	for attempt := 1; attempt <= signalInteractiveMaxAttempts; attempt++ {
+		isCRDName, err := signaler.SignalInteractive(ctx, req.RRNamespace, req.RRName, req.TaskID, req.Username, req.Groups, req.JoinMode)
+		if err == nil {
+			return isCRDName, nil
+		}
+		if strings.Contains(err.Error(), "session_active") {
+			return "", err
+		}
+		lastErr = err
+		if attempt < signalInteractiveMaxAttempts {
+			delay := signalInteractiveRetryBackoff.Calculate(int32(attempt))
+			if sleepErr := sleepInterruptible(ctx, delay); sleepErr != nil {
+				break
+			}
+		}
+	}
+	return "", lastErr
+}
+
+// sleepInterruptible sleeps for d, returning early with ctx.Err() if ctx is
+// cancelled first.
+func sleepInterruptible(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// emitInteractiveSignalFailedAudit records a SOC2/FedRAMP-auditable trace
+// (AU-2/AU-3) when SignalInteractive still fails after exhausting retries
+// (#2289) and the caller fails closed -- the consent-gating guarantee IS
+// CRD creation is meant to provide (DD-INTERACTIVE-002, BR-INTERACTIVE-010)
+// could not be established for this RR, so neither the RR (new-RR path) nor
+// the interactive attach (existing-RR/takeover path) is allowed to proceed.
+func emitInteractiveSignalFailedAudit(ctx context.Context, auditor audit.Emitter, rrID string, sigErr error) {
+	if auditor == nil {
+		return
+	}
+	auditor.Emit(ctx, &audit.Event{
+		Type: audit.EventInteractiveSignalFailed,
+		Detail: map[string]string{
+			"rr_id": rrID,
+			"error": sigErr.Error(),
+		},
+	})
+}
 
 // ISSignaler abstracts IS CRD creation for the investigate tool.
 // Implemented by session.CRDSessionService via an adapter in the handler layer.
@@ -486,8 +580,15 @@ func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args 
 // AF's own, separately-issued InvestigationSession Create call lands. The
 // returned *string is populated with the created IS CRD's name once
 // BeforeCreate succeeds (read by the caller after HandleCreateRRWithHooks
-// returns); it stays empty when no signaler is configured, the dedup branch
-// is hit (BeforeCreate never fires), or the signal itself fails open.
+// returns); it stays empty when no signaler is configured or the dedup
+// branch is hit (BeforeCreate never fires).
+//
+// SignalInteractive is retried with bounded exponential backoff on
+// transient failures (#2289, signalInteractiveWithRetry); if it still fails
+// after exhausting retries, BeforeCreate returns the error and
+// HandleCreateRRWithHooks aborts before the RR is ever created (fail
+// closed) -- an interactively-requested investigation must never silently
+// downgrade to an unconsented autonomous RR.
 func buildPreCreateISHooks(cfg *InvestigateConfig, identity *auth.UserIdentity) (CreateRRHooks, *string) {
 	signaledISCRDName := new(string)
 	if cfg.Signaler == nil || cfg.Client == nil || cfg.Namespace == "" {
@@ -509,15 +610,19 @@ func buildPreCreateISHooks(cfg *InvestigateConfig, identity *auth.UserIdentity) 
 			// first) -- joinMode is unconditionally "start", unlike the
 			// pre-existing-RR takeover path in signalInteractiveSession.
 			taskID := fmt.Sprintf("a2a-%s", rrName)
-			isCRDName, sigErr := cfg.Signaler.SignalInteractive(hctx, cfg.Namespace, rrName, taskID, signalUsername, groups, "start")
+			isCRDName, sigErr := signalInteractiveWithRetry(hctx, cfg.Signaler, signalInteractiveRequest{
+				RRNamespace: cfg.Namespace, RRName: rrName, TaskID: taskID,
+				Username: signalUsername, Groups: groups, JoinMode: "start",
+			})
 			if sigErr != nil {
 				logger := logr.FromContextOrDiscard(hctx)
 				if strings.Contains(sigErr.Error(), "session_active") {
 					logger.Info("IS CRD single-driver enforcement: rejecting duplicate session", "rr_id", rrName, "error", sigErr)
 					return sigErr
 				}
-				logger.Error(sigErr, "failed to create IS CRD before RR (proceeding without IS signal)", "rr_id", rrName)
-				return nil
+				logger.Error(sigErr, "failed to create IS CRD before RR after retries, failing closed (#2289)", "rr_id", rrName, "attempts", signalInteractiveMaxAttempts)
+				emitInteractiveSignalFailedAudit(hctx, cfg.Auditor, rrName, sigErr)
+				return fmt.Errorf("failed to establish interactive session after %d attempts: %w", signalInteractiveMaxAttempts, sigErr)
 			}
 			*signaledISCRDName = isCRDName
 			return nil
@@ -559,9 +664,18 @@ func resolveClusterScoped(ctx context.Context, args *InvestigateMCPArgs) bool {
 // signalInteractiveSession creates the IS CRD before the await loop when a
 // signaler is configured (DD-INTERACTIVE-002, BR-INTERACTIVE-010), detecting
 // and announcing a takeover if an autonomous investigation is already
-// running. Returns the created IS CRD name (used later for
-// UpdateCorrelation), or an error only when KA's single-driver enforcement
-// rejects a duplicate session.
+// running. SignalInteractive is retried with bounded exponential backoff on
+// transient failures (#2289, signalInteractiveWithRetry).
+//
+// Returns the created IS CRD name (used later for UpdateCorrelation), or an
+// error -- either KA's single-driver enforcement rejecting a duplicate
+// session, or (#2289) SignalInteractive still failing after exhausting
+// retries. Both fail closed: the caller aborts the interactive attach
+// entirely rather than silently starting an investigation with no
+// consent-gating established. This does not stop an already-running
+// autonomous RR on the takeover path (that decision was already committed
+// by the prior kubernaut_remediate call) -- it only refuses to accept the
+// interactive attach on top of it.
 func signalInteractiveSession(ctx context.Context, cfg *InvestigateConfig, rrID string, identity *auth.UserIdentity) (string, error) {
 	if cfg.Signaler == nil || cfg.Client == nil || cfg.Namespace == "" {
 		return "", nil
@@ -580,15 +694,19 @@ func signalInteractiveSession(ctx context.Context, cfg *InvestigateConfig, rrID 
 	}
 
 	taskID := fmt.Sprintf("a2a-%s", rrID)
-	isCRDName, sigErr := cfg.Signaler.SignalInteractive(ctx, cfg.Namespace, rrID, taskID, signalUsername, groups, joinMode)
+	isCRDName, sigErr := signalInteractiveWithRetry(ctx, cfg.Signaler, signalInteractiveRequest{
+		RRNamespace: cfg.Namespace, RRName: rrID, TaskID: taskID,
+		Username: signalUsername, Groups: groups, JoinMode: joinMode,
+	})
 	if sigErr != nil {
 		logger := logr.FromContextOrDiscard(ctx)
 		if strings.Contains(sigErr.Error(), "session_active") {
 			logger.Info("IS CRD single-driver enforcement: rejecting duplicate session", "rr_id", rrID, "error", sigErr)
 			return "", sigErr
 		}
-		logger.Error(sigErr, "failed to create IS CRD (proceeding without IS signal)", "rr_id", rrID)
-		return "", nil
+		logger.Error(sigErr, "failed to create IS CRD after retries, failing closed (#2289)", "rr_id", rrID, "attempts", signalInteractiveMaxAttempts)
+		emitInteractiveSignalFailedAudit(ctx, cfg.Auditor, rrID, sigErr)
+		return "", fmt.Errorf("failed to establish interactive session after %d attempts: %w", signalInteractiveMaxAttempts, sigErr)
 	}
 	return isCRDName, nil
 }

--- a/pkg/apifrontend/tools/ka_investigate_signal_retry_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_signal_retry_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// #2289: SignalInteractive (IS CRD creation) previously "failed open" on any
+// error other than a session_active conflict -- a single transient K8s API
+// hiccup silently downgraded an interactively-requested investigation to
+// unconsented autonomous remediation. This suite proves the fix: bounded
+// exponential-backoff retries (pkg/shared/backoff, DD-SHARED-001) for
+// transient failures, and a hard fail-closed (the tool call errors out, no
+// RR/investigation proceeds) once the retry budget is exhausted.
+var _ = Describe("SignalInteractive bounded retry + fail-closed (#2289)", func() {
+
+	Describe("signalInteractiveWithRetry", func() {
+		It("UT-AF-2289-001: succeeds on the first attempt without retrying", func() {
+			recorder := &recordingISSignaler{}
+			name, err := tools.SignalInteractiveWithRetry(context.Background(), recorder, tools.SignalInteractiveRequest{
+				RRNamespace: "kubernaut-system", RRName: "rr-1", TaskID: "task-1", Username: "user", JoinMode: "start",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal("is-rr-1"))
+			Expect(recorder.signalCalls).To(HaveLen(1))
+		})
+
+		It("UT-AF-2289-002: retries transient failures and succeeds once the signaler recovers", func() {
+			recorder := &recordingISSignaler{
+				signalErrFn: func(callNum int) error {
+					if callNum < tools.SignalInteractiveMaxAttempts {
+						return fmt.Errorf("transient k8s api error")
+					}
+					return nil
+				},
+			}
+			name, err := tools.SignalInteractiveWithRetry(context.Background(), recorder, tools.SignalInteractiveRequest{
+				RRNamespace: "kubernaut-system", RRName: "rr-2", TaskID: "task-2", Username: "user", JoinMode: "start",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal("is-rr-2"))
+			Expect(recorder.signalCalls).To(HaveLen(tools.SignalInteractiveMaxAttempts),
+				"must retry until the last configured attempt before succeeding")
+		})
+
+		It("UT-AF-2289-003: exhausts all attempts and returns the last error when the signaler never recovers", func() {
+			persistentErr := errors.New("persistent k8s api error")
+			recorder := &recordingISSignaler{
+				signalErrFn: func(int) error { return persistentErr },
+			}
+			_, err := tools.SignalInteractiveWithRetry(context.Background(), recorder, tools.SignalInteractiveRequest{
+				RRNamespace: "kubernaut-system", RRName: "rr-3", TaskID: "task-3", Username: "user", JoinMode: "start",
+			})
+			Expect(err).To(MatchError(persistentErr))
+			Expect(recorder.signalCalls).To(HaveLen(tools.SignalInteractiveMaxAttempts),
+				"must attempt exactly SignalInteractiveMaxAttempts times before giving up")
+		})
+
+		It("UT-AF-2289-004: does not retry a session_active conflict -- single-driver enforcement is a legitimate rejection, not a transient failure", func() {
+			sessionActiveErr := errors.New("session_active: another driver already attached")
+			recorder := &recordingISSignaler{
+				signalErrFn: func(int) error { return sessionActiveErr },
+			}
+			_, err := tools.SignalInteractiveWithRetry(context.Background(), recorder, tools.SignalInteractiveRequest{
+				RRNamespace: "kubernaut-system", RRName: "rr-4", TaskID: "task-4", Username: "user", JoinMode: "start",
+			})
+			Expect(err).To(MatchError(sessionActiveErr))
+			Expect(recorder.signalCalls).To(HaveLen(1), "session_active must fail fast, never retried")
+		})
+	})
+
+	Describe("existing-rr_id (takeover) path fails closed after retries exhaust (#2289)", func() {
+		It("UT-AF-2289-010: kubernaut_investigate returns an error and never starts KA when SignalInteractive persistently fails", func() {
+			tc := newTypedClientForInvestigate()
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					Fail("KA investigation must never start when the interactive signal could not be established (fail closed)")
+					return nil, nil
+				},
+			}
+			persistentErr := errors.New("etcd unavailable")
+			recorder := &recordingISSignaler{signalErrFn: func(int) error { return persistentErr }}
+			auditRec := &auditRecorder{}
+
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "sre@kubernaut.ai", Groups: []string{"sre"}})
+			_, err := tools.HandleInvestigationMCPWithRegistry(
+				ctx, &tools.InvestigateConfig{
+					MCPClient: mockMCP,
+					Client:    tc,
+					Namespace: "kubernaut-system",
+					Signaler:  recorder,
+					Auditor:   auditRec,
+				}, tools.InvestigateMCPArgs{RRID: "rr-2289-fail"},
+				false, "",
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to establish interactive session"))
+			Expect(recorder.signalCalls).To(HaveLen(tools.SignalInteractiveMaxAttempts))
+
+			Expect(auditRec.events).To(HaveLen(1))
+			Expect(auditRec.events[0].Type).To(Equal(audit.EventInteractiveSignalFailed))
+			Expect(auditRec.events[0].Detail["rr_id"]).To(Equal("rr-2289-fail"))
+		})
+	})
+
+	Describe("new-RR path fails closed before RR creation (#2289)", func() {
+		It("UT-AF-2289-020: kubernaut_investigate returns an error and creates no RemediationRequest when SignalInteractive persistently fails", func() {
+			tc := newTypedClientForInvestigateWithUIDAssignment()
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					Fail("KA investigation must never start when the interactive signal could not be established (fail closed)")
+					return nil, nil
+				},
+			}
+			persistentErr := errors.New("etcd unavailable")
+			recorder := &recordingISSignaler{signalErrFn: func(int) error { return persistentErr }}
+			auditRec := &auditRecorder{}
+
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "sre@kubernaut.ai", Groups: []string{"sre"}})
+			result, err := tools.HandleInvestigationMCPWithRegistry(
+				ctx, &tools.InvestigateConfig{
+					MCPClient: mockMCP,
+					Client:    tc,
+					Namespace: "kubernaut-system",
+					Signaler:  recorder,
+					Triager:   defaultTestTriager("prod", "Deployment", "web-2289"),
+					Auditor:   auditRec,
+				}, tools.InvestigateMCPArgs{
+					APIVersion: "apps/v1", Namespace: "prod", Kind: "Deployment", Name: "web-2289",
+				},
+				false, "sre-user",
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to establish interactive session"))
+			Expect(result.RRID).To(BeEmpty())
+
+			var rrs remediationv1.RemediationRequestList
+			Expect(tc.List(context.Background(), &rrs, crclient.InNamespace("kubernaut-system"))).To(Succeed())
+			Expect(rrs.Items).To(BeEmpty(), "#2289: an unconsented autonomous RR must never be created when the interactive signal fails closed")
+
+			Expect(auditRec.events).To(HaveLen(1))
+			Expect(auditRec.events[0].Type).To(Equal(audit.EventInteractiveSignalFailed))
+		})
+	})
+})

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -1936,6 +1936,7 @@ components:
             - $ref: '#/components/schemas/ApifrontendSeverityTriageFailedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigReloadedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigRejectedPayload'
+            - $ref: '#/components/schemas/ApifrontendInteractiveSignalFailedPayload'
             - $ref: '#/components/schemas/DatastorageRatelimitDeniedPayload'
             - $ref: '#/components/schemas/GatewayConfigReloadedPayload'
             - $ref: '#/components/schemas/GatewayConfigRejectedPayload'
@@ -2105,6 +2106,7 @@ components:
               'apifrontend.severity_triage.failed': '#/components/schemas/ApifrontendSeverityTriageFailedPayload'
               'apifrontend.config.reloaded': '#/components/schemas/ApifrontendConfigReloadedPayload'
               'apifrontend.config.rejected': '#/components/schemas/ApifrontendConfigRejectedPayload'
+              'apifrontend.interactive_signal.failed': '#/components/schemas/ApifrontendInteractiveSignalFailedPayload'
               # Issue #2285: CA hot-reload audit-trail parity (GAP-11 onReload
               # callback wired into the 8 remaining StartCAFileWatcher callers;
               # gateway.config.{reloaded,rejected} and
@@ -7356,4 +7358,20 @@ components:
         config_version:
           type: string
           description: Rejected configuration version or hash
+
+    ApifrontendInteractiveSignalFailedPayload:
+      type: object
+      required: [event_type, rr_id, error]
+      description: Interactive signal failed event payload (apifrontend.interactive_signal.failed) — SignalInteractive (IS CRD creation) failed after exhausting bounded retries and the caller failed closed; consent-gating (DD-INTERACTIVE-002, BR-INTERACTIVE-010) could not be established for this RR (SOC2 CC7.2, AU-2/AU-3, Issue #2289)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.interactive_signal.failed']
+          description: Event type for discriminator (matches parent event_type)
+        rr_id:
+          type: string
+          description: RemediationRequest name the interactive signal was attempted for
+        error:
+          type: string
+          description: Final error returned by SignalInteractive after exhausting retries
 

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -10678,6 +10678,172 @@ func (s *ApifrontendImpersonationCreatedPayloadEventType) UnmarshalJSON(data []b
 }
 
 // Encode implements json.Marshaler.
+func (s *ApifrontendInteractiveSignalFailedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendInteractiveSignalFailedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("rr_id")
+		e.Str(s.RrID)
+	}
+	{
+		e.FieldStart("error")
+		e.Str(s.Error)
+	}
+}
+
+var jsonFieldsNameOfApifrontendInteractiveSignalFailedPayload = [3]string{
+	0: "event_type",
+	1: "rr_id",
+	2: "error",
+}
+
+// Decode decodes ApifrontendInteractiveSignalFailedPayload from json.
+func (s *ApifrontendInteractiveSignalFailedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendInteractiveSignalFailedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "rr_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.RrID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rr_id\"")
+			}
+		case "error":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.Error = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"error\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendInteractiveSignalFailedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendInteractiveSignalFailedPayload) {
+					name = jsonFieldsNameOfApifrontendInteractiveSignalFailedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendInteractiveSignalFailedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendInteractiveSignalFailedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendInteractiveSignalFailedPayloadEventType as json.
+func (s ApifrontendInteractiveSignalFailedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendInteractiveSignalFailedPayloadEventType from json.
+func (s *ApifrontendInteractiveSignalFailedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendInteractiveSignalFailedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendInteractiveSignalFailedPayloadEventType(v) {
+	case ApifrontendInteractiveSignalFailedPayloadEventTypeApifrontendInteractiveSignalFailed:
+		*s = ApifrontendInteractiveSignalFailedPayloadEventTypeApifrontendInteractiveSignalFailed
+	default:
+		*s = ApifrontendInteractiveSignalFailedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendInteractiveSignalFailedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendInteractiveSignalFailedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *ApifrontendJWTDelegationPayload) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -19653,6 +19819,20 @@ func (s AuditEventEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case ApifrontendInteractiveSignalFailedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.interactive_signal.failed")
+		{
+			s := s.ApifrontendInteractiveSignalFailedPayload
+			{
+				e.FieldStart("rr_id")
+				e.Str(s.RrID)
+			}
+			{
+				e.FieldStart("error")
+				e.Str(s.Error)
+			}
+		}
 	case DatastorageRatelimitDeniedPayloadAuditEventEventData:
 		e.FieldStart("event_type")
 		e.Str("datastorage.ratelimit.denied")
@@ -20424,6 +20604,9 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 				case "apifrontend.config.rejected":
 					s.Type = ApifrontendConfigRejectedPayloadAuditEventEventData
 					found = true
+				case "apifrontend.interactive_signal.failed":
+					s.Type = ApifrontendInteractiveSignalFailedPayloadAuditEventEventData
+					found = true
 				case "datastorage.ratelimit.denied":
 					s.Type = DatastorageRatelimitDeniedPayloadAuditEventEventData
 					found = true
@@ -20863,6 +21046,10 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 		}
 	case ApifrontendConfigRejectedPayloadAuditEventEventData:
 		if err := s.ApifrontendConfigRejectedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendInteractiveSignalFailedPayloadAuditEventEventData:
+		if err := s.ApifrontendInteractiveSignalFailedPayload.Decode(d); err != nil {
 			return err
 		}
 	case DatastorageRatelimitDeniedPayloadAuditEventEventData:
@@ -25093,6 +25280,20 @@ func (s AuditEventRequestEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case ApifrontendInteractiveSignalFailedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.interactive_signal.failed")
+		{
+			s := s.ApifrontendInteractiveSignalFailedPayload
+			{
+				e.FieldStart("rr_id")
+				e.Str(s.RrID)
+			}
+			{
+				e.FieldStart("error")
+				e.Str(s.Error)
+			}
+		}
 	case DatastorageRatelimitDeniedPayloadAuditEventRequestEventData:
 		e.FieldStart("event_type")
 		e.Str("datastorage.ratelimit.denied")
@@ -25864,6 +26065,9 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 				case "apifrontend.config.rejected":
 					s.Type = ApifrontendConfigRejectedPayloadAuditEventRequestEventData
 					found = true
+				case "apifrontend.interactive_signal.failed":
+					s.Type = ApifrontendInteractiveSignalFailedPayloadAuditEventRequestEventData
+					found = true
 				case "datastorage.ratelimit.denied":
 					s.Type = DatastorageRatelimitDeniedPayloadAuditEventRequestEventData
 					found = true
@@ -26303,6 +26507,10 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 		}
 	case ApifrontendConfigRejectedPayloadAuditEventRequestEventData:
 		if err := s.ApifrontendConfigRejectedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendInteractiveSignalFailedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendInteractiveSignalFailedPayload.Decode(d); err != nil {
 			return err
 		}
 	case DatastorageRatelimitDeniedPayloadAuditEventRequestEventData:

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -5485,6 +5485,85 @@ func (s *ApifrontendImpersonationCreatedPayloadEventType) UnmarshalText(data []b
 	}
 }
 
+// Interactive signal failed event payload (apifrontend.interactive_signal.failed) —
+// SignalInteractive (IS CRD creation) failed after exhausting bounded retries and the caller failed
+// closed; consent-gating (DD-INTERACTIVE-002, BR-INTERACTIVE-010) could not be established for this
+// RR (SOC2 CC7.2, AU-2/AU-3, Issue.
+// Ref: #/components/schemas/ApifrontendInteractiveSignalFailedPayload
+type ApifrontendInteractiveSignalFailedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendInteractiveSignalFailedPayloadEventType `json:"event_type"`
+	// RemediationRequest name the interactive signal was attempted for.
+	RrID string `json:"rr_id"`
+	// Final error returned by SignalInteractive after exhausting retries.
+	Error string `json:"error"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendInteractiveSignalFailedPayload) GetEventType() ApifrontendInteractiveSignalFailedPayloadEventType {
+	return s.EventType
+}
+
+// GetRrID returns the value of RrID.
+func (s *ApifrontendInteractiveSignalFailedPayload) GetRrID() string {
+	return s.RrID
+}
+
+// GetError returns the value of Error.
+func (s *ApifrontendInteractiveSignalFailedPayload) GetError() string {
+	return s.Error
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendInteractiveSignalFailedPayload) SetEventType(val ApifrontendInteractiveSignalFailedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetRrID sets the value of RrID.
+func (s *ApifrontendInteractiveSignalFailedPayload) SetRrID(val string) {
+	s.RrID = val
+}
+
+// SetError sets the value of Error.
+func (s *ApifrontendInteractiveSignalFailedPayload) SetError(val string) {
+	s.Error = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendInteractiveSignalFailedPayloadEventType string
+
+const (
+	ApifrontendInteractiveSignalFailedPayloadEventTypeApifrontendInteractiveSignalFailed ApifrontendInteractiveSignalFailedPayloadEventType = "apifrontend.interactive_signal.failed"
+)
+
+// AllValues returns all ApifrontendInteractiveSignalFailedPayloadEventType values.
+func (ApifrontendInteractiveSignalFailedPayloadEventType) AllValues() []ApifrontendInteractiveSignalFailedPayloadEventType {
+	return []ApifrontendInteractiveSignalFailedPayloadEventType{
+		ApifrontendInteractiveSignalFailedPayloadEventTypeApifrontendInteractiveSignalFailed,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendInteractiveSignalFailedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendInteractiveSignalFailedPayloadEventTypeApifrontendInteractiveSignalFailed:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendInteractiveSignalFailedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendInteractiveSignalFailedPayloadEventType(data) {
+	case ApifrontendInteractiveSignalFailedPayloadEventTypeApifrontendInteractiveSignalFailed:
+		*s = ApifrontendInteractiveSignalFailedPayloadEventTypeApifrontendInteractiveSignalFailed
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
 // JWT delegation event payload (apifrontend.jwt.delegation) — original JWT forwarded to downstream
 // service (SOC2 CC6.1, Issue.
 // Ref: #/components/schemas/ApifrontendJWTDelegationPayload
@@ -8798,6 +8877,7 @@ type AuditEventEventData struct {
 	ApifrontendSeverityTriageFailedPayload       ApifrontendSeverityTriageFailedPayload
 	ApifrontendConfigReloadedPayload             ApifrontendConfigReloadedPayload
 	ApifrontendConfigRejectedPayload             ApifrontendConfigRejectedPayload
+	ApifrontendInteractiveSignalFailedPayload    ApifrontendInteractiveSignalFailedPayload
 	DatastorageRatelimitDeniedPayload            DatastorageRatelimitDeniedPayload
 	GatewayConfigReloadedPayload                 GatewayConfigReloadedPayload
 	GatewayConfigRejectedPayload                 GatewayConfigRejectedPayload
@@ -8965,6 +9045,7 @@ const (
 	ApifrontendSeverityTriageFailedPayloadAuditEventEventData                        AuditEventEventDataType = "apifrontend.severity_triage.failed"
 	ApifrontendConfigReloadedPayloadAuditEventEventData                              AuditEventEventDataType = "apifrontend.config.reloaded"
 	ApifrontendConfigRejectedPayloadAuditEventEventData                              AuditEventEventDataType = "apifrontend.config.rejected"
+	ApifrontendInteractiveSignalFailedPayloadAuditEventEventData                     AuditEventEventDataType = "apifrontend.interactive_signal.failed"
 	DatastorageRatelimitDeniedPayloadAuditEventEventData                             AuditEventEventDataType = "datastorage.ratelimit.denied"
 	GatewayConfigReloadedPayloadAuditEventEventData                                  AuditEventEventDataType = "gateway.config.reloaded"
 	GatewayConfigRejectedPayloadAuditEventEventData                                  AuditEventEventDataType = "gateway.config.rejected"
@@ -9501,6 +9582,11 @@ func (s AuditEventEventData) IsApifrontendConfigReloadedPayload() bool {
 // IsApifrontendConfigRejectedPayload reports whether AuditEventEventData is ApifrontendConfigRejectedPayload.
 func (s AuditEventEventData) IsApifrontendConfigRejectedPayload() bool {
 	return s.Type == ApifrontendConfigRejectedPayloadAuditEventEventData
+}
+
+// IsApifrontendInteractiveSignalFailedPayload reports whether AuditEventEventData is ApifrontendInteractiveSignalFailedPayload.
+func (s AuditEventEventData) IsApifrontendInteractiveSignalFailedPayload() bool {
+	return s.Type == ApifrontendInteractiveSignalFailedPayloadAuditEventEventData
 }
 
 // IsDatastorageRatelimitDeniedPayload reports whether AuditEventEventData is DatastorageRatelimitDeniedPayload.
@@ -11903,6 +11989,27 @@ func NewApifrontendConfigRejectedPayloadAuditEventEventData(v ApifrontendConfigR
 	return s
 }
 
+// SetApifrontendInteractiveSignalFailedPayload sets AuditEventEventData to ApifrontendInteractiveSignalFailedPayload.
+func (s *AuditEventEventData) SetApifrontendInteractiveSignalFailedPayload(v ApifrontendInteractiveSignalFailedPayload) {
+	s.Type = ApifrontendInteractiveSignalFailedPayloadAuditEventEventData
+	s.ApifrontendInteractiveSignalFailedPayload = v
+}
+
+// GetApifrontendInteractiveSignalFailedPayload returns ApifrontendInteractiveSignalFailedPayload and true boolean if AuditEventEventData is ApifrontendInteractiveSignalFailedPayload.
+func (s AuditEventEventData) GetApifrontendInteractiveSignalFailedPayload() (v ApifrontendInteractiveSignalFailedPayload, ok bool) {
+	if !s.IsApifrontendInteractiveSignalFailedPayload() {
+		return v, false
+	}
+	return s.ApifrontendInteractiveSignalFailedPayload, true
+}
+
+// NewApifrontendInteractiveSignalFailedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendInteractiveSignalFailedPayload.
+func NewApifrontendInteractiveSignalFailedPayloadAuditEventEventData(v ApifrontendInteractiveSignalFailedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendInteractiveSignalFailedPayload(v)
+	return s
+}
+
 // SetDatastorageRatelimitDeniedPayload sets AuditEventEventData to DatastorageRatelimitDeniedPayload.
 func (s *AuditEventEventData) SetDatastorageRatelimitDeniedPayload(v DatastorageRatelimitDeniedPayload) {
 	s.Type = DatastorageRatelimitDeniedPayloadAuditEventEventData
@@ -12930,6 +13037,7 @@ type AuditEventRequestEventData struct {
 	ApifrontendSeverityTriageFailedPayload       ApifrontendSeverityTriageFailedPayload
 	ApifrontendConfigReloadedPayload             ApifrontendConfigReloadedPayload
 	ApifrontendConfigRejectedPayload             ApifrontendConfigRejectedPayload
+	ApifrontendInteractiveSignalFailedPayload    ApifrontendInteractiveSignalFailedPayload
 	DatastorageRatelimitDeniedPayload            DatastorageRatelimitDeniedPayload
 	GatewayConfigReloadedPayload                 GatewayConfigReloadedPayload
 	GatewayConfigRejectedPayload                 GatewayConfigRejectedPayload
@@ -13097,6 +13205,7 @@ const (
 	ApifrontendSeverityTriageFailedPayloadAuditEventRequestEventData                               AuditEventRequestEventDataType = "apifrontend.severity_triage.failed"
 	ApifrontendConfigReloadedPayloadAuditEventRequestEventData                                     AuditEventRequestEventDataType = "apifrontend.config.reloaded"
 	ApifrontendConfigRejectedPayloadAuditEventRequestEventData                                     AuditEventRequestEventDataType = "apifrontend.config.rejected"
+	ApifrontendInteractiveSignalFailedPayloadAuditEventRequestEventData                            AuditEventRequestEventDataType = "apifrontend.interactive_signal.failed"
 	DatastorageRatelimitDeniedPayloadAuditEventRequestEventData                                    AuditEventRequestEventDataType = "datastorage.ratelimit.denied"
 	GatewayConfigReloadedPayloadAuditEventRequestEventData                                         AuditEventRequestEventDataType = "gateway.config.reloaded"
 	GatewayConfigRejectedPayloadAuditEventRequestEventData                                         AuditEventRequestEventDataType = "gateway.config.rejected"
@@ -13633,6 +13742,11 @@ func (s AuditEventRequestEventData) IsApifrontendConfigReloadedPayload() bool {
 // IsApifrontendConfigRejectedPayload reports whether AuditEventRequestEventData is ApifrontendConfigRejectedPayload.
 func (s AuditEventRequestEventData) IsApifrontendConfigRejectedPayload() bool {
 	return s.Type == ApifrontendConfigRejectedPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendInteractiveSignalFailedPayload reports whether AuditEventRequestEventData is ApifrontendInteractiveSignalFailedPayload.
+func (s AuditEventRequestEventData) IsApifrontendInteractiveSignalFailedPayload() bool {
+	return s.Type == ApifrontendInteractiveSignalFailedPayloadAuditEventRequestEventData
 }
 
 // IsDatastorageRatelimitDeniedPayload reports whether AuditEventRequestEventData is DatastorageRatelimitDeniedPayload.
@@ -16032,6 +16146,27 @@ func (s AuditEventRequestEventData) GetApifrontendConfigRejectedPayload() (v Api
 func NewApifrontendConfigRejectedPayloadAuditEventRequestEventData(v ApifrontendConfigRejectedPayload) AuditEventRequestEventData {
 	var s AuditEventRequestEventData
 	s.SetApifrontendConfigRejectedPayload(v)
+	return s
+}
+
+// SetApifrontendInteractiveSignalFailedPayload sets AuditEventRequestEventData to ApifrontendInteractiveSignalFailedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendInteractiveSignalFailedPayload(v ApifrontendInteractiveSignalFailedPayload) {
+	s.Type = ApifrontendInteractiveSignalFailedPayloadAuditEventRequestEventData
+	s.ApifrontendInteractiveSignalFailedPayload = v
+}
+
+// GetApifrontendInteractiveSignalFailedPayload returns ApifrontendInteractiveSignalFailedPayload and true boolean if AuditEventRequestEventData is ApifrontendInteractiveSignalFailedPayload.
+func (s AuditEventRequestEventData) GetApifrontendInteractiveSignalFailedPayload() (v ApifrontendInteractiveSignalFailedPayload, ok bool) {
+	if !s.IsApifrontendInteractiveSignalFailedPayload() {
+		return v, false
+	}
+	return s.ApifrontendInteractiveSignalFailedPayload, true
+}
+
+// NewApifrontendInteractiveSignalFailedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendInteractiveSignalFailedPayload.
+func NewApifrontendInteractiveSignalFailedPayloadAuditEventRequestEventData(v ApifrontendInteractiveSignalFailedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendInteractiveSignalFailedPayload(v)
 	return s
 }
 

--- a/pkg/datastorage/ogen-client/oas_validators_gen.go
+++ b/pkg/datastorage/ogen-client/oas_validators_gen.go
@@ -2168,6 +2168,38 @@ func (s ApifrontendImpersonationCreatedPayloadEventType) Validate() error {
 	}
 }
 
+func (s *ApifrontendInteractiveSignalFailedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendInteractiveSignalFailedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.interactive_signal.failed":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
 func (s *ApifrontendJWTDelegationPayload) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -3731,6 +3763,11 @@ func (s AuditEventEventData) Validate() error {
 			return err
 		}
 		return nil
+	case ApifrontendInteractiveSignalFailedPayloadAuditEventEventData:
+		if err := s.ApifrontendInteractiveSignalFailedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
 	case DatastorageRatelimitDeniedPayloadAuditEventEventData:
 		if err := s.DatastorageRatelimitDeniedPayload.Validate(); err != nil {
 			return err
@@ -4483,6 +4520,11 @@ func (s AuditEventRequestEventData) Validate() error {
 		return nil
 	case ApifrontendConfigRejectedPayloadAuditEventRequestEventData:
 		if err := s.ApifrontendConfigRejectedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendInteractiveSignalFailedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendInteractiveSignalFailedPayload.Validate(); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -1936,6 +1936,7 @@ components:
             - $ref: '#/components/schemas/ApifrontendSeverityTriageFailedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigReloadedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigRejectedPayload'
+            - $ref: '#/components/schemas/ApifrontendInteractiveSignalFailedPayload'
             - $ref: '#/components/schemas/DatastorageRatelimitDeniedPayload'
             - $ref: '#/components/schemas/GatewayConfigReloadedPayload'
             - $ref: '#/components/schemas/GatewayConfigRejectedPayload'
@@ -2105,6 +2106,7 @@ components:
               'apifrontend.severity_triage.failed': '#/components/schemas/ApifrontendSeverityTriageFailedPayload'
               'apifrontend.config.reloaded': '#/components/schemas/ApifrontendConfigReloadedPayload'
               'apifrontend.config.rejected': '#/components/schemas/ApifrontendConfigRejectedPayload'
+              'apifrontend.interactive_signal.failed': '#/components/schemas/ApifrontendInteractiveSignalFailedPayload'
               # Issue #2285: CA hot-reload audit-trail parity (GAP-11 onReload
               # callback wired into the 8 remaining StartCAFileWatcher callers;
               # gateway.config.{reloaded,rejected} and
@@ -7356,4 +7358,20 @@ components:
         config_version:
           type: string
           description: Rejected configuration version or hash
+
+    ApifrontendInteractiveSignalFailedPayload:
+      type: object
+      required: [event_type, rr_id, error]
+      description: Interactive signal failed event payload (apifrontend.interactive_signal.failed) — SignalInteractive (IS CRD creation) failed after exhausting bounded retries and the caller failed closed; consent-gating (DD-INTERACTIVE-002, BR-INTERACTIVE-010) could not be established for this RR (SOC2 CC7.2, AU-2/AU-3, Issue #2289)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.interactive_signal.failed']
+          description: Event type for discriminator (matches parent event_type)
+        rr_id:
+          type: string
+          description: RemediationRequest name the interactive signal was attempted for
+        error:
+          type: string
+          description: Final error returned by SignalInteractive after exhausting retries
 

--- a/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
+++ b/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
@@ -326,17 +326,28 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 2->3 [E2E-FP-18
 })
 
 // E2E-FP-1912-001: No Reinvocation After Session-Terminal Tool (issue #1912).
-// A single combined message declares interaction_mode=full_remediation_autonomous
-// on kubernaut_investigate (so no DD-AF-011 checkpoint is left blocking --
-// driverActive alone is what must be cleared) then completes the driver
-// session with kubernaut_complete in the very same turn. Pre-#1912-fix,
-// phaseGuardAfter's isTerminal branch cleared the ActiveContextRegistry
-// entry but left driverActive stuck true, so NeedsReinvocationCtx could
-// misread a subsequent text-only model turn as "investigation still
-// active" and synthesize a "continue the investigation" nudge back into an
-// already-closed session. This proves the real AF/A2A stack never lets
-// that resurrect into a consequential action: the RR reaches a clean
-// terminal state and no WorkflowExecution is ever created for it.
+// A single combined message chains kubernaut_remediate -> kubernaut_investigate
+// (attaching a chat-visible driver session to the already-autonomous RR,
+// declaring interaction_mode=full_remediation_autonomous so no DD-AF-011
+// checkpoint is left blocking -- driverActive alone is what must be
+// cleared) -> kubernaut_complete, ending the driver session in the very
+// same turn. Pre-#1912-fix, phaseGuardAfter's isTerminal branch cleared the
+// ActiveContextRegistry entry but left driverActive stuck true, so
+// NeedsReinvocationCtx could misread a subsequent text-only model turn as
+// "investigation still active" and synthesize a "continue the
+// investigation" nudge back into an already-closed session.
+//
+// A synthetic not-actionable Warning K8s Event (reason
+// E2EFP1912NotActionable, mirroring E2E-FP-1918-001's identical technique
+// below) is seeded on the target Deployment before the chat turn so KA's
+// RCA deterministically concludes is_actionable=false, independent of
+// RO/AA/KA's autonomous reconciliation timing. This is required because
+// kubernaut_investigate's rr_id attach here is a best-effort chat-session
+// observability hook, not a consent veto over the RR that kubernaut_remediate
+// already committed to running autonomously (#2265 investigation) -- so
+// #1912's actual claim (driverActive hygiene / no errant reinvocation) must
+// not depend on winning that unrelated, intentionally-non-deterministic race
+// to prove "no WorkflowExecution is ever created for it".
 var _ = Describe("AF A2A No Reinvocation After Session-Terminal Tool [E2E-FP-1912-001]", Label("fp", "af", "a2a", "interactive", "issue-1912"), func() {
 
 	It("should complete the driver session cleanly and never reinvoke into a further workflow action", NodeTimeout(6*time.Minute), func(_ SpecContext) {
@@ -397,6 +408,31 @@ var _ = Describe("AF A2A No Reinvocation After Session-Terminal Tool [E2E-FP-191
 			},
 		}
 		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		By("Seeding a synthetic not-actionable signal so KA's RCA is deterministic regardless of takeover timing (#2265)")
+		// See E2E-FP-1918-001's identical Event below for the full explanation
+		// of why this must be a dedicated Reason (not the built-in
+		// "MOCK_NOT_ACTIONABLE" keyword) and why deriveSignalName's Tier 3a
+		// (not a tool-call-argument keyword) is the safe way to ground this.
+		Expect(k8sClient.Create(ctx, &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "memory-eater-e2efp1912-not-actionable-",
+				Namespace:    targetNS,
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Kind:       "Deployment",
+				Namespace:  targetNS,
+				Name:       "memory-eater",
+				APIVersion: "apps/v1",
+			},
+			Reason:         "E2EFP1912NotActionable",
+			Message:        "E2E-FP-1912-001: synthetic signal so KA's RCA concludes is_actionable=false",
+			Type:           corev1.EventTypeWarning,
+			FirstTimestamp: metav1.Now(),
+			LastTimestamp:  metav1.Now(),
+			Count:          1,
+			Source:         corev1.EventSource{Component: "e2e-fp-1912-test"},
+		})).To(Succeed())
 
 		By("Turn 1 (single message): declare full_remediation_autonomous mode, then complete the driver session in the same turn")
 		body := fpA2ATasksSend("fp-t1912-1",

--- a/test/services/mock-llm/scenarios/registry_default.go
+++ b/test/services/mock-llm/scenarios/registry_default.go
@@ -231,6 +231,11 @@ func defaultRegistryWithGoldenDir(goldenDir string) *Registry {
 	// notActionableGroundedConfig's doc comment for the full explanation).
 	r.Register(signalScenario("not_actionable_grounded_1918", []string{"e2efp1918notactionable"}, notActionableGroundedConfig()))
 
+	// Issue #1912/#2265: grounded not-actionable signal for E2E-FP-1912-001,
+	// same rationale and safety properties as not_actionable_grounded_1918
+	// above (see notActionableGrounded1912Config's doc comment).
+	r.Register(signalScenario("not_actionable_grounded_1912", []string{"e2efp1912notactionable"}, notActionableGrounded1912Config()))
+
 	// Issue #1170: Multi-turn param validation self-correction (BR-KA-191).
 	// Returns bad params on first call, corrected params after validation feedback.
 	r.Register(paramValidationSelfcorrectScenarioNew())

--- a/test/services/mock-llm/scenarios/scenario_mock_keywords.go
+++ b/test/services/mock-llm/scenarios/scenario_mock_keywords.go
@@ -161,6 +161,36 @@ func notActionableGroundedConfig() MockScenarioConfig {
 	}
 }
 
+// notActionableGrounded1912Config backs E2E-FP-1912-001 (issue #1912: no
+// reinvocation after a session-terminal tool; #2265 tracks a CI flake where
+// this test's "no WorkflowExecution is ever created" assertion had no
+// deterministic backstop). Mirrors notActionableGroundedConfig's pattern
+// exactly (same grounding mechanism, same signalScenario-only matching, same
+// leak-avoidance rationale -- see that config's doc comment) with a distinct
+// SignalName/ScenarioName so the two tests can't collide. Without this, the
+// RR created by E2E-FP-1912-001's kubernaut_remediate call (no synthetic
+// signal, "unknown" derived SignalName) falls through to the generic
+// "af_unknown" -> oomkilledConfig() actionable scenario shared with genuinely
+// OOM-flavored tests elsewhere in the suite, racing the test's own
+// interactive-takeover attach against RO/AA/KA's independent, already-
+// committed autonomous reconciliation of that RR (#2265's actual root cause:
+// a test-design gap, not a takeover-path defect -- see issue discussion).
+// Grounding the signal here makes KA's RCA deterministically resolve
+// is_actionable=false regardless of that race's outcome, exactly as 1918
+// already does for its own scenario.
+func notActionableGrounded1912Config() MockScenarioConfig {
+	return MockScenarioConfig{
+		ScenarioName: "not_actionable_grounded_1912", SignalName: "E2EFP1912NotActionable", Severity: "info",
+		Confidence:   0.0,
+		Rationale:    "E2E-FP-1912-001: synthetic not-actionable signal, zero-replica Deployment never scheduled a Pod",
+		RootCause:    "Synthetic E2E test signal on a zero-replica Deployment -- no real workload or fault exists",
+		ResourceKind: "Deployment", ResourceNS: "not-actionable-1912", ResourceName: "memory-eater",
+		APIVersion:           "apps/v1",
+		InvestigationOutcome: "predictive_no_action",
+		IsActionable:         BoolPtr(false),
+	}
+}
+
 func parallelToolsConfig() MockScenarioConfig {
 	actionable := true
 	return MockScenarioConfig{


### PR DESCRIPTION
## Summary

Three related, individually-committed fixes that came out of investigating the recurring CI failures on #2265 ("interactive session not correctly recognized as interactive"):

1. **`fix(apifrontend)`** — `SignalInteractive` (IS CRD creation, the mechanism gating autonomous remediation behind user consent per DD-INTERACTIVE-002/BR-INTERACTIVE-010) previously **failed open**: any error other than a `session_active` conflict was logged and swallowed, silently letting RR creation proceed without consent-gating. Now retries transient failures with bounded exponential backoff (`pkg/shared/backoff`), and **fails closed** (hard error, no RR created) once the retry budget is exhausted. Every exhausted-retry failure emits a persisted `apifrontend.interactive_signal.failed` audit event (SOC2 CC7.2, AU-2/AU-3).
2. **`docs(interactive)`** — DD-INTERACTIVE-002, BR-INTERACTIVE-004, and apifrontend's `ARCHITECTURE.md` still described the superseded "cancel + reconstruct" takeover model. Reconciled with the actual "upgrade-in-place" model (issue #1390) and the `AgentSession` CRD architecture (DD-AA-KA-001). No code changes.
3. **`test(e2e-fullpipeline)`** — `E2E-FP-1912-001` relied on whatever signal name KA's RCA happened to derive at runtime to land on a not-actionable mock-LLM scenario, which was the source of #2265's recurring CI flake. Applied the same deterministic-seeding pattern already used by sibling `E2E-FP-1918-001`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./pkg/apifrontend/... ./pkg/datastorage/...` — all pass, including 6 new specs (`UT-AF-2289-001` through `UT-AF-2289-020`) covering retry/exhaustion/fail-closed/audit-event behavior for both the takeover and new-RR paths
- [x] `E2E-FP-1912-001` + `E2E-FP-1918-001` run live on a real Kind cluster (not just CI) — both pass cleanly (17.0s / 16.0s)

## Closes

Closes #2265
Closes #2289