### PR TITLE
feat(kubernautagent): honor endpoint override for native Anthropic/Gemini LLM clients

### DIFF
--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"google.golang.org/genai"
 
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/credentials"
@@ -140,6 +141,17 @@ func buildGeminiNativeClient(cfg types.LLMConfig) (llm.Client, error) {
 	opts = append(opts, geminifamily.WithHTTPTimeout(timeout))
 	opts = append(opts, geminiReasoningOptions(cfg)...)
 
+	// #2255 / BR-AI-089: symmetric with buildAnthropicNativeClient below —
+	// honor an operator-configured endpoint override (e.g. an AI gateway or
+	// NetworkPolicy-allowlisted proxy, see #1819) instead of always hitting
+	// generativelanguage.googleapis.com. Empty cfg.Endpoint (the default
+	// for existing deployments) is a no-op — zero regression. Mirrors the
+	// pattern already production-wired in API Frontend's Gemini triager
+	// (cmd/apifrontend/backend_deps.go).
+	if cfg.Endpoint != "" {
+		opts = append(opts, geminifamily.WithHTTPOptions(genai.HTTPOptions{BaseURL: cfg.Endpoint}))
+	}
+
 	chain, err := buildTransportChain(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("gemini transport chain: %w", err)
@@ -178,6 +190,14 @@ func buildAnthropicNativeClient(cfg types.LLMConfig) (llm.Client, error) {
 	}
 	opts = append(opts, anthropicfamily.WithHTTPTimeout(timeout))
 	opts = append(opts, anthropicReasoningOptions(cfg)...)
+
+	// #2255 / BR-AI-089: honor an operator-configured endpoint override
+	// (e.g. an AI gateway or NetworkPolicy-allowlisted proxy, see #1819)
+	// instead of always hitting api.anthropic.com. Empty cfg.Endpoint (the
+	// default for existing deployments) is a no-op — zero regression.
+	if cfg.Endpoint != "" {
+		opts = append(opts, anthropicfamily.WithBaseURL(cfg.Endpoint))
+	}
 
 	chain, err := buildTransportChain(cfg)
 	if err != nil {

--- a/cmd/kubernautagent/llm_builder_endpoint_2255_test.go
+++ b/cmd/kubernautagent/llm_builder_endpoint_2255_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"github.com/jordigilh/kubernaut/pkg/shared/types"
+)
+
+// Issue #2255 / BR-AI-089: native-auth-mode LLM client construction must
+// honor an operator-configured cfg.Endpoint (FedRAMP AC-4, information flow
+// enforcement). These IT tests exercise the real production dispatch path
+// (buildLLMClientFromConfig -> buildAnthropicNativeClient/
+// buildGeminiNativeClient), proving the wiring rather than just the
+// package-local constructors (CHECKPOINT W).
+var _ = Describe("buildLLMClientFromConfig — native endpoint override wiring (#2255, BR-AI-089)", func() {
+
+	Describe("provider=anthropic honors cfg.Endpoint (IT-KA-2255-101)", func() {
+		var server *httptest.Server
+
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+
+		It("IT-KA-2255-101 [AC-4]: sends the outgoing request to the operator-configured endpoint", func() {
+			var received bool
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				received = true
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"id": "msg_it_2255_101",
+					"type": "message",
+					"role": "assistant",
+					"model": "claude-sonnet-4-6",
+					"stop_reason": "end_turn",
+					"content": [{"type": "text", "text": "routed via gateway"}],
+					"usage": {"input_tokens": 5, "output_tokens": 3}
+				}`))
+			}))
+
+			cfg := types.LLMConfig{
+				Provider: types.LLMProviderAnthropic,
+				Model:    "claude-sonnet-4-6",
+				APIKey:   "sk-ant-fake-test-key",
+				Endpoint: server.URL,
+			}
+
+			client, err := buildLLMClientFromConfig(context.Background(), cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(received).To(BeTrue(),
+				"operator's configured ai.llm.endpoint (e.g. an AI gateway or NetworkPolicy-allowlisted proxy, see issue #1819) must actually receive the request")
+			Expect(resp.Message.Content).To(Equal("routed via gateway"))
+		})
+	})
+
+	Describe("provider=gemini honors cfg.Endpoint (IT-KA-2255-102)", func() {
+		var server *httptest.Server
+
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+
+		It("IT-KA-2255-102 [AC-4]: sends the outgoing request to the operator-configured endpoint", func() {
+			var received bool
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				received = true
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"candidates": [{
+						"content": {"role": "model", "parts": [{"text": "routed via gateway"}]},
+						"finishReason": "STOP"
+					}],
+					"usageMetadata": {"promptTokenCount": 5, "candidatesTokenCount": 3, "totalTokenCount": 8}
+				}`))
+			}))
+
+			cfg := types.LLMConfig{
+				Provider: types.LLMProviderGemini,
+				Model:    "gemini-2.5-pro",
+				APIKey:   "fake-gemini-key",
+				Endpoint: server.URL,
+			}
+
+			client, err := buildLLMClientFromConfig(context.Background(), cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(received).To(BeTrue(),
+				"operator's configured ai.llm.endpoint (e.g. an AI gateway or NetworkPolicy-allowlisted proxy, see issue #1819) must actually receive the request")
+			Expect(resp.Message.Content).To(Equal("routed via gateway"))
+		})
+	})
+
+	Describe("zero-regression when cfg.Endpoint is empty (IT-KA-2255-103)", func() {
+		// No behavior change for existing deployments that don't set
+		// ai.llm.endpoint for these two providers: client construction must
+		// keep succeeding exactly as before this fix.
+		It("IT-KA-2255-103a: provider=anthropic still constructs successfully with no endpoint", func() {
+			cfg := types.LLMConfig{
+				Provider: types.LLMProviderAnthropic,
+				Model:    "claude-sonnet-4-6",
+				APIKey:   "sk-ant-fake-test-key",
+			}
+
+			client, err := buildLLMClientFromConfig(context.Background(), cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+		})
+
+		It("IT-KA-2255-103b: provider=gemini still constructs successfully with no endpoint", func() {
+			cfg := types.LLMConfig{
+				Provider: types.LLMProviderGemini,
+				Model:    "gemini-2.5-pro",
+				APIKey:   "fake-gemini-key",
+			}
+
+			client, err := buildLLMClientFromConfig(context.Background(), cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+		})
+	})
+})

