### PR TITLE
fix(fleet): KuadrantRegistry/EAIGWRegistry cold-start race + pyramid-invariant gaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,6 +479,27 @@ test-integration-datastorage: generate ginkgo setup-envtest ensure-coverage-dirs
 		go tool cover -func=coverage_integration_datastorage.out | grep total || echo "No coverage data"; \
 	fi
 
+# Fleet Metadata Cache integration tests: business code lives under
+# pkg/fleet/{fmc,registry,scopecache,mcpclient}/ (no pkg/fleetmetadatacache/
+# or internal/controller/fleetmetadatacache/ package exists), so the generic
+# test-integration-% pattern's coverpkg=pkg/fleetmetadatacache/...,internal/
+# controller/fleetmetadatacache/... matches zero packages and silently
+# reports "coverage: [no statements]" (#2300 pyramid-invariant gap: IT ran
+# and passed, but proved zero coverage). This dedicated target uses the
+# actual package layout.
+.PHONY: test-integration-fleetmetadatacache
+test-integration-fleetmetadatacache: generate ginkgo setup-envtest ensure-coverage-dirs ## Run Fleet Metadata Cache integration tests (coverpkg: pkg/fleet/{fmc,registry,scopecache,mcpclient})
+	@echo "════════════════════════════════════════════════════════════════════════"
+	@echo "🧪 fleetmetadatacache - Integration Tests ($(TEST_PROCS) procs)"
+	@echo "════════════════════════════════════════════════════════════════════════"
+	@echo "📋 Pattern: DD-INTEGRATION-001 v2.0 (envtest + Podman dependencies)"
+	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_INTEGRATION) --procs=$(TEST_PROCS) --coverprofile=coverage_integration_fleetmetadatacache.out --covermode=atomic --keep-going --coverpkg=github.com/jordigilh/kubernaut/pkg/fleet,github.com/jordigilh/kubernaut/pkg/fleet/fmc/...,github.com/jordigilh/kubernaut/pkg/fleet/registry/...,github.com/jordigilh/kubernaut/pkg/fleet/scopecache/...,github.com/jordigilh/kubernaut/pkg/fleet/mcpclient/... ./test/integration/fleetmetadatacache/...
+	@if [ -f coverage_integration_fleetmetadatacache.out ]; then \
+		echo ""; \
+		echo "📊 Coverage report generated: coverage_integration_fleetmetadatacache.out"; \
+		go tool cover -func=coverage_integration_fleetmetadatacache.out | grep total || echo "No coverage data"; \
+	fi
+
 # E2E Tests
 .PHONY: test-e2e-%
 test-e2e-%: generate ginkgo ensure-coverage-dirs ## Run E2E tests for specified service (e.g., make test-e2e-workflowexecution)

--- a/config/crd/external/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/config/crd/external/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -1,0 +1,38 @@
+---
+# Minimal MCPServerRegistration CRD for envtest.
+# This is an external Kuadrant CRD; only the fields needed by
+# registry.KuadrantRegistry and registry.extractKuadrantClusterInfo are defined.
+# The MCPServerRegistration CR name serves as the cluster ID.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mcpserverregistrations.mcp.kuadrant.io
+spec:
+  group: mcp.kuadrant.io
+  names:
+    kind: MCPServerRegistration
+    listKind: MCPServerRegistrationList
+    plural: mcpserverregistrations
+    singular: mcpserverregistration
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                prefix:
+                  type: string
+                state:
+                  type: string
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/pkg/fleet/registry/eaigw_registry.go
+++ b/pkg/fleet/registry/eaigw_registry.go
@@ -139,35 +139,17 @@ func (w *EAIGWRegistry) Ready() bool {
 
 // Start begins watching Envoy AI Gateway Backend CRDs.
 func (w *EAIGWRegistry) Start(ctx context.Context) error {
-	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(
-		w.client,
-		w.config.ResyncPeriod,
-		w.config.Namespace,
-		func(opts *metav1.ListOptions) {
-			opts.LabelSelector = ManagedLabel + "=true"
-		},
-	)
-
-	informer := factory.ForResource(BackendGVR).Informer()
-
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    w.onAdd,
-		UpdateFunc: w.onUpdate,
-		DeleteFunc: w.onDelete,
-	})
+	seeded, err := startInformerAndSeed(ctx, w.client, w.config, BackendGVR,
+		cache.ResourceEventHandlerFuncs{AddFunc: w.onAdd, UpdateFunc: w.onUpdate, DeleteFunc: w.onDelete},
+		w.stopCh, w.trackableClusterInfo)
 	if err != nil {
-		return fmt.Errorf("failed to add event handler: %w", err)
-	}
-
-	go func() {
-		informer.Run(w.stopCh)
-	}()
-
-	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
-		return fmt.Errorf("failed to sync informer cache")
+		return err
 	}
 
 	w.mu.Lock()
+	for id, info := range seeded {
+		w.clusters[id] = info
+	}
 	w.ready = true
 	clusterCount := len(w.clusters)
 	w.mu.Unlock()
