### PR TITLE
fix(fleet): FMC's mcpGateway.namespace has no safe default -- require it, fail fast

### DIFF
--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -223,7 +223,7 @@ fleetmetadatacache:
         repository: quay.io/kubernaut-ai/fleetmetadatacache
         tag: v1.6.0
     keyTTL: 45s
-    namespace: kubernaut-system
+    namespace: ""
     oauth2:
         credentialsSecretRef: ""
     pdb:

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -18,9 +18,15 @@ mcpGateway:
   endpoint: {{ $fmcFleetPreamble.config.mcpGatewayEndpoint | quote }}
   gatewayType: {{ $fmcFleetPreamble.config.mcpGatewayType | quote }}
   {{- /* Issue #1730: fleetmetadatacache.namespace falls back to
-  global.fleet.mcpGatewayNamespace (via kubernaut.fleet.config) when unset;
-  $v.namespace's own schema default ("kubernaut-system") is the final
-  fallback when neither is set, preserving pre-#1730 behavior. */}}
+  global.fleet.mcpGatewayNamespace (via kubernaut.fleet.config) when unset.
+  Issue #2298: there is no further fallback -- $v.namespace's own schema
+  default is now "" (empty). An unset value renders here as "" (this
+  ConfigMap still renders successfully -- see the RBAC section below for
+  why this isn't a template-level fail()); pkg/fleet/fmc/config.Validate()
+  refuses to start the pod on that empty value instead. MCPServerRegistration/
+  Backend CRs are managed by the MCP Gateway deployment, not FMC, and a
+  cluster can run more than one gateway, so neither FMC's own namespace
+  (the old default) nor cluster-wide is safe. */}}
   namespace: {{ $fmcFleetPreamble.config.namespace | default $v.namespace | quote }}
   {{- /* Issue #2262 Phase 2: fleet.MCPGatewayConfig.Resilience (pkg/fleet/config.go)
   nests under mcpGateway, unlike every other service's fleet.resilience --
@@ -122,9 +128,12 @@ override fail() case. */}}
 {{- $fmcFleetPreamble := include "kubernaut.fleet.preamble" (dict "root" $ "fleet" .Values.fleetmetadatacache "oauth2" .Values.fleetmetadatacache.oauth2) | fromYaml }}
 {{- $v := include "kubernaut.mergedValues" (dict "root" $ "service" "fleetmetadatacache") | fromYaml }}
 {{- /* Issue #1730: fleetmetadatacache.namespace falls back to
-global.fleet.mcpGatewayNamespace (via kubernaut.fleet.config) when unset;
-$v.namespace's own schema default ("kubernaut-system") is the final
-fallback when neither is set, preserving pre-#1730 behavior. */}}
+global.fleet.mcpGatewayNamespace (via kubernaut.fleet.config) when unset.
+Issue #2298: no further fallback -- see the ConfigMap namespace comment
+above. When both are unset this renders an empty-string namespace here,
+and the RBAC section below grants no CRD-watch access at all rather than
+defaulting to cluster-wide read (pkg/fleet/fmc/config.Validate() then
+refuses to start the pod). */}}
 {{- $fmcNamespace := $fmcFleetPreamble.config.namespace | default $v.namespace }}
 {{- /*
 Issue #1984 Phase B/D: FMC being effectively enabled requires
@@ -287,59 +296,27 @@ metadata:
     app.kubernetes.io/component: fleet-metadata-cache
     {{- include "kubernaut.labels" . | nindent 4 }}
 {{- /*
-#1686 (BR-RBAC-020): FMC's ClusterRole exists solely to grant its
-ClusterRegistry's CRD watch (there is no other rule in this ClusterRole),
-so when fleetmetadatacache.namespace scopes that watch to one namespace, the
-ClusterRole/ClusterRoleBinding are skipped entirely in favor of the
-namespace-scoped Role/RoleBinding below (least privilege) instead of
-rendering a redundant empty ClusterRole.
+#1686 (BR-RBAC-020) / Issue #2298: FMC previously fell back to a cluster-wide
+ClusterRole/ClusterRoleBinding when no namespace was configured -- the same
+gap that made #2298 possible (a cluster can run more than one MCP Gateway,
+so "watch everywhere" isn't a safe substitute for the intended namespace and
+just papers over a missing config value). fleetmetadatacache.namespace (or
+its global.fleet.mcpGatewayNamespace fallback, Issue #1730) has no safe
+default; rather than grant cluster-wide read access as a fallback (least
+privilege, AC-6), no RBAC for the CRD watch is granted at all when it's
+unset -- FMC's own pkg/fleet/fmc/config.Validate() then refuses to start
+the pod, rather than running with unbounded permissions it was never
+scoped to need. Not a template-level fail(): a hard `helm template`/
+`helm install` failure here would additionally require every unrelated
+chart test that derive-enables FMC (Valkey TLS, startup probes, schema
+validation, etc., ~13 test files as of this change) to also set a
+namespace, for no benefit beyond what the Go-level guard already provides.
 */}}