--- a/cmd/kubernautagent/llm_builder_wiring_1580_1581_test.go
+++ b/cmd/kubernautagent/llm_builder_wiring_1580_1581_test.go
@@ -98,13 +98,23 @@ var _ = Describe("buildLLMClientFromConfig — provider dispatch wiring (#1578 #
 		// option composition (anthropicReasoningOptions(cfg), the same
 		// unexported helper the production dispatch path calls) against a
 		// live httptest server, and asserts the real outgoing HTTP body
-		// contains "thinking". buildAnthropicNativeClient itself cannot be
-		// redirected to a test server in production code (Anthropic's native
-		// API has no operator-facing "endpoint override" concept — unlike
-		// openai_compatible, see buildOpenAICompatClient — so adding one
-		// purely for testability would be speculative code with no real
-		// deployment use case). anthropicfamily.WithSDKOptions is already
-		// documented as test-only for exactly this purpose.
+		// contains "thinking".
+		//
+		// Correction (#2255, BR-AI-089): this comment previously claimed
+		// Anthropic's native API has no operator-facing "endpoint override"
+		// concept and that adding one would be "speculative code with no
+		// real deployment use case" — that claim did not hold up against a
+		// concrete deployment need (routing through an AI gateway / private
+		// proxy, FedRAMP AC-4) and was reversed: cfg.Endpoint is now wired
+		// into buildAnthropicNativeClient via anthropicfamily.WithBaseURL
+		// (see llm_builder_endpoint_2255_test.go's IT-KA-2255-101, which
+		// exercises that path directly through buildLLMClientFromConfig).
+		// This test is left using the lower-level
+		// anthropicfamily.WithSDKOptions(option.WithBaseURL(...)) escape
+		// hatch rather than switching to cfg.Endpoint, since its purpose is
+		// narrowly to isolate the reasoning-param wiring (IT-KA-1578-003),
+		// not to re-prove the endpoint-override wiring already covered by
+		// IT-KA-2255-101.
 		var (
 			server       *httptest.Server
 			receivedBody map[string]interface{}

--- a/docs/requirements/BR-AI-089-llm-native-client-endpoint-override.md
+++ b/docs/requirements/BR-AI-089-llm-native-client-endpoint-override.md
@@ -1,0 +1,71 @@
+# BR-AI-089: Native-Auth-Mode LLM Client Endpoint Override
+
+**Business Requirement ID**: BR-AI-089
+**Category**: AI (Kubernaut Agent LLM provider configuration)
+**Priority**: P2
+**Target Version**: V1.6
+**Status**: Approved
+
+**Related Design Decisions**:
+- [DD-LLM-004: Generalized Anthropic-Family Client and OpenAI-Compatible Client (langchaingo removal)](../architecture/decisions/DD-LLM-004-langchaingo-removal-generalized-clients.md)
+- [DD-LLM-007: AF and KA Intentionally Do Not Share an Anthropic Client](../architecture/decisions/DD-LLM-007-af-ka-anthropic-client-divergence.md)
+- [DD-LLM-010: Adopt eino-ext's agenticgemini for KA's Native Gemini Client](../architecture/decisions/DD-LLM-010-eino-agenticgemini-for-ka-gemini-client.md)
+
+**Related Issues**: #2255 (parent, Anthropic native), #1819 (KubernautAgent NetworkPolicy egress allowlist, keyed on `ai.llm.endpoint` — direct consumer of this BR), #1342 (LLM transport chain parity — headers/OAuth2/mTLS already solved for these providers)
+
+---
+
+## Business Need
+
+### Problem Statement
+
+Kubernaut Agent (KA)'s native-auth-mode LLM client constructors — `buildAnthropicNativeClient` and `buildGeminiNativeClient` (`cmd/kubernautagent/llm_builder.go`) — never read `cfg.Endpoint` when building their respective clients. Both are left to their SDK's hardcoded default (`https://api.anthropic.com` for Anthropic; `generativelanguage.googleapis.com` for Gemini), regardless of what an operator configures under `ai.llm.endpoint`.
+
+This is a silent configuration footgun, not a hard failure: `types.LLMConfig.Validate` and `internal/kubernautagent/config`'s `LLMRuntimeConfig.Validate` both already treat `endpoint` as *optional* (not forbidden) for `provider: anthropic`/`provider: gemini`, and validate it as a well-formed URL when set. An operator can configure `ai.llm.endpoint` for these providers today, have it pass all validation at startup, and have zero effect on where requests actually go — worse than an outright rejection, because the misconfiguration is invisible.
+
+This is asymmetric with KA's other provider paths:
+- `provider: openai`/`openai_compatible` **require** an explicit endpoint (no universal default makes sense for self-hosted/Azure/vLLM/LiteLLM).
+- `provider: vertex_ai` derives its endpoint from `vertexProject`/`vertexLocation` via the Anthropic/Gemini SDKs' own Vertex middleware.
+- `provider: anthropic`/`gemini` (native) silently ignore any endpoint override entirely.
+
+The rest of KA's transport chain (custom headers, OAuth2 client-credentials, mTLS via `tlsCaFile`/`tlsCertFile`) is already wired for native `anthropic`/`gemini` via `buildTransportChain(cfg)` (issue #1342) — the **only** missing piece for these two provider paths is the target URL itself.
+
+### Business Objective
+
+Allow operators to route native-auth-mode Anthropic and Gemini traffic through an enterprise AI gateway (e.g. Envoy AI Gateway) or private network proxy instead of the provider's public SaaS default, closing the last provider-path gap in KA's ability to enforce a controlled LLM egress boundary.
+
+### Compliance Driver
+
+**FedRAMP AC-4 (Information Flow Enforcement)**: `openai`/`openai_compatible` already satisfy this control today (endpoint is required); `vertex_ai` satisfies it implicitly via GCP project/location scoping. Native `anthropic`/`gemini` are the last two provider paths where KA cannot enforce a controlled egress path.
+
+This is not a hypothetical control gap: open issue #1819 (KubernautAgent NetworkPolicy hardening, v1.6 milestone) adds a `kubernaut.np.llmEgress` Helm NetworkPolicy helper that allowlists KA's egress **specifically keyed off `ai.llm.endpoint`**. Without this BR, that allowlist cannot be correctly enforced for `provider: anthropic`/`gemini`: an operator would configure `ai.llm.endpoint` expecting it to both (a) define the NetworkPolicy allowlist target and (b) be where the client actually sends requests, but today only (a) would hold — the client would keep calling the provider's public default underneath, either breaking connectivity once the NetworkPolicy is enforced (fail-closed) or, if the public default is also reachable, silently defeating the intended boundary.
+
+SC-8 (transmission confidentiality) is unaffected/orthogonal — TLS trust already goes through the separate `tlsCaFile`/`tlsCertFile` machinery regardless of endpoint (proven independently per issue #1342).
+
+---
+
+## Acceptance Criteria
+
+1. `buildAnthropicNativeClient` (`cmd/kubernautagent/llm_builder.go`) passes a non-empty `cfg.Endpoint` through to `anthropicfamily.NewWithAPIKey` via a new first-class `anthropicfamily.WithBaseURL` option, so the Anthropic SDK sends requests to the configured endpoint instead of `https://api.anthropic.com`.
+2. `buildGeminiNativeClient` (`cmd/kubernautagent/llm_builder.go`) passes a non-empty `cfg.Endpoint` through to `geminifamily.NewWithAPIKey` via the existing `geminifamily.WithHTTPOptions(genai.HTTPOptions{BaseURL: ...})` option, mirroring the pattern already production-wired in API Frontend's Gemini triager (`cmd/apifrontend/backend_deps.go`).
+3. When `cfg.Endpoint` is empty (the default, and every existing deployment's current configuration), both clients continue to hit their SDK's default endpoint with zero behavior change — no regression for existing deployments.
+4. `anthropicfamily.New` (the Vertex-hosted constructor) does not silently accept a `WithBaseURL` override — Vertex's endpoint is derived from `vertexProject`/`vertexLocation` via the SDK's own Vertex middleware, and accepting-but-ignoring the option would reintroduce the exact silent-footgun class this BR fixes, just scoped to Vertex instead of native auth.
+5. `buildAnthropicVertexClient` and `buildGeminiVertexClient` (Vertex-hosted constructors) are explicitly out of scope for this BR — their endpoint resolution is a materially different, SDK-internal mechanism not covered by issue #2255.
+6. No change to `types.LLMConfig.Validate` (`pkg/shared/types/llm.go`) — it already correctly treats `endpoint` as optional-but-well-formed for `anthropic`/`gemini`; this BR is a pure wiring fix at that layer.
+
+   **Known pre-existing asymmetry (not fixed by this BR, called out for follow-up)**: at the separate hot-reload runtime layer (`internal/kubernautagent/config.LLMRuntimeConfig.Validate`), `providersWithoutEndpointRequirement` exempts `anthropic` but not `gemini` — so `provider: gemini` in `llm-runtime.yaml` today *requires* a non-empty `endpoint` to pass validation, even though (pre-this-BR) that endpoint was silently ignored at the client-construction layer just like `anthropic`'s. This BR does not change that validation map. A practical consequence worth flagging to operators: any existing `provider: gemini` runtime config that set `endpoint` to a placeholder/arbitrary value (since it was previously inert) will, after this fix, start actually routing there — operators should confirm their configured `endpoint` is the intended target (or the real `https://generativelanguage.googleapis.com` value) before/while upgrading past this fix.
+
+---
+
+## Out of Scope
+
+- Vertex-hosted endpoint override (`buildAnthropicVertexClient`, `buildGeminiVertexClient`) — see AC5.
+- Any change to API Frontend's own LLM client construction — AF's Gemini triager already implements this pattern correctly (`cmd/apifrontend/backend_deps.go`); AF's Anthropic/Vertex path has no reasoning/endpoint parity work tracked here (see DD-LLM-007).
+- Issue #1819's NetworkPolicy egress allowlist implementation itself — this BR is a prerequisite/enabler for that issue, not a substitute for it.
+
+---
+
+**Document Control**:
+- **Created**: 2026-08-25
+- **Version**: 1.0
+- **Status**: Approved

--- a/docs/services/kubernaut-agent/configuration-reference.md
+++ b/docs/services/kubernaut-agent/configuration-reference.md
@@ -205,7 +205,7 @@ YAML path: `ai`
 
 ### 5.1 Provider-specific notes
 
-**Supported today**: `openai`, `anthropic`, `vertex_ai`, `openai_compatible`.
+**Supported today**: `openai`, `anthropic`, `gemini`, `vertex_ai`, `openai_compatible`.
 
 **Not currently supported** (accepted by `LLMRuntimeConfig.Validate` below but rejected at client construction, causing `os.Exit` at startup — do not configure): `bedrock` (tracked in #1582). `vertex` (Google-native Gemini/PaLM via Vertex, distinct from the Anthropic-on-Vertex `vertex_ai` path below) was a `langchaingo`-only provider with no current replacement.
 
@@ -213,7 +213,9 @@ YAML path: `ai`
 
 | Provider strings | Endpoint required in runtime YAML? | Notes |
 |------------------|-----------------------------------|--------|
-| `anthropic`, `vertex_ai` | No | SDK resolves the endpoint implicitly (native API default / GCP project+location). Satisfies `LLMRuntimeConfig.Validate` without `endpoint`. |
+| `anthropic` | No | If set, **honored** (#2255, BR-AI-089): `buildAnthropicNativeClient` passes it through to the Anthropic SDK via `anthropicfamily.WithBaseURL`, so native-auth traffic can be routed through an AI gateway/private proxy instead of `https://api.anthropic.com`. If unset, SDK default applies (unchanged). Satisfies `LLMRuntimeConfig.Validate` without `endpoint`. |
+| `gemini` | **Yes** — pre-existing asymmetry, not changed by #2255/BR-AI-089 | `gemini` is not in `providersWithoutEndpointRequirement`, so `LLMRuntimeConfig.Validate` requires a non-empty `endpoint` even though `types.LLMConfig.Validate` (static config layer) treats it as optional. Whatever value is set **is now honored** (#2255, BR-AI-089) via `geminifamily.WithHTTPOptions(genai.HTTPOptions{BaseURL: ...})` — previously it passed validation but was silently ignored at client construction. **Upgrade note**: if your existing `endpoint` value was a placeholder (harmless while inert), confirm it's the intended target — or the real `https://generativelanguage.googleapis.com` — before/while upgrading, since requests will now actually go there. |
+| `vertex_ai` | No | SDK resolves the endpoint implicitly (GCP project+location via Vertex middleware). Explicitly **not** wired to an endpoint override — see BR-AI-089 AC5. Satisfies `LLMRuntimeConfig.Validate` without `endpoint`. |
 | `openai` | Yes (#2258) | The underlying `openaicompat` client has no default base URL. `LLMRuntimeConfig.Validate` now fails closed at startup on an empty `endpoint`, matching the client's real requirement instead of only failing at request time. |
 | `openai_compatible` | Yes | Validation error if `endpoint` empty. |
 | `vertex` | No (per `providersWithoutEndpointRequirement`) | Stale legacy entry from the pre-#1598 `langchaingo` dispatch, intentionally retained (#2258) — still documented/tested as endpoint-optional even though rejected downstream. |

--- a/pkg/kubernautagent/llm/anthropicfamily/base_url_2255_test.go
+++ b/pkg/kubernautagent/llm/anthropicfamily/base_url_2255_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anthropicfamily_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/anthropicfamily"
+)
+
+// Issue #2255 / BR-AI-089: native Anthropic API-key auth mode must honor an
+// operator-configured endpoint override (FedRAMP AC-4, information flow
+// enforcement — see issue #1819's endpoint-keyed NetworkPolicy egress
+// allowlist for the concrete downstream consumer of this behavior). Prior to
+// this, the only way to redirect native Anthropic traffic was the
+// internal/test-only WithSDKOptions(option.WithBaseURL(...)) escape hatch;
+// WithBaseURL promotes this into a first-class, cfg-driven production Option.
+var _ = Describe("anthropicfamily.WithBaseURL — #2255", func() {
+
+	Describe("NewWithAPIKey — native auth honors WithBaseURL", func() {
+		var server *httptest.Server
+
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+
+		It("UT-KA-2255-001 [AC-4]: Chat() sends requests to the overridden base URL, not the SDK default", func() {
+			var received bool
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				received = true
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"id": "msg_2255_001",
+					"type": "message",
+					"role": "assistant",
+					"model": "claude-sonnet-4-6",
+					"stop_reason": "end_turn",
+					"content": [{"type": "text", "text": "endpoint override works"}],
+					"usage": {"input_tokens": 10, "output_tokens": 5}
+				}`))
+			}))
+
+			client, err := anthropicfamily.NewWithAPIKey("sk-ant-fake-key", "claude-sonnet-4-6",
+				anthropicfamily.WithBaseURL(server.URL),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(received).To(BeTrue(), "request must land on the operator-configured endpoint, not api.anthropic.com")
+			Expect(resp.Message.Content).To(Equal("endpoint override works"))
+		})
+
+		It("UT-KA-2255-001b: request body is unaffected by the base URL override (no Vertex-specific fields leak in)", func() {
+			var receivedBody map[string]interface{}
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body := make([]byte, r.ContentLength)
+				_, _ = r.Body.Read(body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"id": "msg_2255_002",
+					"type": "message",
+					"role": "assistant",
+					"model": "claude-sonnet-4-6",
+					"stop_reason": "end_turn",
+					"content": [{"type": "text", "text": "ok"}],
+					"usage": {"input_tokens": 5, "output_tokens": 2}
+				}`))
+			}))
+
+			client, err := anthropicfamily.NewWithAPIKey("sk-ant-fake-key", "claude-sonnet-4-6",
+				anthropicfamily.WithBaseURL(server.URL),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).To(HaveKeyWithValue("model", "claude-sonnet-4-6"))
+		})
+
+		It("UT-KA-2255-001c: empty WithBaseURL (unset) is a no-op — zero regression for existing deployments", func() {
+			client, err := anthropicfamily.NewWithAPIKey("sk-ant-fake-key", "claude-sonnet-4-6",
+				anthropicfamily.WithBaseURL(""),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+		})
+	})
+
+	Describe("New (Vertex) — WithBaseURL is rejected, not silently ignored", func() {
+		var origADC string
+
+		BeforeEach(func() {
+			origADC = os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+			adcPath := filepath.Join(GinkgoT().TempDir(), "adc.json")
+			Expect(os.WriteFile(adcPath, generateFakeServiceAccountJSON(), 0600)).To(Succeed())
+			Expect(os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", adcPath)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			if origADC != "" {
+				Expect(os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", origADC)).To(Succeed())
+			} else {
+				Expect(os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")).To(Succeed())
+			}
+		})
+
+		// UT-KA-2255-002 [AC-4]: New (Vertex-hosted auth) must not silently
+		// accept WithBaseURL — Vertex's endpoint is derived from
+		// vertexProject/vertexLocation via the SDK's own middleware.
+		// Accepting-but-ignoring the option here would reintroduce the exact
+		// silent-footgun class issue #2255 fixes, just scoped to Vertex
+		// instead of native auth (BR-AI-089 AC4). The existing
+		// WithSDKOptions(option.WithBaseURL(...)) escape hatch remains
+		// available for Vertex tests that need to redirect to an httptest
+		// server (see client_test.go's makeClient) — this guard is specific
+		// to the new first-class WithBaseURL Option, not the raw SDK option.
+		It("UT-KA-2255-002 [AC-4]: returns an explicit error rather than ignoring the option", func() {
+			client, err := anthropicfamily.New(context.Background(),
+				"claude-sonnet-4-6", nil, "my-project", "us-central1",
+				anthropicfamily.WithBaseURL("https://gateway.example.com"),
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("WithBaseURL"))
+			Expect(client).To(BeNil())
+		})
+
+		It("UT-KA-2255-002b: New still succeeds when WithBaseURL is not supplied (no regression)", func() {
+			client, err := anthropicfamily.New(context.Background(),
+				"claude-sonnet-4-6", nil, "my-project", "us-central1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/kubernautagent/llm/anthropicfamily/client.go
+++ b/pkg/kubernautagent/llm/anthropicfamily/client.go
@@ -74,12 +74,31 @@ type clientOpts struct {
 	httpTimeout      time.Duration
 	baseTransport    http.RoundTripper
 	defaultReasoning *llm.ReasoningRequest
+	baseURL          string
 }
 
-// WithSDKOptions injects additional Anthropic SDK request options (e.g. base URL
-// override for testing). Production code should not need this.
+// WithSDKOptions injects additional Anthropic SDK request options.
+// Production code should not need this for base-URL overrides — see
+// WithBaseURL for the first-class, cfg-driven equivalent (#2255,
+// BR-AI-089). Retained for options with no dedicated wrapper (e.g. test
+// middleware, header injection for edge-case test setups).
 func WithSDKOptions(opts ...option.RequestOption) Option {
 	return func(o *clientOpts) { o.extraSDKOpts = append(o.extraSDKOpts, opts...) }
+}
+
+// WithBaseURL overrides the native Anthropic API's default base URL
+// (https://api.anthropic.com), letting operators route native-auth-mode
+// (NewWithAPIKey) traffic through an enterprise AI gateway (e.g. Envoy AI
+// Gateway) or private network proxy instead of Anthropic's public SaaS
+// endpoint (#2255, BR-AI-089, FedRAMP AC-4 — information flow enforcement).
+// An empty url is a no-op, preserving the SDK default.
+//
+// Only meaningful for NewWithAPIKey (native auth). New (Vertex-hosted auth)
+// derives its endpoint from vertexProject/vertexLocation via the SDK's own
+// Vertex middleware and rejects this option outright rather than silently
+// ignoring it — see New's doc comment.
+func WithBaseURL(url string) Option {
+	return func(o *clientOpts) { o.baseURL = url }
 }
 
 // WithLogger injects a logr.Logger for diagnostic messages (e.g., malformed tool schemas).
@@ -146,6 +165,16 @@ func New(ctx context.Context, model string, credentialsJSON []byte, project, loc
 	}
 
 	o := newClientOpts(opts...)
+	// #2255 / BR-AI-089: WithBaseURL is native-auth-only. Vertex's endpoint
+	// is derived from project/location via the SDK's own Vertex middleware
+	// (rawPredict URL rewriting, multi-region routing) — silently accepting
+	// but ignoring an explicit WithBaseURL here would reintroduce the exact
+	// silently-ignored-config anti-pattern this issue fixes, just scoped to
+	// Vertex instead of native auth. Fail fast instead.
+	if o.baseURL != "" {
+		return nil, fmt.Errorf("anthropicfamily: WithBaseURL is not supported for Vertex-hosted auth (New) — " +
+			"Vertex's endpoint is derived from vertexProject/vertexLocation; use NewWithAPIKey for a custom endpoint")
+	}
 
 	vertexOpt, tokenSource, err := resolveVertexAuth(ctx, credentialsJSON, project, location)
 	if err != nil {
@@ -168,6 +197,9 @@ func NewWithAPIKey(apiKey, model string, opts ...Option) (*Client, error) {
 
 	o := newClientOpts(opts...)
 	sdkOpts := applyHTTPOptions([]option.RequestOption{option.WithAPIKey(apiKey)}, o, nil)
+	if o.baseURL != "" {
+		sdkOpts = append(sdkOpts, option.WithBaseURL(o.baseURL))
+	}
 	sdkOpts = append(sdkOpts, o.extraSDKOpts...)
 
 	sdk := anthropic.NewClient(sdkOpts...)

--- a/pkg/kubernautagent/llm/geminifamily/client.go
+++ b/pkg/kubernautagent/llm/geminifamily/client.go
@@ -98,8 +98,12 @@ func WithBaseTransport(rt http.RoundTripper) Option {
 }
 
 // WithHTTPOptions overrides the genai SDK's HTTP options (e.g. BaseURL).
-// Test-only: production code has no operator-facing "endpoint override"
-// concept for Gemini's own API surface (unlike openai_compatible).
+// Production-wired for native API-key auth: buildGeminiNativeClient
+// (cmd/kubernautagent/llm_builder.go) passes genai.HTTPOptions{BaseURL:
+// cfg.Endpoint} through this option when an operator configures
+// ai.llm.endpoint, letting native Gemini traffic route through an AI
+// gateway or private proxy (#2255, BR-AI-089, FedRAMP AC-4). Tests also use
+// it directly to redirect Chat()/StreamChat() calls to an httptest server.
 func WithHTTPOptions(opts genai.HTTPOptions) Option {
 	return func(o *clientOpts) { o.httpOptions = &opts }
 }


### PR DESCRIPTION
## Summary

Native-auth-mode `buildAnthropicNativeClient`/`buildGeminiNativeClient` (`cmd/kubernautagent/llm_builder.go`) never read `cfg.Endpoint`, silently defaulting to `api.anthropic.com` / `generativelanguage.googleapis.com` regardless of what an operator configured under `ai.llm.endpoint`. This closes that gap for both provider paths (issue #2255 was Anthropic-only; scope expanded to the symmetric Gemini bug found during preflight):

- Adds a first-class `anthropicfamily.WithBaseURL` construction option for native API-key auth, and wires `cfg.Endpoint` through it in `buildAnthropicNativeClient`.
- Wires `cfg.Endpoint` through the existing `geminifamily.WithHTTPOptions(genai.HTTPOptions{BaseURL: ...})` option in `buildGeminiNativeClient`, mirroring the pattern already production-wired in API Frontend's Gemini triager.
- Vertex-hosted auth (`anthropicfamily.New`) explicitly **rejects** `WithBaseURL` rather than silently ignoring it — Vertex's endpoint is derived from `vertexProject`/`vertexLocation` via the SDK's own middleware, and accepting-but-ignoring the option would reintroduce the same silent-footgun class this PR fixes.
- Empty `cfg.Endpoint` (existing deployments) remains a no-op — zero behavior change.

**Business driver**: FedRAMP AC-4 (information flow enforcement) — lets operators route native Anthropic/Gemini traffic through an AI gateway (e.g. Envoy AI Gateway) or private proxy instead of the provider's public SaaS default. This is also a direct prerequisite for issue #1819's endpoint-keyed NetworkPolicy egress allowlist, which cannot be correctly enforced for these two provider paths without this fix. Full rationale, acceptance criteria, and a documented pre-existing (unrelated) validation asymmetry for `gemini`'s runtime config layer are in `docs/requirements/BR-AI-089-llm-native-client-endpoint-override.md`.

## Commits

1. `docs(requirements)`: BR-AI-089 business requirement doc
2. `feat(anthropicfamily)`: `WithBaseURL` option + UT-KA-2255-001/002 (and sub-cases)
3. `feat(kubernautagent)`: wiring into both native client builders + IT-KA-2255-101/102/103
4. `docs(kubernautagent)`: corrects a now-stale "no real deployment use case" rationale comment left over from #1580/#1581, and updates the LLM configuration reference

## Test plan

- [x] RED confirmed: new IT tests genuinely reached the real `api.anthropic.com`/`generativelanguage.googleapis.com` before the fix (123/125 other specs unaffected)
- [x] GREEN confirmed: `go test ./cmd/kubernautagent/... ./pkg/kubernautagent/...` — all pass
- [x] `go build ./...` clean
- [x] `golangci-lint run` — 0 issues
- [x] Full regression sweep: `./internal/kubernautagent/...` all pass, zero regressions
- [x] Tests assert on business-observable behavior (request actually lands on the configured endpoint via a live `httptest` server through the real `buildLLMClientFromConfig` dispatch path), not implementation details

Closes #2255