@@ -175,6 +157,65 @@ func (w *EAIGWRegistry) Start(ctx context.Context) error {
 	w.metrics.NilSafeIncReconcile()
 	w.logger.Info("EAIGWRegistry started and synced", "clusters", clusterCount)
 	return nil
+}
+
+// startInformerAndSeed builds a filtered dynamic informer for gvr, registers
+// handlers, waits for the initial cache sync, then synchronously seeds
+// already-present objects via trackable before returning. Shared by
+// KuadrantRegistry.Start and EAIGWRegistry.Start (#2299/#2300 dupl fix):
+// their startup sequence is otherwise identical and previously duplicated
+// wholesale between the two files (golangci-lint dupl finding once the
+// #2299 seed-from-indexer fix landed in both).
+//
+// #2299: cache.WaitForCacheSync only guarantees the reflector's initial
+// List has populated informer.GetIndexer(); it does NOT guarantee the
+// sharedProcessor has finished dispatching AddFunc to registered handlers
+// for every pre-existing object, since that dispatch runs on an
+// independent processorListener goroutine with no ordering guarantee
+// relative to WaitForCacheSync returning. Seeding synchronously from the
+// indexer itself makes the caller's Start() returning success a
+// correctness guarantee, not a race against async dispatch.
+func startInformerAndSeed(
+	ctx context.Context,
+	client dynamic.Interface,
+	cfg EAIGWRegistryConfig,
+	gvr schema.GroupVersionResource,
+	handlers cache.ResourceEventHandlerFuncs,
+	stopCh chan struct{},
+	trackable func(*unstructured.Unstructured) (ClusterInfo, bool),
+) (map[string]ClusterInfo, error) {
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(
+		client,
+		cfg.ResyncPeriod,
+		cfg.Namespace,
+		func(opts *metav1.ListOptions) {
+			opts.LabelSelector = ManagedLabel + "=true"
+		},
+	)
+
+	informer := factory.ForResource(gvr).Informer()
+
+	if _, err := informer.AddEventHandler(handlers); err != nil {
+		return nil, fmt.Errorf("failed to add event handler: %w", err)
+	}
+
+	go func() {
+		informer.Run(stopCh)
+	}()
+
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		return nil, fmt.Errorf("failed to sync informer cache")
+	}
+
+	seeded := make(map[string]ClusterInfo)
+	for _, obj := range informer.GetIndexer().List() {
+		if u, ok := obj.(*unstructured.Unstructured); ok {
+			if info, ok := trackable(u); ok {
+				seeded[info.ID] = info
+			}
+		}
+	}
+	return seeded, nil
 }
 
 // Stop halts the watcher and closes the event channel.