-{{- if not $fmcNamespace }}
+{{- if $fmcNamespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: fleetmetadatacache
-  labels:
-    app.kubernetes.io/name: fleetmetadatacache
-    {{- include "kubernaut.labels" . | nindent 4 }}
-rules:
-{{- if eq $fmcFleetPreamble.config.mcpGatewayType "kuadrant" }}
-  - apiGroups: ["mcp.kuadrant.io"]
-    resources: ["mcpserverregistrations"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways", "httproutes"]
-    verbs: ["get", "list", "watch"]
-{{- else }}
-  - apiGroups: ["gateway.envoyproxy.io"]
-    resources: ["backends"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["aigateway.envoyproxy.io"]
-    resources: ["mcproutes"]
-    verbs: ["get", "list", "watch"]
-{{- end }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: fleetmetadatacache
-  labels:
-    app.kubernetes.io/name: fleetmetadatacache
-    {{- include "kubernaut.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: fleetmetadatacache
-subjects:
-  - kind: ServiceAccount
-    name: fleetmetadatacache
-    namespace: {{ .Release.Namespace }}
-{{- else }}
----
-# #1686 (BR-RBAC-020): namespace-scoped equivalent of the ClusterRole rules
-# above, granted instead of them when fleetmetadatacache.namespace (or its
-# global.fleet.mcpGatewayNamespace fallback, Issue #1730) is set.
+# #1686 (BR-RBAC-020): namespace-scoped RBAC for FMC's ClusterRegistry CRD
+# watch (mcpserverregistrations/backends etc.), granted only when a
+# namespace is configured -- see the comment above for the unset case.
 {{ include "kubernaut.fleet.registryNsRBAC" (dict "name" "fleetmetadatacache" "serviceAccount" "fleetmetadatacache" "namespace" $fmcNamespace "appLabels" "app.kubernetes.io/name: fleetmetadatacache" "mcpServerRegistrations" (eq $fmcFleetPreamble.config.mcpGatewayType "kuadrant") "kuadrantGateways" (eq $fmcFleetPreamble.config.mcpGatewayType "kuadrant") "eaigwBackends" (ne $fmcFleetPreamble.config.mcpGatewayType "kuadrant") "Release" .Release "labels" (include "kubernaut.labels" .)) }}
 {{- end }}
 ---

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -20,13 +20,14 @@ mcpGateway:
   {{- /* Issue #1730: fleetmetadatacache.namespace falls back to
   global.fleet.mcpGatewayNamespace (via kubernaut.fleet.config) when unset.
   Issue #2298: there is no further fallback -- $v.namespace's own schema
-  default is now "" (empty). An unset value renders here as "" (this
-  ConfigMap still renders successfully -- see the RBAC section below for
-  why this isn't a template-level fail()); pkg/fleet/fmc/config.Validate()
-  refuses to start the pod on that empty value instead. MCPServerRegistration/
-  Backend CRs are managed by the MCP Gateway deployment, not FMC, and a
-  cluster can run more than one gateway, so neither FMC's own namespace
-  (the old default) nor cluster-wide is safe. */}}
+  default is now "" (empty). This configYAML define is also reused for the
+  checksum/config annotation above, outside the effectiveEnabled-gated fail()
+  guard further below, so an unset value still renders here as "" rather than
+  failing at this call site; the guard (and pkg/fleet/fmc/config.Validate() as
+  a second layer) catches it before the pod/Deployment actually render.
+  MCPServerRegistration/Backend CRs are managed by the MCP Gateway deployment,
+  not FMC, and a cluster can run more than one gateway, so neither FMC's own
+  namespace (the old default) nor cluster-wide is safe. */}}
   namespace: {{ $fmcFleetPreamble.config.namespace | default $v.namespace | quote }}
   {{- /* Issue #2262 Phase 2: fleet.MCPGatewayConfig.Resilience (pkg/fleet/config.go)
   nests under mcpGateway, unlike every other service's fleet.resilience --
@@ -142,6 +143,18 @@ requires global.fleet.oauth2.{enabled,tokenURL,credentialsSecretRef} complete
 (Phase D, values.schema.json) -- jointly subsuming this unconditional
 tokenURL/credentialsSecretRef fail() guard, which is now redundant (BR-PLATFORM-010).
 */}}
+{{- /*
+Issue #2298: fleetmetadatacache.namespace (or its global.fleet.mcpGatewayNamespace
+fallback, Issue #1730) has no safe default -- a cluster can run more than one MCP
+Gateway, so neither FMC's own namespace (the old default) nor cluster-wide is a
+safe substitute for the intended namespace. pkg/fleet/fmc/config.Validate() already
+refuses to start the pod on an empty value, but that only covers this chart's own
+Deployment -- fail the render too, so `helm install`/`helm template` catches the
+same misconfiguration before a pod ever crash-loops (defense in depth, SI-10/CM-6).
+*/}}
+{{- if not $fmcNamespace }}
+{{- fail "fleetmetadatacache.namespace (or global.fleet.mcpGatewayNamespace) is required when FleetMetadataCache is effectively enabled -- there is no safe default, since a cluster can run more than one MCP Gateway and cluster-wide read access is not granted by default (least privilege, AC-6). Set one of the two." }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -300,25 +313,14 @@ metadata:
 ClusterRole/ClusterRoleBinding when no namespace was configured -- the same
 gap that made #2298 possible (a cluster can run more than one MCP Gateway,
 so "watch everywhere" isn't a safe substitute for the intended namespace and
-just papers over a missing config value). fleetmetadatacache.namespace (or
-its global.fleet.mcpGatewayNamespace fallback, Issue #1730) has no safe
-default; rather than grant cluster-wide read access as a fallback (least
-privilege, AC-6), no RBAC for the CRD watch is granted at all when it's
-unset -- FMC's own pkg/fleet/fmc/config.Validate() then refuses to start
-the pod, rather than running with unbounded permissions it was never
-scoped to need. Not a template-level fail(): a hard `helm template`/
-`helm install` failure here would additionally require every unrelated
-chart test that derive-enables FMC (Valkey TLS, startup probes, schema
-validation, etc., ~13 test files as of this change) to also set a
-namespace, for no benefit beyond what the Go-level guard already provides.
+just papers over a missing config value). The fail() guard above already
+aborts the render when $fmcNamespace is unset, so by this point it's always
+set -- grant namespace-scoped RBAC only, never the old cluster-wide fallback.
 */}}
-{{- if $fmcNamespace }}
 ---
 # #1686 (BR-RBAC-020): namespace-scoped RBAC for FMC's ClusterRegistry CRD
-# watch (mcpserverregistrations/backends etc.), granted only when a
-# namespace is configured -- see the comment above for the unset case.
+# watch (mcpserverregistrations/backends etc.) -- see the fail() guard above.
 {{ include "kubernaut.fleet.registryNsRBAC" (dict "name" "fleetmetadatacache" "serviceAccount" "fleetmetadatacache" "namespace" $fmcNamespace "appLabels" "app.kubernetes.io/name: fleetmetadatacache" "mcpServerRegistrations" (eq $fmcFleetPreamble.config.mcpGatewayType "kuadrant") "kuadrantGateways" (eq $fmcFleetPreamble.config.mcpGatewayType "kuadrant") "eaigwBackends" (ne $fmcFleetPreamble.config.mcpGatewayType "kuadrant") "Release" .Release "labels" (include "kubernaut.labels" .)) }}
-{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/kubernaut/tests/apifrontend_fmc_hardening_test.yaml
+++ b/charts/kubernaut/tests/apifrontend_fmc_hardening_test.yaml
@@ -19,6 +19,7 @@ set:
       existingConfigMap: test-cm
   fleetmetadatacache:
     enabled: true
+    namespace: "mcp-gateway-system"
     oauth2:
       credentialsSecretRef: "fmc-creds"
   global:

--- a/charts/kubernaut/tests/default_hardening_test.yaml
+++ b/charts/kubernaut/tests/default_hardening_test.yaml
@@ -45,6 +45,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
       global:

--- a/charts/kubernaut/tests/fleet_af_fmc_networkpolicy_test.yaml
+++ b/charts/kubernaut/tests/fleet_af_fmc_networkpolicy_test.yaml
@@ -19,6 +19,7 @@ set:
         credentialsSecretRef: we-oauth2-creds
   fleetmetadatacache:
     enabled: true
+    namespace: "mcp-gateway-system"
     oauth2:
       credentialsSecretRef: "fmc-creds"
   global:

--- a/charts/kubernaut/tests/fleet_config_consolidation_test.yaml
+++ b/charts/kubernaut/tests/fleet_config_consolidation_test.yaml
@@ -104,7 +104,9 @@ tests:
           # DD-PLATFORM-006 Decision Area 10: an unset backend here resolves
           # to "fleetmetadatacache" (the very default this test proves), so
           # fleetmetadatacache.enabled is now derived true too and needs its
-          # own required oauth2 fields for the render to succeed.
+          # own required oauth2 fields (and namespace, Issue #2298) for the
+          # render to succeed.
+          mcpGatewayNamespace: "mcp-gateway-system"
           oauth2:
             enabled: true
             tokenURL: "https://dex.example.com/token"
@@ -127,6 +129,7 @@ tests:
         fleet:
           enabled: true
           mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayNamespace: "mcp-gateway-system"
           oauth2:
             enabled: true
             tokenURL: "https://dex.example.com/token"
@@ -191,6 +194,7 @@ tests:
         fleet:
           enabled: true
           mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayNamespace: "mcp-gateway-system"
           oauth2:
             enabled: true
             tokenURL: "https://dex.example.com/token"
@@ -297,6 +301,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
       global:
@@ -327,6 +332,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
       global:
@@ -373,6 +379,7 @@ tests:
         fleet:
           enabled: true
           mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayNamespace: "mcp-gateway-system"
           oauth2:
             enabled: true
             tokenURL: "http://oauth.example.com"

--- a/charts/kubernaut/tests/fleet_idp_egress_networkpolicy_test.yaml
+++ b/charts/kubernaut/tests/fleet_idp_egress_networkpolicy_test.yaml
@@ -241,6 +241,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
       global:
         fleet:
           mcpGatewayEndpoint: "http://mcp.example.com"
@@ -266,6 +267,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
       global:
         fleet:
           mcpGatewayEndpoint: "http://mcp.example.com"

--- a/charts/kubernaut/tests/fleet_mcp_gateway_namespace_test.yaml
+++ b/charts/kubernaut/tests/fleet_mcp_gateway_namespace_test.yaml
@@ -191,7 +191,7 @@ tests:
           path: metadata.namespace
           value: fmc-only-ns
 
-  - it: "IT-PLATFORM-1730-002d: FMC falls back to its own kubernaut-system default when neither fleetmetadatacache.namespace nor global.fleet.mcpGatewayNamespace is set (regression guard)"
+  - it: "IT-PLATFORM-1730-002d / #2298: FMC grants no CRD-watch RBAC at all (no ClusterRole, no Role) when neither fleetmetadatacache.namespace nor global.fleet.mcpGatewayNamespace is set -- there is no safe default (MCPServerRegistration/Backend CRs are managed by the MCP Gateway, not FMC, and a cluster can run more than one gateway), so cluster-wide read access is no longer granted as a fallback (least privilege, AC-6); pkg/fleet/fmc/config.Validate() refuses to start the pod on this same empty value instead"
     set:
       fleetmetadatacache:
         enabled: true
@@ -204,9 +204,10 @@ tests:
             tokenURL: "http://oauth.example.com"
     template: templates/fleetmetadatacache/fleetmetadatacache.yaml
     documentSelector:
-      path: metadata.name
-      value: fleetmetadatacache-config
+      path: kind
+      value: ClusterRole
+      skipEmptyTemplates: true
     asserts:
-      - matchRegex:
-          path: data["config.yaml"]
-          pattern: "(?m)^\\s*namespace: \"kubernaut-system\""
+      - hasDocuments:
+          count: 0
+          filterAware: true

--- a/charts/kubernaut/tests/fleet_mcp_gateway_namespace_test.yaml
+++ b/charts/kubernaut/tests/fleet_mcp_gateway_namespace_test.yaml
@@ -191,7 +191,7 @@ tests:
           path: metadata.namespace
           value: fmc-only-ns
 
-  - it: "IT-PLATFORM-1730-002d / #2298: FMC grants no CRD-watch RBAC at all (no ClusterRole, no Role) when neither fleetmetadatacache.namespace nor global.fleet.mcpGatewayNamespace is set -- there is no safe default (MCPServerRegistration/Backend CRs are managed by the MCP Gateway, not FMC, and a cluster can run more than one gateway), so cluster-wide read access is no longer granted as a fallback (least privilege, AC-6); pkg/fleet/fmc/config.Validate() refuses to start the pod on this same empty value instead"
+  - it: "IT-PLATFORM-1730-002d / #2298: fails the render (not a silent cluster-wide RBAC fallback) when neither fleetmetadatacache.namespace nor global.fleet.mcpGatewayNamespace is set -- there is no safe default (MCPServerRegistration/Backend CRs are managed by the MCP Gateway, not FMC, and a cluster can run more than one gateway); pkg/fleet/fmc/config.Validate() enforces the same rule at Go-level startup as a second layer"
     set:
       fleetmetadatacache:
         enabled: true
@@ -203,11 +203,6 @@ tests:
           oauth2:
             tokenURL: "http://oauth.example.com"
     template: templates/fleetmetadatacache/fleetmetadatacache.yaml
-    documentSelector:
-      path: kind
-      value: ClusterRole
-      skipEmptyTemplates: true
     asserts:
-      - hasDocuments:
-          count: 0
-          filterAware: true
+      - failedTemplate:
+          errorMessage: "fleetmetadatacache.namespace (or global.fleet.mcpGatewayNamespace) is required when FleetMetadataCache is effectively enabled -- there is no safe default, since a cluster can run more than one MCP Gateway and cluster-wide read access is not granted by default (least privilege, AC-6). Set one of the two."

--- a/charts/kubernaut/tests/fleet_registry_rbac_test.yaml
+++ b/charts/kubernaut/tests/fleet_registry_rbac_test.yaml
@@ -194,7 +194,7 @@ tests:
           count: 0
           filterAware: true
 
-  - it: "IT-HELM-020-004: FMC (kuadrant) retains the ClusterRole rules when namespace is unset (regression guard)"
+  - it: "IT-HELM-020-004: FMC (kuadrant) grants no ClusterRole/Role for the CRD watch when namespace is unset (#2298: cluster-wide fallback removed, least privilege -- see fleet_mcp_gateway_namespace_test.yaml IT-PLATFORM-1730-002d)"
     set:
       fleetmetadatacache:
         enabled: true
@@ -211,21 +211,13 @@ tests:
     documentSelector:
       path: kind
       value: ClusterRole
+      skipEmptyTemplates: true
     asserts:
-      - contains:
-          path: rules
-          content:
-            apiGroups: ["mcp.kuadrant.io"]
-            resources: ["mcpserverregistrations"]
-            verbs: ["get", "list", "watch"]
-      - contains:
-          path: rules
-          content:
-            apiGroups: ["gateway.networking.k8s.io"]
-            resources: ["gateways", "httproutes"]
-            verbs: ["get", "list", "watch"]
+      - hasDocuments:
+          count: 0
+          filterAware: true
 
-  - it: "IT-HELM-020-004b: FMC does not render a Role for the fleet registry when namespace is unset"
+  - it: "IT-HELM-020-004b: FMC does not render a Role for the fleet registry either when namespace is unset (#2298)"
     set:
       fleetmetadatacache:
         enabled: true
@@ -310,7 +302,7 @@ tests:
           count: 0
           filterAware: true
 
-  - it: "IT-HELM-020-006: FMC (eaigw) retains the ClusterRole rules when namespace is unset (regression guard)"
+  - it: "IT-HELM-020-006: FMC (eaigw) grants no ClusterRole/Role for the CRD watch when namespace is unset (#2298: cluster-wide fallback removed, least privilege -- see fleet_mcp_gateway_namespace_test.yaml IT-PLATFORM-1730-002d)"
     set:
       fleetmetadatacache:
         enabled: true
@@ -327,19 +319,34 @@ tests:
     documentSelector:
       path: kind
       value: ClusterRole
+      skipEmptyTemplates: true
     asserts:
-      - contains:
-          path: rules
-          content:
-            apiGroups: ["gateway.envoyproxy.io"]
-            resources: ["backends"]
-            verbs: ["get", "list", "watch"]
-      - contains:
-          path: rules
-          content:
-            apiGroups: ["aigateway.envoyproxy.io"]
-            resources: ["mcproutes"]
-            verbs: ["get", "list", "watch"]
+      - hasDocuments:
+          count: 0
+          filterAware: true
+
+  - it: "IT-HELM-020-006b: FMC does not render a Role for the fleet registry either when namespace is unset (#2298)"
+    set:
+      fleetmetadatacache:
+        enabled: true
+        namespace: ""
+        oauth2:
+          credentialsSecretRef: "fmc-creds"
+      global:
+        fleet:
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayType: eaigw
+          oauth2:
+            tokenURL: "http://oauth.example.com"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: metadata.name
+      value: fleetmetadatacache-fleet-registry
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true
 
   # ---------------------------------------------------------------------
   # AF (IT-HELM-020-007/008)

--- a/charts/kubernaut/tests/fleet_registry_rbac_test.yaml
+++ b/charts/kubernaut/tests/fleet_registry_rbac_test.yaml
@@ -194,7 +194,7 @@ tests:
           count: 0
           filterAware: true
 
-  - it: "IT-HELM-020-004: FMC (kuadrant) grants no ClusterRole/Role for the CRD watch when namespace is unset (#2298: cluster-wide fallback removed, least privilege -- see fleet_mcp_gateway_namespace_test.yaml IT-PLATFORM-1730-002d)"
+  - it: "IT-HELM-020-004: FMC (kuadrant) fails the render rather than granting cluster-wide ClusterRole/Role RBAC for the CRD watch when namespace is unset (#2298: cluster-wide fallback removed, least privilege -- see fleet_mcp_gateway_namespace_test.yaml IT-PLATFORM-1730-002d)"
     set:
       fleetmetadatacache:
         enabled: true
@@ -208,37 +208,9 @@ tests:
           oauth2:
             tokenURL: "http://oauth.example.com"
     template: templates/fleetmetadatacache/fleetmetadatacache.yaml
-    documentSelector:
-      path: kind
-      value: ClusterRole
-      skipEmptyTemplates: true
     asserts:
-      - hasDocuments:
-          count: 0
-          filterAware: true
-
-  - it: "IT-HELM-020-004b: FMC does not render a Role for the fleet registry either when namespace is unset (#2298)"
-    set:
-      fleetmetadatacache:
-        enabled: true
-        namespace: ""
-        oauth2:
-          credentialsSecretRef: "fmc-creds"
-      global:
-        fleet:
-          mcpGatewayEndpoint: "http://mcp.example.com"
-          mcpGatewayType: kuadrant
-          oauth2:
-            tokenURL: "http://oauth.example.com"
-    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
-    documentSelector:
-      path: metadata.name
-      value: fleetmetadatacache-fleet-registry
-      skipEmptyTemplates: true
-    asserts:
-      - hasDocuments:
-          count: 0
-          filterAware: true
+      - failedTemplate:
+          errorMessage: "fleetmetadatacache.namespace (or global.fleet.mcpGatewayNamespace) is required when FleetMetadataCache is effectively enabled -- there is no safe default, since a cluster can run more than one MCP Gateway and cluster-wide read access is not granted by default (least privilege, AC-6). Set one of the two."
 
   # ---------------------------------------------------------------------
   # FMC — eaigw branch (IT-HELM-020-005/006)
@@ -302,7 +274,7 @@ tests:
           count: 0
           filterAware: true
 
-  - it: "IT-HELM-020-006: FMC (eaigw) grants no ClusterRole/Role for the CRD watch when namespace is unset (#2298: cluster-wide fallback removed, least privilege -- see fleet_mcp_gateway_namespace_test.yaml IT-PLATFORM-1730-002d)"
+  - it: "IT-HELM-020-006: FMC (eaigw) fails the render rather than granting cluster-wide ClusterRole/Role RBAC for the CRD watch when namespace is unset (#2298: cluster-wide fallback removed, least privilege -- see fleet_mcp_gateway_namespace_test.yaml IT-PLATFORM-1730-002d)"
     set:
       fleetmetadatacache:
         enabled: true
@@ -316,37 +288,9 @@ tests:
           oauth2:
             tokenURL: "http://oauth.example.com"
     template: templates/fleetmetadatacache/fleetmetadatacache.yaml
-    documentSelector:
-      path: kind
-      value: ClusterRole
-      skipEmptyTemplates: true
     asserts:
-      - hasDocuments:
-          count: 0
-          filterAware: true
-
-  - it: "IT-HELM-020-006b: FMC does not render a Role for the fleet registry either when namespace is unset (#2298)"
-    set:
-      fleetmetadatacache:
-        enabled: true
-        namespace: ""
-        oauth2:
-          credentialsSecretRef: "fmc-creds"
-      global:
-        fleet:
-          mcpGatewayEndpoint: "http://mcp.example.com"
-          mcpGatewayType: eaigw
-          oauth2:
-            tokenURL: "http://oauth.example.com"
-    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
-    documentSelector:
-      path: metadata.name
-      value: fleetmetadatacache-fleet-registry
-      skipEmptyTemplates: true
-    asserts:
-      - hasDocuments:
-          count: 0
-          filterAware: true
+      - failedTemplate:
+          errorMessage: "fleetmetadatacache.namespace (or global.fleet.mcpGatewayNamespace) is required when FleetMetadataCache is effectively enabled -- there is no safe default, since a cluster can run more than one MCP Gateway and cluster-wide read access is not granted by default (least privilege, AC-6). Set one of the two."
 
   # ---------------------------------------------------------------------
   # AF (IT-HELM-020-007/008)

--- a/charts/kubernaut/tests/fleet_resilience_config_test.yaml
+++ b/charts/kubernaut/tests/fleet_resilience_config_test.yaml
@@ -36,6 +36,7 @@ set:
     fleet:
       enabled: true
       mcpGatewayEndpoint: "http://mcp.example.com"
+      mcpGatewayNamespace: "mcp-gateway-system"
       backend: "fleetmetadatacache"
       mcpGatewayType: "eaigw"
       oauth2:

--- a/charts/kubernaut/tests/fleetmetadatacache_debug_pprof_test.yaml
+++ b/charts/kubernaut/tests/fleetmetadatacache_debug_pprof_test.yaml
@@ -9,6 +9,7 @@ templates:
 set:
   fleetmetadatacache:
     enabled: true
+    namespace: "mcp-gateway-system"
     oauth2:
       credentialsSecretRef: fmc-creds
   global:

--- a/charts/kubernaut/tests/fleetmetadatacache_effective_enabled_test.yaml
+++ b/charts/kubernaut/tests/fleetmetadatacache_effective_enabled_test.yaml
@@ -37,6 +37,7 @@ tests:
         fleet:
           enabled: true
           mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayNamespace: "mcp-gateway-system"
           oauth2:
             enabled: true
             tokenURL: "https://dex.example.com/token"
@@ -85,6 +86,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
       global:
         fleet:
           mcpGatewayEndpoint: "http://mcp.example.com"
@@ -146,6 +148,7 @@ tests:
         fleet:
           enabled: true
           mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayNamespace: "mcp-gateway-system"
           oauth2:
             enabled: true
             tokenURL: "https://dex.example.com/token"

--- a/charts/kubernaut/tests/fleetmetadatacache_tls_test.yaml
+++ b/charts/kubernaut/tests/fleetmetadatacache_tls_test.yaml
@@ -15,6 +15,7 @@ set:
         credentialsSecretRef: "fleet-oauth2-creds"
   fleetmetadatacache:
     enabled: true
+    namespace: "mcp-gateway-system"
     oauth2:
       credentialsSecretRef: "fmc-creds"
   signalprocessing:

--- a/charts/kubernaut/tests/mcp_gateway_endpoint_schema_validation_test.yaml
+++ b/charts/kubernaut/tests/mcp_gateway_endpoint_schema_validation_test.yaml
@@ -87,6 +87,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
       global:
         fleet:
           mcpGatewayEndpoint: "http://mcp.example.com"
@@ -113,6 +114,7 @@ tests:
         fleet:
           enabled: true
           mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayNamespace: "mcp-gateway-system"
           oauth2:
             enabled: true
             tokenURL: "http://oauth.example.com"
@@ -135,6 +137,7 @@ tests:
         fleet:
           enabled: true
           mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayNamespace: "mcp-gateway-system"
           oauth2:
             enabled: true
             tokenURL: "http://oauth.example.com"
@@ -157,6 +160,7 @@ tests:
         fleet:
           enabled: true
           mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayNamespace: "mcp-gateway-system"
           oauth2:
             enabled: true
             tokenURL: "http://oauth.example.com"

--- a/charts/kubernaut/tests/startup_probe_test.yaml
+++ b/charts/kubernaut/tests/startup_probe_test.yaml
@@ -160,6 +160,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
       global:

--- a/charts/kubernaut/tests/valkey_tls_test.yaml
+++ b/charts/kubernaut/tests/valkey_tls_test.yaml
@@ -240,6 +240,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
       global:
@@ -315,6 +316,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
       global:
@@ -337,6 +339,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
       global:
@@ -359,6 +362,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
         valkeyTLS:
@@ -383,6 +387,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
       global:
@@ -452,6 +457,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
       global:
@@ -477,6 +483,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: "fmc-creds"
         valkeyTLS:

--- a/charts/kubernaut/tests/values_yaml_trim_test.yaml
+++ b/charts/kubernaut/tests/values_yaml_trim_test.yaml
@@ -208,6 +208,7 @@ tests:
     set:
       fleetmetadatacache:
         enabled: true
+        namespace: "mcp-gateway-system"
         oauth2:
           credentialsSecretRef: fmc-creds
       global:

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -2862,7 +2862,8 @@
         },
         "namespace": {
           "type": "string",
-          "default": "kubernaut-system"
+          "default": "",
+          "description": "Namespace where the MCP Gateway manages its MCPServerRegistration (kuadrant) or Backend (eaigw) CRs. #2298 RCA: previously defaulted to \"kubernaut-system\" (FMC's own namespace), which silently scoped the ClusterRegistry watch away from wherever the MCP Gateway actually runs -- there is no safe default (a cluster can run more than one MCP Gateway). This (or its global.fleet.mcpGatewayNamespace fallback) must be set, or the FMC pod fails fast at startup: pkg/fleet/fmc/config.Validate() enforces this at the Go level (covers every deployment path, including the kubernaut-operator, which renders this ConfigMap independently of this chart)."
         },
         "oauth2": {
           "$ref": "#/definitions/fleetOAuth2CredentialsOverride"

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -672,8 +672,10 @@ valkey:
 # when a user hasn't set it explicitly -- see kubernaut.fleetmetadatacache.effectiveEnabled in
 # _helpers.tpl. Set fleetmetadatacache.enabled explicitly (true or false) to override the
 # derived default.
-# DD-PLATFORM-006 DA14: replicas/image.*/syncInterval/keyTTL/namespace all have
+# DD-PLATFORM-006 DA14: replicas/image.*/syncInterval/keyTTL all have
 # non-zero schema defaults -- omitted here, override only what you need.
+# Issue #2298: namespace has no safe default (see values.schema.json) --
+# set fleetmetadatacache.namespace or global.fleet.mcpGatewayNamespace.
 fleetmetadatacache:
   oauth2: {}
   # DD-PLATFORM-006 Decision Area 13 follow-up (round-16 RCA): mandatory Valkey

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -257,7 +257,7 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `image.repository` | string |  | `"quay.io/kubernaut-ai/fleetmetadatacache"` | No |
 | `image.tag` | string |  | `"v1.6.0"` | No |
 | `keyTTL` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"45s"` | No |
-| `namespace` | string |  | `"kubernaut-system"` | No |
+| `namespace` | string | Namespace where the MCP Gateway manages its MCPServerRegistration (kuadrant) or Backend (eaigw) CRs. #2298 RCA: previously defaulted to "kubernaut-system" (FMC's own namespace), which silently scoped the ClusterRegistry watch away from wherever the MCP Gateway actually runs -- there is no safe default (a cluster can run more than one MCP Gateway). This (or its global.fleet.mcpGatewayNamespace fallback) must be set, or the FMC pod fails fast at startup: pkg/fleet/fmc/config.Validate() enforces this at the Go level (covers every deployment path, including the kubernaut-operator, which renders this ConfigMap independently of this chart). | `""` | No |
 | `nodeSelector` | map[string]object | Kubernetes node selector | `` | No |
 | `oauth2.credentialsSecretRef` | string | K8s Secret with keys: client-id, client-secret. Overrides global.fleet.oauth2.credentialsSecretRef for this service only. | `""` | No |
 | `pdb.enabled` | boolean |  | `true` | No |

--- a/pkg/fleet/fmc/config/config.go
+++ b/pkg/fleet/fmc/config/config.go
@@ -126,7 +126,6 @@ func DefaultServiceConfig() *ServiceConfig {
 		},
 		MCPGateway: fleet.MCPGatewayConfig{
 			GatewayType: "eaigw",
-			Namespace:   "kubernaut-system",
 		},
 		Valkey: ValkeyConfig{
 			Addr: "valkey:6379",
@@ -182,6 +181,15 @@ func (c *ServiceConfig) Validate() error {
 	}
 	if !registry.SupportedGateways[registry.MCPGatewayType(c.MCPGateway.GatewayType)] {
 		return fmt.Errorf("unsupported mcpGateway.gatewayType %q; must be one of: eaigw, kuadrant", c.MCPGateway.GatewayType)
+	}
+	// #2298 RCA: MCPServerRegistration (kuadrant) / Backend (eaigw) CRs are
+	// managed by the MCP Gateway deployment, not FMC, and a cluster can run
+	// more than one gateway. Neither FMC's own namespace nor cluster-wide is
+	// a safe default -- both risk silently watching the wrong namespace with
+	// zero clusters discovered and no error (exactly what made #2298
+	// invisible on a live cluster). Require it explicitly.
+	if c.MCPGateway.Namespace == "" {
+		return fmt.Errorf("mcpGateway.namespace is required — specify the namespace where the MCP Gateway manages its MCPServerRegistration/Backend CRs")
 	}
 	if c.Valkey.Addr == "" {
 		return fmt.Errorf("valkey.addr is required")

--- a/pkg/fleet/fmc/config/config_test.go
+++ b/pkg/fleet/fmc/config/config_test.go
@@ -29,8 +29,9 @@ import (
 
 // goconst dedup: test-fixture literals deduplicated below.
 const (
-	urlGateway8080 = "http://gateway:8080"
-	urlIdpToken    = "https://idp/token"
+	urlGateway8080   = "http://gateway:8080"
+	urlIdpToken      = "https://idp/token"
+	testMCPNamespace = "mcp-gateway-system"
 )
 
 func TestConfig(t *testing.T) {
@@ -53,7 +54,10 @@ var _ = Describe("FMC ServiceConfig [BR-FLEET-054, ADR-030]", func() {
 			Expect(cfg.TLSProfile).To(BeEmpty(),
 				"Issue #748: TLSProfile is OCP-only, operator-managed; empty is a no-op on vanilla K8s")
 			Expect(cfg.MCPGateway.GatewayType).To(Equal("eaigw"))
-			Expect(cfg.MCPGateway.Namespace).To(Equal("kubernaut-system"))
+			Expect(cfg.MCPGateway.Namespace).To(BeEmpty(),
+				"#2298: no safe default exists -- MCPServerRegistration/Backend CRs are "+
+					"managed by the MCP Gateway deployment, not FMC, and a cluster can run "+
+					"more than one gateway; Validate() requires this explicitly instead")
 			Expect(cfg.Valkey.Addr).To(Equal("valkey:6379"))
 			Expect(cfg.Valkey.TLS.Enabled).To(BeFalse(),
 				"DD-PLATFORM-006 DA9 follow-up: TLS is opt-in at the Go-defaults level; the Helm chart renders it mandatory-on for chart-deployed installs")
@@ -182,6 +186,7 @@ oauth2:
 		It("UT-FMC-CFG-007: passes with all required fields set [IA-5, SC-8]", func() {
 			cfg := config.DefaultServiceConfig()
 			cfg.MCPGateway.Endpoint = urlGateway8080
+			cfg.MCPGateway.Namespace = testMCPNamespace
 			cfg.OAuth2.TokenURL = urlIdpToken
 
 			Expect(cfg.Validate()).To(Succeed())
@@ -189,6 +194,7 @@ oauth2:
 
 		It("UT-FMC-CFG-008: fails when mcpGateway.endpoint is empty [SC-7]", func() {
 			cfg := config.DefaultServiceConfig()
+			cfg.MCPGateway.Namespace = testMCPNamespace
 			cfg.OAuth2.TokenURL = urlIdpToken
 
 			err := cfg.Validate()
@@ -199,6 +205,7 @@ oauth2:
 		It("UT-FMC-CFG-009: fails when valkey.addr is empty [SC-7]", func() {
 			cfg := config.DefaultServiceConfig()
 			cfg.MCPGateway.Endpoint = urlGateway8080
+			cfg.MCPGateway.Namespace = testMCPNamespace
 			cfg.OAuth2.TokenURL = urlIdpToken
 			cfg.Valkey.Addr = ""
 
@@ -210,6 +217,7 @@ oauth2:
 		It("UT-FMC-CFG-010: fails when oauth2.tokenUrl is empty — OAuth2 is mandatory [IA-5, SC-8]", func() {
 			cfg := config.DefaultServiceConfig()
 			cfg.MCPGateway.Endpoint = urlGateway8080
+			cfg.MCPGateway.Namespace = testMCPNamespace
 
 			err := cfg.Validate()
 			Expect(err).To(HaveOccurred())
@@ -225,12 +233,32 @@ oauth2:
 			// pkg/fleet.FleetConfig.Validate() pattern for MCPGatewayType.
 			cfg := config.DefaultServiceConfig()
 			cfg.MCPGateway.Endpoint = urlGateway8080
+			cfg.MCPGateway.Namespace = testMCPNamespace
 			cfg.OAuth2.TokenURL = urlIdpToken
 			cfg.MCPGateway.GatewayType = ""
 
 			err := cfg.Validate()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("mcpGateway.gatewayType is required"))
+		})
+
+		It("UT-FMC-CFG-016: fails when mcpGateway.namespace is empty [AC-6, SI-10]", func() {
+			// #2298 RCA: DefaultServiceConfig() previously defaulted this to
+			// "kubernaut-system" (FMC's own namespace), which silently
+			// scoped the ClusterRegistry's CRD watch away from wherever the
+			// MCP Gateway actually manages MCPServerRegistration/Backend
+			// CRs -- invisible on a live cluster where those CRs lived in a
+			// different namespace, since Start() logged 0 clusters with no
+			// error rather than failing. There is no safe default (a
+			// cluster can run more than one MCP Gateway), so this must be
+			// explicit or fail fast at startup.
+			cfg := config.DefaultServiceConfig()
+			cfg.MCPGateway.Endpoint = urlGateway8080
+			cfg.OAuth2.TokenURL = urlIdpToken
+
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("mcpGateway.namespace is required"))
 		})
 
 		It("UT-FMC-CFG-014: fails when valkey.tls.enabled is true but caFile is empty [SC-8]", func() {
@@ -240,6 +268,7 @@ oauth2:
 			// fast at startup, not silently fall back to plaintext or hang.
 			cfg := config.DefaultServiceConfig()
 			cfg.MCPGateway.Endpoint = urlGateway8080
+			cfg.MCPGateway.Namespace = testMCPNamespace
 			cfg.OAuth2.TokenURL = urlIdpToken
 			cfg.Valkey.TLS.Enabled = true
 
@@ -252,6 +281,7 @@ oauth2:
 		It("UT-FMC-CFG-015: passes when valkey.tls.enabled is true and caFile is set [SC-8]", func() {
 			cfg := config.DefaultServiceConfig()
 			cfg.MCPGateway.Endpoint = urlGateway8080
+			cfg.MCPGateway.Namespace = testMCPNamespace
 			cfg.OAuth2.TokenURL = urlIdpToken
 			cfg.Valkey.TLS.Enabled = true
 			cfg.Valkey.TLS.CAFile = "/etc/fleetmetadatacache/tls/ca.crt"
@@ -262,6 +292,7 @@ oauth2:
 		It("UT-FMC-CFG-013: fails when mcpGateway.gatewayType is unsupported [SI-10]", func() {
 			cfg := config.DefaultServiceConfig()
 			cfg.MCPGateway.Endpoint = urlGateway8080
+			cfg.MCPGateway.Namespace = testMCPNamespace
 			cfg.OAuth2.TokenURL = urlIdpToken
 			cfg.MCPGateway.GatewayType = "not-a-real-gateway"
 

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -1278,12 +1278,14 @@ run_mon_003() {
 #
 # Object list confirmed via `helm template` spike, not assumed. Issue #2298:
 # FMC's own plain-named ClusterRole/ClusterRoleBinding no longer exist at
-# all -- fleetmetadatacache.namespace has no safe default, and an unset
-# value now renders no RBAC for the CRD watch rather than falling back to
-# cluster-wide (see fleetmetadatacache.yaml). Not exercised here either way,
-# since that's a second, independent toggle. The 5 objects below are the
-# ones that actually render under fleetmetadatacache.enabled=true with no
-# other overrides, which is what this test (and #2159) is about.
+# all -- fleetmetadatacache.namespace has no safe default, and the chart's
+# own fail() guard now aborts the render (rather than falling back to
+# cluster-wide RBAC) when it's unset, so this flow's `helm upgrade` below
+# sets it explicitly. That guard is exercised independently by chart unit
+# tests (fleet_registry_rbac_test.yaml, fleet_mcp_gateway_namespace_test.yaml),
+# not here. The 5 objects below are the ones that actually render under
+# fleetmetadatacache.enabled=true with a namespace set, which is what this
+# test (and #2159) is about.
 run_rbac_prune_001() {
   local desc="ST-CHART-RBAC-PRUNE-001: BR-PLATFORM-005 FR-6 -- fleetmetadatacache cluster-scoped RBAC is pruned by helm upgrade when fleetmetadatacache.enabled transitions to false"
   local objs=(
@@ -1311,6 +1313,7 @@ run_rbac_prune_001() {
   if ! helm upgrade kubernaut "$CHART_PATH" \
     --namespace "$NAMESPACE" --reuse-values \
     --set fleetmetadatacache.enabled=true \
+    --set fleetmetadatacache.namespace="$NAMESPACE" \
     --set global.fleet.mcpGatewayEndpoint=https://mcp.smoke-test.local \
     --set global.fleet.oauth2.enabled=true \
     --set global.fleet.oauth2.tokenURL=https://oauth.smoke-test.local/token \

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -1276,13 +1276,14 @@ run_mon_003() {
 # once global.fleet.mcpGatewayEndpoint is non-empty (confirmed via `helm
 # template` spike), not FMC-specific.
 #
-# Object list confirmed via `helm template` spike, not assumed: FMC's own
-# ClusterRole/ClusterRoleBinding (plain "fleetmetadatacache" name) only render
-# when fleetmetadatacache.namespace is explicitly cleared to "" (opts out of
-# the default namespace-scoped Role/RoleBinding) -- not exercised here, since
-# that's a second, independent toggle. The 5 objects below are the ones that
-# actually render under fleetmetadatacache.enabled=true with no other
-# overrides, which is what this test (and #2159) is about.
+# Object list confirmed via `helm template` spike, not assumed. Issue #2298:
+# FMC's own plain-named ClusterRole/ClusterRoleBinding no longer exist at
+# all -- fleetmetadatacache.namespace has no safe default, and an unset
+# value now renders no RBAC for the CRD watch rather than falling back to
+# cluster-wide (see fleetmetadatacache.yaml). Not exercised here either way,
+# since that's a second, independent toggle. The 5 objects below are the
+# ones that actually render under fleetmetadatacache.enabled=true with no
+# other overrides, which is what this test (and #2159) is about.
 run_rbac_prune_001() {
   local desc="ST-CHART-RBAC-PRUNE-001: BR-PLATFORM-005 FR-6 -- fleetmetadatacache cluster-scoped RBAC is pruned by helm upgrade when fleetmetadatacache.enabled transitions to false"
   local objs=(

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -498,6 +498,11 @@ func SetupFleetE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPat
 			OAuth2Scopes:              fleetScopes,
 			WEOAuth2CredentialsSecret: fleetOAuth2SecretName,
 			SignalProcessingNamespace: namespace,
+			// Issue #2298: MCPServerRegistrations are created in `namespace`
+			// by deployKuadrantRegistrations above (via DeployFleetGatewayInfra
+			// -> deployKubeMCPServerAndRegister), so FMC's own watch must be
+			// scoped there too -- there's no safe default to fall back to.
+			FleetMetadataCacheNamespace: namespace,
 		}, nil
 	}
 

--- a/test/infrastructure/fullpipeline_e2e_helm.go
+++ b/test/infrastructure/fullpipeline_e2e_helm.go
@@ -315,6 +315,14 @@ type FleetHelmOptions struct {
 	// SignalProcessingNamespace restricts SP's ClusterRegistry CRD watch
 	// (signalprocessing.fleet.namespace) -- empty watches cluster-wide.
 	SignalProcessingNamespace string
+	// FleetMetadataCacheNamespace is the namespace where the MCP Gateway
+	// manages its MCPServerRegistration/Backend CRs
+	// (fleetmetadatacache.namespace). Issue #2298: unlike
+	// SignalProcessingNamespace above, this has no safe empty-string
+	// fallback -- pkg/fleet/fmc/config.Validate() refuses to start FMC
+	// without it, so callers MUST set this whenever FleetHelmOptions is
+	// non-nil (FMC is chart-managed and effectively enabled in that case).
+	FleetMetadataCacheNamespace string
 }
 
 // FleetProvisioner, when non-nil, is invoked by SetupFullPipelineInfrastructure
@@ -1164,6 +1172,11 @@ func InstallFullPipelineHelmChart(ctx context.Context, kubeconfigPath, namespace
 		if fleetOpts.SignalProcessingNamespace != "" {
 			args = append(args, "--set", "signalprocessing.fleet.namespace="+fleetOpts.SignalProcessingNamespace)
 		}
+		// Issue #2298: fleetmetadatacache.namespace has no safe default --
+		// FMC refuses to start without it (pkg/fleet/fmc/config.Validate()),
+		// so this is set unconditionally here, unlike SignalProcessingNamespace
+		// above (which may legitimately watch cluster-wide).
+		args = append(args, "--set", "fleetmetadatacache.namespace="+fleetOpts.FleetMetadataCacheNamespace)
 	}
 
 	_, _ = fmt.Fprintln(writer, "  🚀 helm install kubernaut charts/kubernaut ...")


### PR DESCRIPTION
## Root cause (#2298)

`pkg/fleet/fmc/config.DefaultServiceConfig()` and the chart's `values.schema.json` both defaulted `mcpGateway.namespace` to `"kubernaut-system"` (FMC's own namespace). On the live hub cluster the actual `MCPServerRegistration` CRs live in `mcp-system`, so FMC's `ClusterRegistry` informer watched the wrong namespace: `Start()` logged 0 clusters with no error, since a scoped-but-empty watch isn't distinguishable from "no clusters exist" without checking *which* namespace it's watching.

Confirmed live: a goroutine/pprof dump of the running FMC pod plus a curl against the API server from inside it showed the informer's actual watch target, and patching the `Kubernaut` CR's `spec.fleet.mcpGatewayNamespace` to `mcp-system` immediately fixed it (`fleet_registry_clusters_active` went from 0 to 2).

This corrects the original issue's "ruled out: namespace scoping" note. That triage characterized the effective namespace as unset/cluster-wide based on the chart's schema default, but the live ConfigMap actually rendered `kubernaut-system`, not empty — a curl without a namespace qualifier (used to rule this out) couldn't have caught a namespace-scoping bug.

[PR #2301](https://github.com/jordigilh/kubernaut/pull/2301) (registry seeding race) fixed a real, separate bug but wasn't the root cause of this issue's persistent 0-clusters symptom.

## Fix

A cluster can run more than one MCP Gateway, so there's no safe default for this namespace. Two independent guards, no fallback:

- **Go**: `Validate()` fails startup if `mcpGateway.namespace` is empty (`pkg/fleet/fmc/config/config.go`) — covers every deployment path, including the kubernaut-operator, which renders this ConfigMap independently of this chart.
- **Chart**: a `fail()` guard aborts `helm install`/`helm template` when the namespace is unset, instead of waiting for the pod to crash-loop. No RBAC is granted for the CRD watch either (previously this fell back to a cluster-wide `ClusterRole`/`ClusterRoleBinding`, papering over the missing config value instead of a deliberate scope choice).

~13 chart test files that derive-enable FMC without setting a namespace now set one explicitly.

## Test plan

- [x] `pkg/fleet/fmc/config` UTs: added UT-FMC-CFG-016 (fails when namespace empty), updated UT-FMC-CFG-001/007-015 for the new empty default
- [x] `helm unittest charts/kubernaut`: 78/78 suites, 650/650 tests pass; namespace set explicitly across ~13 affected test files; `fleet_mcp_gateway_namespace_test.yaml`/`fleet_registry_rbac_test.yaml` now assert `failedTemplate` for the unset-namespace case
- [x] `helm template` sanity check: render fails with the namespace-required error when unset; namespace-scoped `Role`/`RoleBinding` rendered correctly when set
- [x] `go build ./...`, `go test ./pkg/fleet/... ./cmd/fleetmetadatacache/...`, `golangci-lint run ./pkg/fleet/fmc/...`

Closes #2298