@@ -195,10 +236,8 @@ func (w *EAIGWRegistry) onAdd(obj interface{}) {
 	if !ok {
 		return
 	}
-	info, err := ExtractClusterInfo(u)
-	if err != nil {
-		w.logger.Error(err, "failed to extract cluster info on add", "name", u.GetName())
-		w.metrics.NilSafeIncReconcileError()
+	info, trackable := w.trackableClusterInfo(u)
+	if !trackable {
 		return
 	}
 
@@ -210,6 +249,20 @@ func (w *EAIGWRegistry) onAdd(obj interface{}) {
 	w.metrics.NilSafeIncReconcile()
 	w.emit(ClusterEvent{Type: EventAdded, Cluster: info})
 	w.logger.Info("cluster added", "id", info.ID, "endpoint", info.MCPEndpoint)
+}
+
+// trackableClusterInfo extracts ClusterInfo from u, reporting false if
+// extraction fails. Shared by onAdd's async dispatch path and Start()'s
+// synchronous seed-from-indexer path (#2299) so cold-start population
+// applies the identical extraction rules as live events.
+func (w *EAIGWRegistry) trackableClusterInfo(u *unstructured.Unstructured) (ClusterInfo, bool) {
+	info, err := ExtractClusterInfo(u)
+	if err != nil {
+		w.logger.Error(err, "failed to extract cluster info", "name", u.GetName())
+		w.metrics.NilSafeIncReconcileError()
+		return ClusterInfo{}, false
+	}
+	return info, true
 }
 
 func (w *EAIGWRegistry) onUpdate(oldObj, newObj interface{}) {

--- a/pkg/fleet/registry/kuadrant_registry.go
+++ b/pkg/fleet/registry/kuadrant_registry.go
@@ -22,11 +22,9 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -103,40 +101,23 @@ func (w *KuadrantRegistry) Ready() bool {
 
 // Start begins watching Kuadrant MCPServerRegistration CRDs.
 func (w *KuadrantRegistry) Start(ctx context.Context) error {
-	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(
-		w.client,
-		w.config.ResyncPeriod,
-		w.config.Namespace,
-		func(opts *metav1.ListOptions) {
-			opts.LabelSelector = ManagedLabel + "=true"
-		},
-	)
-
-	informer := factory.ForResource(MCPServerRegistrationGVR).Informer()
-
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    w.onAdd,
-		UpdateFunc: w.onUpdate,
-		DeleteFunc: w.onDelete,
-	})
+	seeded, err := startInformerAndSeed(ctx, w.client, w.config, MCPServerRegistrationGVR,
+		cache.ResourceEventHandlerFuncs{AddFunc: w.onAdd, UpdateFunc: w.onUpdate, DeleteFunc: w.onDelete},
+		w.stopCh, w.trackableClusterInfo)
 	if err != nil {
-		return fmt.Errorf("failed to add event handler: %w", err)
-	}
-
-	go func() {
-		informer.Run(w.stopCh)
-	}()
-
-	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
-		return fmt.Errorf("failed to sync informer cache")
+		return err
 	}
 
 	w.mu.Lock()
+	for id, info := range seeded {
+		w.clusters[id] = info
+	}
 	w.ready = true
+	clusterCount := len(w.clusters)
 	w.mu.Unlock()
 
 	w.metrics.NilSafeIncReconcile()
-	w.logger.Info("KuadrantRegistry started and synced", "clusters", len(w.clusters))
+	w.logger.Info("KuadrantRegistry started and synced", "clusters", clusterCount)
 	return nil
 }
 
@@ -158,20 +139,8 @@ func (w *KuadrantRegistry) onAdd(obj interface{}) {
 		return
 	}
 
-	if isKuadrantDisabled(u) {
-		w.logger.V(1).Info("skipping disabled MCPServerRegistration", "name", u.GetName())
-		return
-	}
-
-	labels := u.GetLabels()
-	if labels[ManagedLabel] != "true" {
-		return
-	}
-
-	info, err := extractKuadrantClusterInfo(u)
-	if err != nil {
-		w.logger.Error(err, "failed to extract cluster info on add", "name", u.GetName())
-		w.metrics.NilSafeIncReconcileError()
+	info, trackable := w.trackableClusterInfo(u)
+	if !trackable {
 		return
 	}
 
@@ -183,6 +152,32 @@ func (w *KuadrantRegistry) onAdd(obj interface{}) {
 	w.metrics.NilSafeIncReconcile()
 	w.emit(ClusterEvent{Type: EventAdded, Cluster: info})
 	w.logger.Info("cluster added", "id", info.ID, "toolPrefix", info.ToolPrefix)
+}
+
+// trackableClusterInfo reports whether u should be tracked in the registry
+// (respecting the managed label and disabled state) and, if so, extracts
+// its ClusterInfo. Shared by onAdd's async dispatch path and Start()'s
+// synchronous seed-from-indexer path (#2299) so cold-start population
+// applies the identical inclusion/extraction rules as live events.
+func (w *KuadrantRegistry) trackableClusterInfo(u *unstructured.Unstructured) (ClusterInfo, bool) {
+	if isKuadrantDisabled(u) {
+		w.logger.V(1).Info("skipping disabled MCPServerRegistration", "name", u.GetName())
+		return ClusterInfo{}, false
+	}
+
+	labels := u.GetLabels()
+	if labels[ManagedLabel] != "true" {
+		return ClusterInfo{}, false
+	}
+
+	info, err := extractKuadrantClusterInfo(u)
+	if err != nil {
+		w.logger.Error(err, "failed to extract cluster info", "name", u.GetName())
+		w.metrics.NilSafeIncReconcileError()
+		return ClusterInfo{}, false
+	}
+
+	return info, true
 }
 
 func (w *KuadrantRegistry) onUpdate(oldObj, newObj interface{}) {

--- a/pkg/fleet/registry/kuadrant_registry_lifecycle_test.go
+++ b/pkg/fleet/registry/kuadrant_registry_lifecycle_test.go
@@ -96,6 +96,61 @@ var _ = Describe("UT-REG-KUA: KuadrantRegistry lifecycle", func() {
 		})
 	})
 
+	Describe("onUpdate", func() {
+		It("UT-REG-KUA-007 [SI-4]: should update existing cluster's toolPrefix and emit Updated event", func() {
+			u1 := newMCPServerRegistrationUnstructured("staging", "staging_old_",
+				map[string]interface{}{ManagedLabel: "true"})
+			w.onAdd(u1)
+			Eventually(w.WatchClusters()).Should(Receive())
+
+			u2 := newMCPServerRegistrationUnstructured("staging", "staging_new_",
+				map[string]interface{}{ManagedLabel: "true"})
+			w.onUpdate(u1, u2)
+
+			info, found := w.Get("staging")
+			Expect(found).To(BeTrue())
+			Expect(info.ToolPrefix).To(Equal("staging_new_"))
+
+			Eventually(w.WatchClusters()).Should(Receive(Equal(ClusterEvent{
+				Type:    EventUpdated,
+				Cluster: info,
+			})))
+		})
+
+		It("UT-REG-KUA-008 [AC-3]: should remove cluster and emit Deleted event when update transitions to spec.state: Disabled", func() {
+			u1 := newMCPServerRegistrationUnstructured("dev-north", "dev_north_",
+				map[string]interface{}{ManagedLabel: "true"})
+			w.onAdd(u1)
+			Eventually(w.WatchClusters()).Should(Receive())
+
+			u2 := newMCPServerRegistrationUnstructured("dev-north", "dev_north_",
+				map[string]interface{}{ManagedLabel: "true"})
+			_ = unstructured.SetNestedField(u2.Object, "Disabled", "spec", "state")
+
+			w.onUpdate(u1, u2)
+
+			Expect(w.List()).To(BeEmpty(),
+				"cluster must be removed once its MCPServerRegistration transitions to spec.state: Disabled")
+			_, found := w.Get("dev-north")
+			Expect(found).To(BeFalse())
+
+			Eventually(w.WatchClusters()).Should(Receive(WithTransform(
+				func(e ClusterEvent) EventType { return e.Type },
+				Equal(EventDeleted),
+			)))
+		})
+
+		It("UT-REG-KUA-009 [AC-3]: should no-op when a disabled update targets a cluster the registry never tracked", func() {
+			u := newMCPServerRegistrationUnstructured("never-added", "never_added_",
+				map[string]interface{}{ManagedLabel: "true"})
+			_ = unstructured.SetNestedField(u.Object, "Disabled", "spec", "state")
+
+			w.onUpdate(u, u)
+
+			Expect(w.List()).To(BeEmpty())
+		})
+	})
+
 	Describe("onDelete", func() {
 		It("UT-REG-KUA-003 [SI-4]: Registry emits EventDeleted when labeled MCPServerRegistration is removed", func() {
 			u := newMCPServerRegistrationUnstructured("dev-west", "dev_west_",

--- a/pkg/fleet/registry/kuadrant_registry_test.go
+++ b/pkg/fleet/registry/kuadrant_registry_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
+)
+
+var _ = Describe("KuadrantRegistry.Start (BR-INTEGRATION-065)", func() {
+	// UT-FLEET-2299-001: port of UT-FLEET-003-006 (EAIGWRegistry) to
+	// KuadrantRegistry. Guards against the data race between Start()'s read
+	// of w.clusters (for the "started and synced" log line) and the
+	// mutex-protected write in onAdd(). client-go's WaitForCacheSync only
+	// guarantees the reflector's initial List has populated the informer's
+	// internal store; it does NOT guarantee that the sharedProcessor has
+	// finished dispatching AddFunc for every pre-existing object (handler
+	// dispatch runs on separate processorListener goroutines -- see
+	// k8s.io/client-go/tools/cache/shared_informer.go). Exercising Start()
+	// with pre-existing MCPServerRegistrations under `go test -race` is the
+	// regression guard for that race, mirroring EAIGWRegistry's existing
+	// UT-FLEET-003-006 (PR #1539 post-merge run).
+	//
+	// RED-phase outcome (documented, #2299): run under
+	// `go test -race -count=50 ./pkg/fleet/registry/... -run TestFleetRegistry`
+	// prior to GREEN -- passed all 50 iterations with no race detected and
+	// no missing clusters. This matches the throwaway spike's finding that
+	// the WaitForCacheSync/onAdd-dispatch gap requires handler-side delay
+	// (absent here, and absent in production onAdd) to manifest reliably;
+	// it is not a flag that a fast dynamicfake client trips on its own. The
+	// race is still real (confirmed by direct client-go source review and
+	// the spike's 30/30-with-delay result) -- this test's value is as a
+	// permanent regression guard once GREEN's seed-from-indexer fix lands,
+	// not as a test that fails today.
+	It("UT-FLEET-2299-001: Start() succeeds and does not race when pre-existing MCPServerRegistrations are synced", func() {
+		scheme := runtime.NewScheme()
+		fakeClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				registry.MCPServerRegistrationGVR: "MCPServerRegistrationList",
+			},
+		)
+
+		for i := 0; i < 20; i++ {
+			reg := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "mcp.kuadrant.io/v1alpha1",
+					"kind":       "MCPServerRegistration",
+					"metadata": map[string]interface{}{
+						"name":      fmt.Sprintf("cluster-%d", i),
+						"namespace": "kuadrant-system",
+						"labels": map[string]interface{}{
+							"kubernaut.ai/managed": "true",
+						},
+					},
+					"spec": map[string]interface{}{
+						"prefix": fmt.Sprintf("cluster_%d_", i),
+					},
+				},
+			}
+			_, err := fakeClient.Resource(registry.MCPServerRegistrationGVR).Namespace("kuadrant-system").Create(
+				context.Background(), reg, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		reg := registry.NewKuadrantRegistry(fakeClient, registry.EAIGWRegistryConfig{}, nil, logr.Discard())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		Expect(reg.Start(ctx)).To(Succeed())
+		reg.Stop()
+	})
+})
+
+var _ = Describe("KuadrantRegistry.Ready (BR-INTEGRATION-065)", func() {
+	// UT-FLEET-2299-002: Ready() must reflect Start()'s actual completion
+	// state -- false beforehand, true only once Start() has returned
+	// successfully. Previously untested (0% coverage per #2300's gap
+	// analysis).
+	It("UT-FLEET-2299-002 [SI-4]: Ready() reports true only after Start() completes", func() {
+		scheme := runtime.NewScheme()
+		fakeClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+			map[schema.GroupVersionResource]string{
+				registry.MCPServerRegistrationGVR: "MCPServerRegistrationList",
+			},
+		)
+
+		reg := registry.NewKuadrantRegistry(fakeClient, registry.EAIGWRegistryConfig{}, nil, logr.Discard())
+		Expect(reg.Ready()).To(BeFalse(), "Ready() must be false before Start() is called")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		Expect(reg.Start(ctx)).To(Succeed())
+		Expect(reg.Ready()).To(BeTrue(), "Ready() must be true once Start() returns successfully")
+		reg.Stop()
+	})
+})

--- a/pkg/fleet/registry/scope_adapter_test.go
+++ b/pkg/fleet/registry/scope_adapter_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
+)
+
+// stubClusterRegistry is a minimal registry.ClusterRegistry test double for
+// exercising scope_adapter.go's adapters in isolation from any real
+// watcher/informer.
+type stubClusterRegistry struct {
+	clusters map[string]registry.ClusterInfo
+}
+
+var _ registry.ClusterRegistry = (*stubClusterRegistry)(nil)
+
+func (s *stubClusterRegistry) List() []registry.ClusterInfo {
+	result := make([]registry.ClusterInfo, 0, len(s.clusters))
+	for _, c := range s.clusters {
+		result = append(result, c)
+	}
+	return result
+}
+
+func (s *stubClusterRegistry) Get(id string) (registry.ClusterInfo, bool) {
+	info, ok := s.clusters[id]
+	return info, ok
+}
+
+func (s *stubClusterRegistry) WatchClusters() <-chan registry.ClusterEvent { return nil }
+func (s *stubClusterRegistry) Ready() bool                                { return true }
+func (s *stubClusterRegistry) Start(_ context.Context) error              { return nil }
+func (s *stubClusterRegistry) Stop()                                      {}
+
+// #2300 Gap 3: scope_adapter.go's adapters had 0% UT coverage despite being
+// the server-side access-enforcement point for cluster-scoped tool calls
+// (ASVS V1.4.1: enforced at a trusted server-side point). The not-found
+// branches specifically prove ASVS V4.1.3 (deny by default for unrecognized
+// principals) actually holds, rather than being an untested assumption.
+var _ = Describe("ClusterLookupAdapter (BR-INTEGRATION-065)", func() {
+	var reg *stubClusterRegistry
+
+	BeforeEach(func() {
+		reg = &stubClusterRegistry{clusters: map[string]registry.ClusterInfo{
+			"prod-east": {ID: "prod-east", ToolPrefix: "prod_east_"},
+		}}
+	})
+
+	It("UT-REG-ADAPT-001 [AC-3]: IsKnownCluster returns true for a cluster tracked by the registry", func() {
+		adapter := registry.NewClusterLookupAdapter(reg)
+		Expect(adapter.IsKnownCluster("prod-east")).To(BeTrue())
+	})
+
+	It("UT-REG-ADAPT-002 [V4.1.3, AC-3]: IsKnownCluster returns false (deny-by-default) for an unknown cluster", func() {
+		adapter := registry.NewClusterLookupAdapter(reg)
+		Expect(adapter.IsKnownCluster("no-such-cluster")).To(BeFalse())
+	})
+})
+
+var _ = Describe("ToolPrefixAdapter (BR-INTEGRATION-065)", func() {
+	var reg *stubClusterRegistry
+
+	BeforeEach(func() {
+		reg = &stubClusterRegistry{clusters: map[string]registry.ClusterInfo{
+			"prod-east": {ID: "prod-east", ToolPrefix: "prod_east_"},
+		}}
+	})
+
+	It("UT-REG-ADAPT-003 [AC-3]: ToolPrefixFor returns the registry's ToolPrefix for a known cluster", func() {
+		adapter := registry.NewToolPrefixAdapter(reg)
+		Expect(adapter.ToolPrefixFor("prod-east")).To(Equal("prod_east_"))
+	})
+
+	It("UT-REG-ADAPT-004 [V4.1.3, AC-3]: ToolPrefixFor returns empty string (deny-by-default) for an unknown cluster", func() {
+		adapter := registry.NewToolPrefixAdapter(reg)
+		Expect(adapter.ToolPrefixFor("no-such-cluster")).To(Equal(""))
+	})
+})

--- a/test/e2e/fleetmetadatacache/shared/helpers.go
+++ b/test/e2e/fleetmetadatacache/shared/helpers.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os/exec"
 	"strings"
+	"time"
 
 	. "github.com/onsi/gomega" //nolint:staticcheck // Ginkgo/Gomega DSL dot-import convention
 
@@ -81,6 +82,61 @@ func ClusterIDs(g Gomega, h *Harness) []string {
 		ids = append(ids, c.ID)
 	}
 	return ids
+}
+
+// ClusterIDsAfterNetworkReady behaves like ClusterIDs, except it tolerates a
+// bounded number of transport-level connection failures (dial/EOF/reset)
+// before making the one real, content-asserting request.
+//
+// #2299/#2300 finding: kubelet's readiness probe and kube-proxy's Service
+// iptables/ipvs sync are independent control loops -- kubelet probes the Pod
+// IP directly, bypassing kube-proxy entirely, so Pod-Ready flipping true
+// gives no guarantee that the NodePort's DNAT rule has converged yet.
+// Observed directly in a real Kind run: the first request right after
+// Pod-Ready got `Get https://localhost:<nodePort>/api/v1/clusters: EOF`,
+// unrelated to FMC's own registry-population race -- this is exactly the
+// kube-proxy propagation gap, not a masked completeness bug.
+//
+// This function draws a hard line other zero-grace-period specs in this
+// package must keep: retries are only permitted on transport-level errors
+// (the network path isn't wired up yet), never on the response content
+// itself. The instant a request succeeds, its cluster list is returned
+// as-is with no further retry -- a stale/incomplete list from FMC's own
+// registry still fails the caller's assertion immediately, exactly as a
+// true single-shot check would.
+func ClusterIDsAfterNetworkReady(g Gomega, h *Harness) []string {
+	const (
+		maxAttempts = 20
+		retryDelay  = 250 * time.Millisecond
+	)
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		req, err := http.NewRequestWithContext(h.Ctx, http.MethodGet, h.FMCAPIBaseURL+fmc.ClustersPath, http.NoBody)
+		g.Expect(err).ToNot(HaveOccurred(), "failed to build cluster list request")
+
+		resp, doErr := h.FMCHTTPClient.Do(req)
+		if doErr != nil {
+			lastErr = doErr
+			time.Sleep(retryDelay)
+			continue
+		}
+
+		defer func() { _ = resp.Body.Close() }()
+		g.Expect(resp.StatusCode).To(Equal(http.StatusOK), "cluster list should return 200")
+
+		var body fmc.ClusterListResponse
+		g.Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+		ids := make([]string, 0, len(body.Clusters))
+		for _, c := range body.Clusters {
+			ids = append(ids, c.ID)
+		}
+		return ids
+	}
+
+	g.Expect(lastErr).ToNot(HaveOccurred(),
+		fmt.Sprintf("FMC API never became network-reachable (kube-proxy NodePort propagation) after %d attempts", maxAttempts))
+	return nil
 }
 
 // ReadyzStatus queries FMC's real /readyz endpoint on the dedicated health

--- a/test/e2e/fleetmetadatacache/shared/sync_journey.go
+++ b/test/e2e/fleetmetadatacache/shared/sync_journey.go
@@ -58,6 +58,35 @@ func SyncJourney(h *Harness, v Variant) bool {
 			})
 		})
 
+		// #2299/#2300: single-shot, no-retry-on-content check -- deliberately
+		// does NOT use Eventually for the cluster-list assertion itself. By
+		// the time this spec runs, FMC's Pod has long since passed its
+		// /readyz probe (kubelet gates Pod-Ready on it), which itself only
+		// returns 200 once wireFMCDependencies -- including the blocking
+		// clusterRegistry.Start(ctx) call -- has completed
+		// (cmd/fleetmetadatacache/main.go). Cold-start discovery of
+		// loopback-cluster/prod-east/prod-west must therefore already be
+		// complete; this assertion proves that contract without letting a
+		// retry loop mask a completeness gap the way the Eventually-based
+		// spec below structurally cannot distinguish from ordinary sync lag.
+		//
+		// ClusterIDsAfterNetworkReady (not the plain ClusterIDs the spec
+		// below uses) tolerates a bounded number of transport-level
+		// connection failures before its one real request: a real Kind run
+		// surfaced that kubelet's Pod-Ready and kube-proxy's Service
+		// iptables/ipvs sync are independent control loops (kubelet probes
+		// the Pod IP directly, bypassing kube-proxy), so Pod-Ready gives no
+		// guarantee the NodePort's DNAT rule has converged yet -- an
+		// orthogonal infra propagation gap, not the registry race this spec
+		// exists to guard. Retries there are scoped to "is the network path
+		// wired up at all", never to the cluster-list content.
+		It(fmt.Sprintf("[no-retry, #2299] lists loopback-cluster, prod-east, and prod-west via real %s discovery with zero grace period", v.DynamicResourceKind()), func() {
+			ids := ClusterIDsAfterNetworkReady(Default, h)
+			Expect(ids).To(ContainElements("loopback-cluster", "prod-east", "prod-west"),
+				"cold-start discovery must be complete by the time FMC's Pod is Ready (and thus its API "+
+					"reachable) -- no retry window should be needed to observe the pre-existing clusters")
+		})
+
 		It(fmt.Sprintf("lists loopback-cluster, prod-east, and prod-west via real %s discovery", v.DynamicResourceKind()), func() {
 			Eventually(func(g Gomega) {
 				ids := ClusterIDs(g, h)

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -593,7 +593,7 @@ stringData:
 // kubeconfig-mode config).
 //
 // Total memory: ~1.7-2.5 GB (passthrough mode, Keycloak).
-func DeployFleetCoreInfra(ctx context.Context, namespace, kubeconfigPath, fmcImage string, authConfig KubeMCPServerAuthConfig, fmcOAuth2Config FMCOAuth2Config, writer io.Writer) error {
+func DeployFleetCoreInfra(ctx context.Context, namespace, kubeconfigPath, fmcImage string, authConfig KubeMCPServerAuthConfig, fmcOAuth2Config FMCOAuth2Config, enableCoverage bool, writer io.Writer) error {
 	_, _ = fmt.Fprintln(writer, "🚀 Deploying Fleet Core E2E Infrastructure...")
 
 	mcpGatewayEndpoint, err := DeployFleetGatewayInfra(ctx, namespace, kubeconfigPath, authConfig, writer)
@@ -602,7 +602,7 @@ func DeployFleetCoreInfra(ctx context.Context, namespace, kubeconfigPath, fmcIma
 	}
 
 	// ── Phase 4: FMC Stack (Valkey + FMC) ───────────────────────────────
-	return deployValkeyAndFMC(ctx, namespace, kubeconfigPath, fmcImage, mcpGatewayEndpoint, authConfig, fmcOAuth2Config, writer)
+	return deployValkeyAndFMC(ctx, namespace, kubeconfigPath, fmcImage, mcpGatewayEndpoint, authConfig, fmcOAuth2Config, enableCoverage, writer)
 }
 
 // DeployFleetGatewayInfra deploys Phases 1-3 of DeployFleetCoreInfra --
@@ -1597,7 +1597,7 @@ spec:
 	return nil
 }
 
-func deployValkeyAndFMC(ctx context.Context, namespace, kubeconfigPath, fmcImage, mcpGatewayEndpoint string, authConfig KubeMCPServerAuthConfig, fmcOAuth2Config FMCOAuth2Config, writer io.Writer) error {
+func deployValkeyAndFMC(ctx context.Context, namespace, kubeconfigPath, fmcImage, mcpGatewayEndpoint string, authConfig KubeMCPServerAuthConfig, fmcOAuth2Config FMCOAuth2Config, enableCoverage bool, writer io.Writer) error {
 	// ── Phase 4: FMC Stack (Valkey + FMC) ───────────────────────────────
 	_, _ = fmt.Fprintln(writer, "\n  💾 Phase 4: Deploying FMC stack (Valkey + FMC)...")
 
@@ -1663,6 +1663,31 @@ func deployValkeyAndFMC(ctx context.Context, namespace, kubeconfigPath, fmcImage
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
   verbs: ["create"]`
+	}
+
+	// DD-TEST-007 coverage instrumentation (#2300 Gap 4b): FMC's Dockerfile
+	// already builds a GOFLAGS=-cover binary when requested
+	// (docker/fleetmetadatacache.Dockerfile), but until now this manifest
+	// never mounted a /coverdata volume or set GOCOVERDIR, so the
+	// instrumented binary had nowhere to flush counters -- E2E runs with
+	// E2E_COVERAGE=true silently produced zero FMC E2E coverage data.
+	// Mirrors notificationControllerManifest's injection pattern
+	// (notification_e2e.go) using the same shared fixtures.
+	coverageEnvYAML := ""
+	coverageVolumeMountYAML := ""
+	coverageVolumeYAML := ""
+	coverageSecurityContextYAML := ""
+	if enableCoverage {
+		coverageEnvYAML = "\n        env:" + coverageEnvYAMLFixture
+		coverageVolumeMountYAML = `
+        - name: coverdata
+          mountPath: /coverdata`
+		coverageVolumeYAML = `
+      - name: coverdata
+        hostPath:
+          path: /coverdata
+          type: DirectoryOrCreate`
+		coverageSecurityContextYAML = coverageSecurityContextYAMLFixture
 	}
 
 	fmcManifest := fmt.Sprintf(`---
@@ -1812,11 +1837,11 @@ spec:
         app: fleetmetadatacache
         component: fleet
     spec:
-      serviceAccountName: fleetmetadatacache
+      serviceAccountName: fleetmetadatacache%[10]s
       containers:
       - name: fleetmetadatacache
         image: %[2]s
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: IfNotPresent%[11]s
         volumeMounts:
         - name: config
           mountPath: /etc/fleetmetadatacache
@@ -1829,7 +1854,7 @@ spec:
           readOnly: true
         - name: tls-certs
           mountPath: /etc/tls
-          readOnly: true
+          readOnly: true%[12]s
         ports:
         - name: api
           containerPort: 8080
@@ -1883,7 +1908,7 @@ spec:
       - name: tls-certs
         secret:
           secretName: fleetmetadatacache-tls
-          optional: true
+          optional: true%[13]s
 ---
 apiVersion: v1
 kind: Service
@@ -1906,7 +1931,7 @@ spec:
     targetPort: metrics
   selector:
     app: fleetmetadatacache
-`, namespace, fmcImage, fmcOAuth2Config.TokenURL, fmcOAuth2Config.ClientID, fmcOAuth2Config.ClientSecret, fmcOAuth2ScopesYAML, mcpGatewayEndpoint, string(authConfig.GatewayType), fmcGatewayRBACRules)
+`, namespace, fmcImage, fmcOAuth2Config.TokenURL, fmcOAuth2Config.ClientID, fmcOAuth2Config.ClientSecret, fmcOAuth2ScopesYAML, mcpGatewayEndpoint, string(authConfig.GatewayType), fmcGatewayRBACRules, coverageSecurityContextYAML, coverageEnvYAML, coverageVolumeMountYAML, coverageVolumeYAML)
 
 	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, fmcManifest); err != nil {
 		return fmt.Errorf("fmc deployment failed: %w", err)

--- a/test/infrastructure/fleetmetadatacache_e2e.go
+++ b/test/infrastructure/fleetmetadatacache_e2e.go
@@ -262,7 +262,7 @@ func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 		kubeMCPAuthConfig.BrokerCredentialToken = brokerCredToken
 	}
 
-	if coreErr := DeployFleetCoreInfra(ctx, namespace, kubeconfigPath, fmcImage, kubeMCPAuthConfig, fmcOAuth2Config, writer); coreErr != nil {
+	if coreErr := DeployFleetCoreInfra(ctx, namespace, kubeconfigPath, fmcImage, kubeMCPAuthConfig, fmcOAuth2Config, buildCfg.EnableCoverage, writer); coreErr != nil {
 		return "", "", fmt.Errorf("fleet-core infra deployment failed: %w", coreErr)
 	}
 

--- a/test/integration/fleetmetadatacache/helpers_test.go
+++ b/test/integration/fleetmetadatacache/helpers_test.go
@@ -57,6 +57,32 @@ func deleteBackend(ctx context.Context, name string) {
 	_ = dynClient.Resource(registry.BackendGVR).Namespace("default").Delete(ctx, name, metav1.DeleteOptions{})
 }
 
+func createMCPServerRegistration(ctx context.Context, name string) {
+	GinkgoHelper()
+	reg := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "mcp.kuadrant.io/v1alpha1",
+			"kind":       "MCPServerRegistration",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": "default",
+				"labels": map[string]interface{}{
+					"kubernaut.ai/managed": "true",
+				},
+			},
+			"spec": map[string]interface{}{
+				"prefix": name + "_",
+			},
+		},
+	}
+	_, err := dynClient.Resource(registry.MCPServerRegistrationGVR).Namespace("default").Create(ctx, reg, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred(), "MCPServerRegistration %s should be created in envtest", name)
+}
+
+func deleteMCPServerRegistration(ctx context.Context, name string) {
+	_ = dynClient.Resource(registry.MCPServerRegistrationGVR).Namespace("default").Delete(ctx, name, metav1.DeleteOptions{})
+}
+
 // localAlwaysFalse is a stub local scope checker that always returns false,
 // isolating the remote (Valkey/FMC) path under test.
 type localAlwaysFalse struct{}

--- a/test/integration/fleetmetadatacache/kuadrant_registry_coldstart_it_test.go
+++ b/test/integration/fleetmetadatacache/kuadrant_registry_coldstart_it_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fleetmetadatacache_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
+)
+
+// IT-REG-GW-004 [AC-3, SI-4]: cold-start discovery of pre-existing managed
+// resources must be complete synchronously the instant Start() returns --
+// no Eventually, no retry, zero grace period.
+//
+// Guards the gap identified in #2299/#2298: cache.WaitForCacheSync only
+// guarantees the reflector's initial List has populated the informer's
+// internal indexer; it does NOT guarantee the sharedProcessor has finished
+// dispatching AddFunc (onAdd) for every pre-existing object -- that dispatch
+// runs on independent processorListener goroutines with no ordering
+// guarantee relative to WaitForCacheSync returning. Both ClusterRegistry
+// implementations (Kuadrant and EAIGW) share this gap, so both are covered
+// here against the real envtest API server.
+//
+// RED-phase outcome (documented, #2299): against envtest's fast in-process
+// API server with only 10 objects and no handler-side delay, dispatch
+// latency is low enough that this test passes today more often than not --
+// matching the earlier throwaway spike's finding (0/30 trials showed a gap
+// with zero artificial delay, vs. 30/30 with a 5ms handler delay). The gap
+// is real and structural (confirmed by that spike and by direct client-go
+// source review) but not reliably reproducible in a fast, low-object-count
+// integration test without injecting delay into production code. This
+// test guards the contract going forward (GREEN's seed-from-indexer fix
+// makes it correct by construction, not by luck) -- the primary
+// regression-proving evidence for the race itself is the UT run under
+// go test -race -count=50 in pkg/fleet/registry/kuadrant_registry_test.go.
+//
+// Assertion note: this suite's specs share one real envtest API server
+// cluster-wide (each Registry here watches all namespaces), and other
+// specs in this package (e.g. fmc_e2e_test.go's Ordered "e2e-cluster"
+// Backend) hold their own long-lived managed objects for their lifetime.
+// Under parallel (--procs) execution those specs can run concurrently
+// with this one, so asserting an exact List() length is a real flake --
+// confirmed by a `make test-integration-fleetmetadatacache` run: passes
+// every time in isolation (--focus, single proc) but failed the
+// EAIGWRegistry variant once under the default parallel Makefile target.
+// Asserting containment of every name this test created (not exact
+// count) proves the same completeness contract -- zero grace period,
+// no Eventually -- without depending on being the only spec with
+// managed objects live in the shared cluster at that instant.
+var _ = Describe("IT-REG-GW-004 [AC-3, SI-4]: cold-start discovery of pre-existing objects (BR-INTEGRATION-065)", Label("fmc", "integration"), func() {
+	const numObjects = 10
+
+	Describe("KuadrantRegistry", func() {
+		var names []string
+
+		BeforeEach(func() {
+			names = make([]string, numObjects)
+			for i := 0; i < numObjects; i++ {
+				name := fmt.Sprintf("it-reg-gw-004-kuadrant-%d", i)
+				names[i] = name
+				createMCPServerRegistration(context.Background(), name)
+			}
+		})
+
+		AfterEach(func() {
+			for _, name := range names {
+				deleteMCPServerRegistration(context.Background(), name)
+			}
+		})
+
+		It("discovers all pre-existing MCPServerRegistrations synchronously when Start() returns", func() {
+			reg := registry.NewKuadrantRegistry(dynClient, registry.EAIGWRegistryConfig{}, nil, logr.Discard())
+			defer reg.Stop()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			Expect(reg.Start(ctx)).To(Succeed(), "KuadrantRegistry should start against envtest")
+
+			clusters := reg.List()
+			Expect(clusterIDs(clusters)).To(ContainElements(names),
+				"IT-REG-GW-004: cold-start discovery must be complete the instant Start() returns, "+
+					"not eventually -- expected all %d pre-existing clusters with zero grace period, got %v",
+				numObjects, clusterIDs(clusters))
+		})
+	})
+
+	Describe("EAIGWRegistry", func() {
+		var names []string
+
+		BeforeEach(func() {
+			names = make([]string, numObjects)
+			for i := 0; i < numObjects; i++ {
+				name := fmt.Sprintf("it-reg-gw-004-eaigw-%d", i)
+				names[i] = name
+				createBackend(context.Background(), name)
+			}
+		})
+
+		AfterEach(func() {
+			for _, name := range names {
+				deleteBackend(context.Background(), name)
+			}
+		})
+
+		It("discovers all pre-existing Backends synchronously when Start() returns", func() {
+			reg := registry.NewEAIGWRegistry(dynClient, registry.EAIGWRegistryConfig{}, nil, logr.Discard())
+			defer reg.Stop()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			Expect(reg.Start(ctx)).To(Succeed(), "EAIGWRegistry should start against envtest")
+
+			clusters := reg.List()
+			Expect(clusterIDs(clusters)).To(ContainElements(names),
+				"IT-REG-GW-004: cold-start discovery must be complete the instant Start() returns, "+
+					"not eventually -- expected all %d pre-existing clusters with zero grace period, got %v",
+				numObjects, clusterIDs(clusters))
+		})
+	})
+})
+
+// clusterIDs extracts the ID field from a slice of ClusterInfo for use with
+// ContainElements, since exact-count assertions are unsafe here (see
+// "Assertion note" above this Describe block).
+func clusterIDs(clusters []registry.ClusterInfo) []string {
+	ids := make([]string, 0, len(clusters))
+	for _, c := range clusters {
+		ids = append(ids, c.ID)
+	}
+	return ids
+}


### PR DESCRIPTION
## Summary

- Fixes the root cause of #2298 ("0 clusters after restart"): `cache.WaitForCacheSync` only guarantees the informer's indexer is populated, not that `onAdd` has been dispatched to listeners for every pre-existing object. Both `KuadrantRegistry.Start()` and `EAIGWRegistry.Start()` now seed the cluster map synchronously from `informer.GetIndexer().List()` via a shared helper, closing #2299.
- Closes the pyramid-invariant coverage gaps identified in #2300: UT for `onUpdate`/`Ready()` on `KuadrantRegistry` and for `scope_adapter.go`'s cluster-lookup adapters (previously 0% covered), a no-retry E2E cold-start check for both gateway variants, and FMC's IT/E2E coverage collection wiring (was silently producing `[no statements]`/0 coverage files despite passing).

## Test plan

- `pkg/fleet/registry/...` UT suite green under `-race`, including 50x repeats of the new race-sensitive tests.
- `make test-integration-fleetmetadatacache`: 20/22 passed (2 skipped, pre-existing), 27.3% coverage now collected (was `[no statements]`).
- `make test-e2e-fleetmetadatacache-kuadrant` with `E2E_COVERAGE=true`: 15/15 passed against a real Kind cluster, 76.9% coverage collected for `cmd/fleetmetadatacache` (was 0 files).
- `go build ./...` and `golangci-lint run` clean.

Closes #2299
Closes #2300