### PR TITLE
docs(readme): fix stale roadmap status, missing FMC service, and installation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ Each method's guide lives alongside its own code, so it stays current without a 
 
 ---
 
+## Try It Out
+
+Once Kubernaut is installed, see it in action. [kubernaut-demo-scenarios](https://github.com/jordigilh/kubernaut-demo-scenarios) provides 37 fault-injection scenarios you can run against your own cluster.
+
+New to Kubernaut? Start with [crashloop](https://github.com/jordigilh/kubernaut-demo-scenarios/tree/main/scenarios/crashloop) — the same demo shown at the top of this page. It deploys a misconfigured app, lets it crash-loop, and watches Kubernaut detect the issue and roll back to the last working revision automatically:
+
+```bash
+./scenarios/crashloop/run.sh
+```
+
+---
+
 ## Signed & Verified
 
 Every container image published to `quay.io/kubernaut-ai` is keylessly signed with

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ New to Kubernaut? Start with the Helm chart's [Quick Start](charts/kubernaut/REA
 
 Each method's guide lives alongside its own code, so it stays current without a cross-repo docs update.
 
+Once installed, pick a setup guide for how you want to trigger remediation — the three are
+independent and can be combined on the same install:
+
+| Mode | Trigger | Guide |
+|---|---|---|
+| Autonomous | Alert-driven (Prometheus/AlertManager → Gateway) | [Autonomous Mode Setup Guide](docs/operations/deployment/AUTONOMOUS_MODE_SETUP_GUIDE.md) |
+| Interactive | Chat-driven (Console/APIFrontend, human-in-the-loop) | [Interactive Mode Setup Guide](docs/operations/deployment/INTERACTIVE_MODE_SETUP_GUIDE.md) |
+| Fleet | Multi-cluster (hub + spoke, layers onto either mode above) | [Fleet Setup Guide](docs/operations/deployment/FLEET_SETUP_GUIDE.md) |
+
 ---
 
 ## Try It Out

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ See the interactive version with per-phase detail: [How It Works](https://jordig
 | **Notification** | `cmd/notification` | Slack, webhook, and console notification delivery |
 | **Effectiveness Monitor** | `cmd/effectivenessmonitor` | Post-remediation health checks and effectiveness scoring |
 | **Auth Webhook** | `cmd/authwebhook` | Kubernetes authentication webhook for service identity |
+| **Fleet Metadata Cache** | `cmd/fleetmetadatacache` | Multi-cluster metadata cache for cross-cluster workflow targeting |
 
 </details>
 
@@ -100,10 +101,10 @@ See the interactive version with per-phase detail: [How It Works](https://jordig
 
 ## Roadmap
 
-### v1.6 — Fleet Remediation & ITSM (in progress)
+### v1.6 — Fleet Operations (release candidate)
 
 - **Fleet operations** — Multi-cluster remediation orchestration through a pluggable scope-checking adapter: Red Hat ACM/OCM for ACM shops, or a control-plane-free mode backed by the built-in Fleet Metadata Cache (FMC) for GitOps and standalone clusters — with Rancher and Clusterpedia adapters architected for other vendor fleet platforms ([#54](https://github.com/jordigilh/kubernaut/issues/54))
-- **ServiceNow incident triage** — Consume ServiceNow incidents as signals through the API Frontend, enabling Kubernaut to investigate and remediate ITSM tickets alongside Kubernetes alerts ([#1338](https://github.com/jordigilh/kubernaut/issues/1338))
+- **ServiceNow incident triage** (v1.6.1) — Consume ServiceNow incidents as signals through the API Frontend, enabling Kubernaut to investigate and remediate ITSM tickets alongside Kubernetes alerts ([#1338](https://github.com/jordigilh/kubernaut/issues/1338))
 
 **[Full roadmap](docs/roadmap/ROADMAP.md)** — for released features, see the [CHANGELOG](CHANGELOG.md).
 
@@ -111,7 +112,14 @@ See the interactive version with per-phase detail: [How It Works](https://jordig
 
 ## Installation
 
-See the [Installation Guide](https://jordigilh.github.io/kubernaut-docs/latest/getting-started/installation/) for prerequisites, configuration, and deployment instructions.
+Pick the guide for your platform — both are production-ready deployment paths. New to Kubernaut? Start with the Helm chart's [Quick Start](charts/kubernaut/README.md#quick-start) — namespace, three credential Secrets, two Rego policies, and one `helm install`.
+
+| Platform | Method | Guide |
+|---|---|---|
+| Vanilla Kubernetes (non-OpenShift) | Helm chart | [charts/kubernaut/README.md](charts/kubernaut/README.md) |
+| OpenShift | Operator (OLM) | [kubernaut-operator installation guide](https://github.com/jordigilh/kubernaut-operator/blob/main/docs/installation/00-quickstart.md) |
+
+Each method's guide lives alongside its own code, so it stays current without a cross-repo docs update.
 
 ---
 
@@ -196,6 +204,6 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 
 ---
 
-**Issues**: [GitHub Issues](https://github.com/jordigilh/kubernaut/issues) · **Discussions**: [GitHub Discussions](https://github.com/jordigilh/kubernaut/discussions)
+**Website**: [kubernaut.ai](https://kubernaut.ai) · **Issues**: [GitHub Issues](https://github.com/jordigilh/kubernaut/issues) · **Discussions**: [GitHub Discussions](https://github.com/jordigilh/kubernaut/discussions)
 
 **Kubernaut** — From alert to remediation, intelligently.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See the interactive version with per-phase detail: [How It Works](https://jordig
 
 Pick the guide for your platform — both are production-ready deployment paths.
 
-New to Kubernaut? Start with the Helm chart's [Quick Start](charts/kubernaut/README.md#quick-start) — namespace, three credential Secrets, two Rego policies, and one `helm install`.
+New to Kubernaut? Start with the Helm chart's [Quick Start](charts/kubernaut/README.md#quick-start) — namespace, three credential Secrets (PostgreSQL, Valkey, and an LLM provider API key), two Rego policies, and one `helm install`.
 
 | Platform | Method | Guide |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ See the interactive version with per-phase detail: [How It Works](https://jordig
 
 ## Installation
 
-Pick the guide for your platform — both are production-ready deployment paths. New to Kubernaut? Start with the Helm chart's [Quick Start](charts/kubernaut/README.md#quick-start) — namespace, three credential Secrets, two Rego policies, and one `helm install`.
+Pick the guide for your platform — both are production-ready deployment paths.
+
+New to Kubernaut? Start with the Helm chart's [Quick Start](charts/kubernaut/README.md#quick-start) — namespace, three credential Secrets, two Rego policies, and one `helm install`.
 
 | Platform | Method | Guide |
 |---|---|---|

--- a/docs/operations/deployment/AUTONOMOUS_MODE_SETUP_GUIDE.md
+++ b/docs/operations/deployment/AUTONOMOUS_MODE_SETUP_GUIDE.md
@@ -1,0 +1,177 @@
+# Autonomous Mode Setup Guide (Gateway + AlertManager)
+
+**Status**: Operator-facing setup guide, condensed from the Helm chart's own reference
+(`charts/kubernaut/README.md`).
+**Audience**: Operators and SREs who want alert-driven, webhook-triggered remediation —
+Prometheus/AlertManager fires, Gateway ingests it as a signal, and Kubernaut investigates
+and (subject to your approval policy) remediates, with no human chat interaction required
+to kick it off.
+**Authority**: `charts/kubernaut/README.md` ("Enable Monitoring Integration",
+"Enable/Disable Gateway or APIFrontend"), Issue #2162.
+
+---
+
+## What you're building
+
+```
+Prometheus ──fires──▶ AlertManager ──webhook (Bearer token)──▶ Gateway
+                                                                   │
+                                                                   ▼
+                                              RemediationRequest CRD created
+                                                                   │
+                                                                   ▼
+                              SignalProcessing → AIAnalysis → RemediationWorkflow → WorkflowExecution
+```
+
+This is Kubernaut's webhook-driven ingestion path. **Console and APIFrontend (AF) are not
+part of it** — nothing here requires a human to open a chat session. Gateway and AF are
+independent entry points into the same `RemediationRequest` pipeline (Issue #2162); this
+guide only sets up Gateway's.
+
+If you also want the chat-driven path (a human investigating on demand instead of, or
+alongside, alerts), see
+[INTERACTIVE_MODE_SETUP_GUIDE.md](./INTERACTIVE_MODE_SETUP_GUIDE.md) — the two are
+independent and can both be enabled on the same install.
+
+---
+
+## Prerequisites
+
+- A Kubernetes cluster with a dynamic-provisioning `StorageClass` (for PostgreSQL/Valkey)
+- Helm 3.12+
+- An API key from an LLM provider (OpenAI, Anthropic, etc.)
+- [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
+  installed (or an existing Prometheus + AlertManager you control the config for)
+
+If you don't already have Prometheus/AlertManager running:
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+  --namespace monitoring --create-namespace
+```
+
+---
+
+## 1. Install Kubernaut with Gateway + monitoring enabled
+
+Follow [charts/kubernaut/README.md](../../../charts/kubernaut/README.md)'s Quick Start for
+the namespace and the three credential Secrets (PostgreSQL, Valkey, LLM provider API key),
+plus your Rego policies, then install with monitoring wired to your Prometheus/AlertManager:
+
+```bash
+helm install kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
+  --namespace kubernaut-system \
+  --set global.llmProfiles.primary.provider=openai \
+  --set global.llmProfiles.primary.model=gpt-4o \
+  --set global.llmProfiles.primary.endpoint=https://api.openai.com/v1 \
+  --set global.llmProfiles.primary.credentialsSecretName=llm-credentials \
+  --set kubernautAgent.llmProfileRef=primary \
+  --set-file signalprocessing.policies.content=path/to/policy.rego \
+  --set-file aianalysis.policies.content=path/to/approval.rego \
+  --set apifrontend.enabled=false \
+  --set monitoring.prometheus.enabled=true \
+  --set monitoring.prometheus.url=http://kube-prometheus-stack-prometheus.monitoring.svc:9090 \
+  --set monitoring.alertManager.enabled=true \
+  --set monitoring.alertManager.url=http://kube-prometheus-stack-alertmanager.monitoring.svc:9093 \
+  --set gateway.auth.signalSources[0].name=alertmanager \
+  --set gateway.auth.signalSources[0].serviceAccount=alertmanager-kube-prometheus-stack-alertmanager \
+  --set gateway.auth.signalSources[0].namespace=monitoring
+```
+
+`gateway.enabled` defaults to `true` — no need to set it. `apifrontend.enabled=false` above
+is optional; it's set here to keep this a minimal, Gateway-only footprint (no
+Console/AF Deployment, Service, RBAC, or NetworkPolicy at all) matching this guide's scope.
+Leave it at its default (`true`) if you might add [Interactive
+mode](./INTERACTIVE_MODE_SETUP_GUIDE.md) later without a redeploy.
+
+`gateway.auth.signalSources` is the actual authorization gate for who can call Gateway's
+webhook endpoint — it defaults to an empty list, so **nothing** can POST a signal to
+Gateway until you add an entry here. Each entry creates a `ClusterRoleBinding` granting
+that `ServiceAccount` `create` on `services/gateway-service`, checked via a real
+`TokenReview`+`SubjectAccessReview` on every request (401 for a missing/invalid token, 403
+for a valid token with no matching binding).
+
+## 2. Point AlertManager at Gateway
+
+```yaml
+receivers:
+  - name: kubernaut
+    webhook_configs:
+      - url: "http://gateway-service.kubernaut-system.svc.cluster.local:8080/api/v1/signals/prometheus"
+        send_resolved: true
+        http_config:
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+route:
+  routes:
+    - receiver: kubernaut
+      matchers:
+        - alertname!=""
+      continue: true
+```
+
+Apply this to your `Alertmanager` CR's `alertmanager.yaml` (or the equivalent
+`AlertmanagerConfig` if you're using the Prometheus Operator's namespaced config CRD). The
+`bearer_token_file` path is AlertManager's own auto-mounted ServiceAccount token — the same
+identity `gateway.auth.signalSources[0].serviceAccount` above authorizes.
+
+## 3. (Optional) ServiceMonitor + PrometheusRule + autoscaling
+
+If the Prometheus Operator CRDs are installed, the chart can generate its own
+`ServiceMonitor`/`PrometheusRule` for observability parity with the Kubernaut Operator, and
+`HorizontalPodAutoscaler`s for DataStorage/APIFrontend:
+
+```bash
+helm upgrade kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
+  --namespace kubernaut-system --reuse-values \
+  --set monitoring.serviceMonitor.enabled=true \
+  --set monitoring.prometheusRule.enabled=true \
+  --set datastorage.autoscaling.enabled=true
+```
+
+Both `serviceMonitor`/`prometheusRule` are safe to leave `true` even on clusters without the
+Prometheus Operator CRDs installed — they no-op (render nothing) rather than fail.
+
+---
+
+## Verify
+
+Fire a test alert (or wait for a real one) and confirm a `RemediationRequest` is created:
+
+```bash
+kubectl get remediationrequests -n kubernaut-system -w
+```
+
+Check Gateway's own logs for the `TokenReview`/`SubjectAccessReview` result if nothing
+appears:
+
+```bash
+kubectl logs -n kubernaut-system deployment/gateway --tail=50
+```
+
+For an end-to-end example with a real fault (not just a synthetic test alert), see the
+[Try It Out](../../../README.md#try-it-out) section of the root README —
+[kubernaut-demo-scenarios](https://github.com/jordigilh/kubernaut-demo-scenarios)'
+`crashloop` scenario exercises exactly this path.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| AlertManager webhook returns `401` | `bearer_token_file` missing/wrong, or `gateway.enabled=false` | Confirm the path in step 2 and that Gateway is running |
+| AlertManager webhook returns `403` | No `gateway.auth.signalSources` entry for AlertManager's ServiceAccount | Add the entry from step 1, matching AlertManager's actual ServiceAccount name/namespace |
+| No `RemediationRequest` created despite a `200`/`201` from Gateway | Signal deduplicated (identical fingerprint within the dedup window), or the alert's target resource doesn't exist/isn't labeled `kubernaut.ai/managed=true` | Check Gateway logs for the dedup/scope-check decision |
+| `ServiceMonitor`/`PrometheusRule` don't appear | Prometheus Operator CRDs (`monitoring.coreos.com/v1`) not installed on this cluster | Expected — both are a deliberate no-op without the CRDs, not an error |
+
+---
+
+## References
+
+- [charts/kubernaut/README.md](../../../charts/kubernaut/README.md) — full Helm chart reference
+- [Enable/Disable Gateway or APIFrontend](../../../charts/kubernaut/README.md#enable-disable-gateway-or-apifrontend-issue-2162)
+- [INTERACTIVE_MODE_SETUP_GUIDE.md](./INTERACTIVE_MODE_SETUP_GUIDE.md) — the complementary chat-driven entry point
+- [FLEET_SETUP_GUIDE.md](./FLEET_SETUP_GUIDE.md) — layering multi-cluster fleet mode on top of this
+- [Issue #2162: Gateway/APIFrontend independent enable toggles](https://github.com/jordigilh/kubernaut/issues/2162)

--- a/docs/operations/deployment/FLEET_SETUP_GUIDE.md
+++ b/docs/operations/deployment/FLEET_SETUP_GUIDE.md
@@ -1,0 +1,514 @@
+# Fleet Mode Setup Guide (Hub + Spoke)
+
+**Status**: Local/dev walkthrough for a genuine two-cluster fleet topology, condensed
+from this repo's own E2E test infrastructure.
+**Audience**: Operators and SREs who want to configure a real hub+spoke environment to
+try (or validate) Kubernaut's multi-cluster fleet mode, and contributors who want to
+understand each moving part instead of running it as a black box.
+**Authority**: Issue #54, [ADR-068: Fleet Federation Architecture](../../architecture/decisions/ADR-068-fleet-federation-architecture.md), `test/infrastructure/fleet_e2e.go` (source of truth for every step below).
+
+---
+
+## What you're building
+
+```
+┌─────────────────────────────── hub cluster ───────────────────────────────┐
+│                                                                             │
+│  Kubernaut (Helm, global.fleet.enabled=true)   Keycloak (kubernaut-fleet) │
+│  GW · SP · RO · WE · AA · EM · KA · AF · DS  ──────────▲───────────────── │
+│         │ MCP tool calls (Bearer token)                │ OIDC issuer      │
+│         ▼                                               │                 │
+│  Kuadrant MCP Gateway ──registration "remote-cluster"───┘                 │
+│         │ tools/call                                                      │
+│         ▼                                                                 │
+│  bridge Service (kube-mcp-server-remote) ─────┐                           │
+└────────────────────────────────────────────────┼──────────────────────────┘
+                                                   │ podman "kind" bridge network
+┌──────────────────────────────────────────────── ▼ ────── spoke cluster ───┐
+│  kube-mcp-server (passthrough + RFC 8693 token exchange)                  │
+│         │                                                                  │
+│         ▼                                                                  │
+│  Kubernetes API (OIDC-trusts the SAME Keycloak, via a bridged Service)    │
+│         │                                                                  │
+│         ▼                                                                  │
+│  kubernaut-workflows namespace (WorkflowExecution Job dispatch target)    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The **hub** runs the full Kubernaut stack and holds every CRD (`RemediationRequest`,
+`RemediationWorkflow`, `MCPServerRegistration`, etc.). The **spoke** is a genuinely
+separate Kubernetes control plane — no Kubernaut CRDs, just `kube-mcp-server` plus
+whatever target workloads and the `kubernaut-workflows` namespace where
+`WorkflowExecution`'s Job dispatch actually runs remediation Jobs
+(`pkg/workflowexecution/executor/client_factory.go`: an empty `ClusterID` routes to a
+local client, a non-empty one routes through the MCP Gateway to the spoke).
+
+Both clusters trust the **same** Keycloak realm (`kubernaut-fleet`), reached from the
+spoke via a hand-authored Service+Endpoints bridge over the podman `kind` network — no
+SSH tunnel, no separate IdP per cluster.
+
+---
+
+## Prerequisites
+
+- `kind`, `kubectl`, `helm`, `podman` (this repo's E2E harness uses podman as the Kind
+  provider — set `KIND_EXPERIMENTAL_PROVIDER=podman`)
+- `openssl`, `curl`, `python3`
+- ~4 GB free RAM across both clusters
+- An API key from an LLM provider, if you intend to install the full Kubernaut chart
+  on the hub (Path B's last step) rather than just exercising the gateway/spoke wiring
+  on its own
+
+---
+
+## Path A (recommended): use the existing automation
+
+The full two-cluster topology is already wired into this repo's E2E harness and is
+exactly what CI runs — the fastest, most reliably-in-sync way to get a working hub+spoke
+environment:
+
+```bash
+PRESERVE_E2E_CLUSTER=true make test-e2e-fleet
+```
+
+This takes ~35 minutes and, on success, leaves **both** clusters running:
+
+```bash
+export KUBECONFIG=~/.kube/fleet-e2e-config          # hub
+export REMOTE_KUBECONFIG=~/.kube/fleet-e2e-remote-config  # spoke
+
+kubectl get pods -n kubernaut-system                       # hub: full Kubernaut stack
+KUBECONFIG=$REMOTE_KUBECONFIG kubectl get ns kubernaut-workflows  # spoke: dispatch target
+```
+
+| Endpoint | URL |
+|---|---|
+| Kuadrant MCP Gateway (hub) | `http://localhost:31975/mcp` |
+| Keycloak (hub) | `https://localhost:30557/realms/kubernaut-fleet` |
+| Remote cluster identity | `remote-cluster` (every fleet test targets this name) |
+
+To tear down: `kind delete cluster --name fleet-e2e && kind delete cluster --name fleet-e2e-remote`.
+
+This automation lives in `test/infrastructure/fleet_e2e.go`
+(`SetupFleetE2EInfrastructure`) and `fleetmetadatacache_remote_cluster.go`
+(`SetupRemoteClusterForFMC`) if you want to read the real source instead of the
+condensed steps below.
+
+Skip to [Verify hub+spoke routing](#verify-hubspoke-routing) to start poking at it, or
+continue reading for the manual walkthrough.
+
+---
+
+## Path B: Manual walkthrough
+
+### B1. Create the hub cluster
+
+```bash
+kind create cluster --name fleet-hub
+export KUBECONFIG=~/.kube/fleet-hub-config
+kind get kubeconfig --name fleet-hub > "$KUBECONFIG"
+kubectl create namespace kubernaut-system
+```
+
+### B2. Deploy Keycloak with the kubernaut-fleet realm
+
+Same realm three clients used by the single-cluster FMC walkthrough — reused here
+unmodified:
+
+| Client ID | Secret | Purpose |
+|---|---|---|
+| `kubernaut-fleet-read` | `e2e-fleet-secret` | Every fleet-aware service's `client_credentials` identity |
+| `kube-mcp-server` | `e2e-kube-mcp-server-secret` | Requests the RFC 8693 token exchange |
+| `k8s-api` | *(bearer-only, no secret)* | The exchange's target audience — what **both** clusters' API servers validate |
+
+Follow [`fleet-mcp-gateway-keycloak-local-setup.md`](../../development/getting-started/fleet-mcp-gateway-keycloak-local-setup.md)'s
+**B2 (Deploy Keycloak)**, **B3 (Enable OIDC on the Kind API server)**, **B4 (Deploy
+kube-mcp-server)**, and **B5 (Deploy the Kuadrant MCP Gateway)** against this hub
+cluster — those four steps are identical for hub+spoke and single-cluster loopback; no
+changes needed. Come back here once B5 is done and the Kuadrant broker is `Ready`.
+
+At the end of B4/B5, note two things you'll need below:
+
+- **Keycloak's TLS cert** (`/tmp/keycloak-tls.crt`) — the spoke's API server needs to
+  trust it too.
+- **The hub node's name**: `fleet-hub-control-plane`.
+
+### B3. Create the spoke cluster
+
+```bash
+kind create cluster --name fleet-spoke
+export SPOKE_KUBECONFIG=~/.kube/fleet-spoke-config
+kind get kubeconfig --name fleet-spoke > "$SPOKE_KUBECONFIG"
+kubectl --kubeconfig "$SPOKE_KUBECONFIG" create namespace kubernaut-system
+```
+
+Kind clusters created by the same podman daemon share the `kind` bridge network — any
+node's IP is directly routable from any other node's containers, no host port mapping
+required (validated in Spike S19). This is what lets the spoke's API server reach the
+hub's Keycloak, and what lets the hub's Kuadrant Gateway reach the spoke's
+`kube-mcp-server`, without a tunnel.
+
+### B4. Create the workflow dispatch namespace + RBAC on the spoke
+
+The hub only pre-creates `kubernaut-workflows` on itself. Job-backend workflows (e.g.
+`crashloop-config-fix-v1`) dispatch their Job to whichever cluster
+`RemediationRequest.ClusterID` names, so the namespace and its executor identity must
+also exist on the spoke:
+
+```bash
+kubectl --kubeconfig "$SPOKE_KUBECONFIG" apply -f - <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubernaut-workflows
+EOF
+
+kubectl --kubeconfig "$SPOKE_KUBECONFIG" apply -f - <<'EOF'
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workflow-job-executor
+  namespace: kubernaut-workflows
+  labels: {app: workflowexecution, component: job-executor}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workflow-job-executor
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets", "daemonsets"]
+  verbs: ["get", "list", "patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: workflow-job-executor
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: workflow-job-executor}
+subjects: [{kind: ServiceAccount, name: workflow-job-executor, namespace: kubernaut-workflows}]
+EOF
+```
+
+`workflow-job-executor` is the ServiceAccount Job pods run as (e.g.
+`oomkill-increase-memory-job`'s `remediate.sh` patches a Deployment's resource limits;
+`crashloop-config-fix-v1` patches a ConfigMap back to a known-good value) — see
+`execution.serviceAccountName` in the relevant `RemediationWorkflow` manifest.
+
+### B5. Bridge Keycloak into the spoke
+
+The spoke's API server needs to reach the hub's Keycloak by the same hostname
+(`keycloak:8443`) the OIDC issuer URL uses — a hand-authored Service+Endpoints pair
+does this without a selector, resolvable by plain in-cluster DNS:
+
+```bash
+HUB_NODE_IP=$(podman inspect fleet-hub-control-plane \
+  --format '{{.NetworkSettings.Networks.kind.IPAddress}}')
+
+kubectl --kubeconfig "$SPOKE_KUBECONFIG" apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: kubernaut-system
+spec:
+  ports: [{port: 8443, targetPort: 30557}]
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: keycloak
+  namespace: kubernaut-system
+subsets:
+- addresses: [{ip: "$HUB_NODE_IP"}]
+  ports: [{port: 30557}]
+EOF
+```
+
+`targetPort`/the Endpoints port here is the hub's Keycloak **NodePort** (`30557`), while
+the Service's own `port` (`8443`) is what in-cluster clients dial — these are
+deliberately different numbers. A bridge created with them equal reproduces a
+"connection refused" (Spike S19 finding: in-cluster clients dial the well-known port,
+not the peer's NodePort).
+
+Copy Keycloak's self-signed TLS cert to wherever your spoke-side OIDC patch step (B6)
+expects a CA bundle — same file `/tmp/keycloak-tls.crt` from B2.
+
+### B6. Enable OIDC on the spoke's API server
+
+Identical to the hub's B3 step, run against the spoke instead:
+
+```bash
+NODE=fleet-spoke-control-plane
+podman cp /tmp/keycloak-tls.crt "$NODE:/etc/kubernetes/pki/oidc-ca.crt"
+podman exec "$NODE" bash -c '
+sed -i "/--tls-private-key-file/a\\
+    - \"--oidc-username-prefix=keycloak:\"\\
+    - --oidc-username-claim=preferred_username\\
+    - --oidc-client-id=k8s-api\\
+    - --oidc-ca-file=/etc/kubernetes/pki/oidc-ca.crt\\
+    - \"--oidc-issuer-url=https://keycloak:8443/realms/kubernaut-fleet\"" \
+  /etc/kubernetes/manifests/kube-apiserver.yaml'
+
+# Same hostNetwork DNS caveat as the hub (see the referenced doc's B3) --
+# patch the node's /etc/hosts with the bridge Service's ClusterIP:
+KC_IP=$(kubectl --kubeconfig "$SPOKE_KUBECONFIG" get svc keycloak -n kubernaut-system -o jsonpath='{.spec.clusterIP}')
+podman exec "$NODE" bash -c "echo '$KC_IP keycloak' >> /etc/hosts"
+
+until kubectl --kubeconfig "$SPOKE_KUBECONFIG" get --raw /readyz &>/dev/null; do sleep 3; done
+```
+
+### B7. Deploy kube-mcp-server on the spoke + grant it RBAC
+
+Deploy the exact same passthrough+STS `kube-mcp-server` as the hub (B4's manifest,
+unchanged — same Keycloak realm, same STS client), then grant the **exchanged**
+identity two things: read access, and — spoke-only — write access to `batch/jobs` so
+`WorkflowExecution` can actually create the remediation Job here:
+
+```bash
+# Deploy kube-mcp-server into $SPOKE_KUBECONFIG using the referenced doc's B4 manifest.
+
+kubectl --kubeconfig "$SPOKE_KUBECONFIG" apply -f - <<'EOF'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fleet-exchanged-identity-binding
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: view}
+subjects:
+- {kind: User, name: "keycloak:service-account-kubernaut-fleet-read", apiGroup: rbac.authorization.k8s.io}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fleet-exchanged-identity-job-write
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create", "get", "list", "watch", "delete", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fleet-exchanged-identity-job-write-binding
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: fleet-exchanged-identity-job-write}
+subjects:
+- {kind: User, name: "keycloak:service-account-kubernaut-fleet-read", apiGroup: rbac.authorization.k8s.io}
+EOF
+```
+
+`patch`+`update` (not just `create`) are both required: `kube-mcp-server`'s
+create-or-update tool always issues a server-side-apply `patch`, regardless of whether
+the Job already exists — a bare `create` grant 403s with "cannot patch resource jobs".
+
+Expose it so the hub can reach it:
+
+```bash
+kubectl --kubeconfig "$SPOKE_KUBECONFIG" apply -f - <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-mcp-server-nodeport
+  namespace: kubernaut-system
+spec:
+  type: NodePort
+  selector: {app: kube-mcp-server}
+  ports: [{port: 8080, targetPort: 8080, nodePort: 30180}]
+EOF
+
+SPOKE_NODE_IP=$(podman inspect fleet-spoke-control-plane \
+  --format '{{.NetworkSettings.Networks.kind.IPAddress}}')
+```
+
+### B8. Bridge the hub's Kuadrant Gateway to the spoke, register as "remote-cluster"
+
+Back on the hub, bridge a local Service to the spoke's `kube-mcp-server` NodePort, then
+register it with Kuadrant under the identity every fleet test (and, once you install
+the chart, every fleet-tagged `RemediationRequest`) expects: `remote-cluster`.
+
+```bash
+kubectl --kubeconfig "$KUBECONFIG" apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-mcp-server-remote
+  namespace: kubernaut-system
+spec:
+  ports: [{port: 8080, targetPort: 30180}]
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: kube-mcp-server-remote
+  namespace: kubernaut-system
+subsets:
+- addresses: [{ip: "$SPOKE_NODE_IP"}]
+  ports: [{port: 30180}]
+EOF
+```
+
+Get a broker discovery token (the Kuadrant broker's own upstream connection needs a
+static credential whenever `require_oauth = true` — separate from, and never injected
+into, per-request `tools/call` proxying):
+
+```bash
+BROKER_TOKEN=$(curl -sk -X POST \
+  https://localhost:30557/realms/kubernaut-fleet/protocol/openid-connect/token \
+  -d grant_type=client_credentials -d client_id=kubernaut-fleet-read \
+  -d client_secret=e2e-fleet-secret -d scope=kube-mcp-server-audience \
+  | python3 -c 'import json,sys;print(json.load(sys.stdin)["access_token"])')
+
+kubectl --kubeconfig "$KUBECONFIG" apply -n kubernaut-system -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata: {name: kube-mcp-server-remote-broker-cred, labels: {mcp.kuadrant.io/secret: "true"}}
+type: Opaque
+stringData: {token: "Bearer ${BROKER_TOKEN}"}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata: {name: kube-mcp-server-remote-route}
+spec:
+  hostnames: [kube-mcp-server-remote.127-0-0-1.sslip.io]
+  parentRefs: [{name: mcp-gateway, namespace: gateway-system, sectionName: mcp}]
+  rules: [{backendRefs: [{name: kube-mcp-server-remote, port: 8080}]}]
+---
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata: {name: remote-cluster, labels: {kubernaut.ai/managed: "true"}}
+spec:
+  prefix: "remote_cluster_"
+  credentialRef: {name: kube-mcp-server-remote-broker-cred}
+  targetRef: {group: gateway.networking.k8s.io, kind: HTTPRoute, name: kube-mcp-server-remote-route, namespace: kubernaut-system}
+EOF
+```
+
+Grant the hub the same exchanged-identity `view` binding from B7's first manifest (the
+hub's own local loopback registration, if you keep one, needs it too).
+
+### B9. Create the shared fleet OAuth2 Secret, then install Kubernaut
+
+Every fleet-aware service (GW, RO, SP, AF, EM, WE) authenticates its own MCP Gateway
+calls with one shared Keycloak client:
+
+```bash
+kubectl --kubeconfig "$KUBECONFIG" apply -n kubernaut-system -f - <<'EOF'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fleet-oauth2-creds
+  namespace: kubernaut-system
+  labels: {component: fleet}
+type: Opaque
+stringData:
+  client-id: "kubernaut-fleet-read"
+  client-secret: "e2e-fleet-secret"
+EOF
+```
+
+Install the chart on the hub with fleet enabled (see
+[charts/kubernaut/README.md](../../../charts/kubernaut/README.md) for the rest of the
+Quick Start — namespace, PostgreSQL/Valkey Secrets, Rego policies, and an LLM provider
+API key are still required the same as any install):
+
+```bash
+helm install kubernaut charts/kubernaut -n kubernaut-system \
+  --set global.fleet.enabled=true \
+  --set global.fleet.mcpGatewayEndpoint="http://mcp-gateway-istio.gateway-system.svc:8080/mcp" \
+  --set global.fleet.mcpGatewayType=kuadrant \
+  --set global.fleet.oauth2.enabled=true \
+  --set global.fleet.oauth2.tokenURL="https://keycloak:8443/realms/kubernaut-fleet/protocol/openid-connect/token" \
+  --set global.fleet.oauth2.credentialsSecretRef=fleet-oauth2-creds \
+  --set workflowexecution.fleet.oauth2.credentialsSecretRef=fleet-oauth2-creds \
+  # ... plus your usual PostgreSQL/Valkey/LLM/Rego overrides
+```
+
+`workflowexecution.fleet.oauth2.credentialsSecretRef` is called out explicitly because
+WE is the only fleet-integration-capable service that does **not** fall back to
+`global.fleet.oauth2.credentialsSecretRef` — it's the sole service calling MCP *write*
+tools (`resources_create_or_update`/`resources_delete`), so it keeps its own,
+independently-settable credential for least-privilege.
+
+### Fleet still needs a triggering path: Autonomous or Interactive
+
+`global.fleet.*` only wires the MCP Gateway plumbing — it doesn't put anything in
+front of Kubernaut that can start an investigation. Layer one of the other two modes
+on top, in the same `helm install`:
+
+- **Autonomous** (alert-driven): `gateway.enabled` defaults to `true` already; add
+  `gateway.auth.signalSources` for your AlertManager instance. See
+  [AUTONOMOUS_MODE_SETUP_GUIDE.md](./AUTONOMOUS_MODE_SETUP_GUIDE.md).
+- **Interactive** (chat-driven): `console.enabled=true` plus `console.auth.secretName`
+  and `apifrontend.config.auth.issuerURL`/`jwtProviders` for your OIDC provider. See
+  [INTERACTIVE_MODE_SETUP_GUIDE.md](./INTERACTIVE_MODE_SETUP_GUIDE.md).
+
+Both work with fleet mode simultaneously — the full `test-e2e-fleet` suite (Path A)
+deploys Gateway *and* Console/AF together specifically to exercise both triggering
+paths against the same hub+spoke topology. Whether an individual `RemediationRequest`
+resolves to the hub or a spoke is driven entirely by
+`RemediationRequest.spec.clusterID` (SignalProcessing's `ClusterClassification`, or an
+explicit `cluster_id` in an interactive chat message) — independent of which path
+created it.
+
+---
+
+## Verify hub+spoke routing
+
+Send a fleet-scoped alert naming `remote-cluster` and confirm the resulting
+`RemediationRequest` actually routes through the spoke, not the hub:
+
+```bash
+curl -s http://localhost:31975/mcp \
+  -H "Authorization: Bearer $BROKER_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | python3 -m json.tool
+```
+
+Expect tool names prefixed `remote_cluster_` (e.g. `remote_cluster_resources_get`) —
+confirming the spoke's tools are discoverable, distinct from any `loopback_cluster_`
+tools you may also have registered. Once you post an alert with
+`labels.cluster_id: remote-cluster` to the Gateway's `/api/v1/signals/prometheus`
+endpoint, check the target namespace on the **spoke**, not the hub:
+
+```bash
+KUBECONFIG=$SPOKE_KUBECONFIG kubectl get jobs -n kubernaut-workflows -w
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Spoke's API server: `oidc: authenticator not initialized` / DNS resolution failure | Same hostNetwork `/etc/hosts` gap as the hub (see referenced doc's B3) | Patch `/etc/hosts` on the spoke's node too (B6) |
+| Kuadrant broker gets `401` discovering `remote-cluster` | No `credentialRef` on the `MCPServerRegistration`, or a stale/expired broker token | Re-mint `BROKER_TOKEN` and recreate the Secret |
+| `tools/call` against `remote_cluster_*` tools returns `403` on Job creation | Spoke RBAC only has the `view` binding, missing `fleet-exchanged-identity-job-write` | Apply B7's second `ClusterRoleBinding` |
+| Job never appears in `kubernaut-workflows` on the spoke | `RemediationRequest.ClusterID` wasn't set, or the alert used a different cluster identity than the `MCPServerRegistration`'s name | Confirm the alert payload's `cluster_id` matches `remote-cluster` exactly (case-sensitive) |
+| Bridge Service connection refused | `port/targetPort` swapped between the Service (well-known port) and the Endpoints (peer's real NodePort) — see B5's note | Double-check which number is the NodePort vs. the in-cluster dial port |
+| Everything above already covered | Single-cluster loopback issues (Keycloak, Kuadrant, kube-mcp-server itself) | See [`fleet-mcp-gateway-keycloak-local-setup.md`](../../development/getting-started/fleet-mcp-gateway-keycloak-local-setup.md)'s own troubleshooting table |
+
+---
+
+## Cleanup
+
+```bash
+kind delete cluster --name fleet-hub
+kind delete cluster --name fleet-spoke
+```
+
+---
+
+## References
+
+- [ADR-068: Fleet Federation Architecture](../../architecture/decisions/ADR-068-fleet-federation-architecture.md)
+- [Fleet Federation Guide](../../architecture/fleet-federation-guide.md) — production onboarding, not local dev
+- [fleet-mcp-gateway-keycloak-local-setup.md](../../development/getting-started/fleet-mcp-gateway-keycloak-local-setup.md) — single-cluster loopback variant this guide extends; B2-B5 are reused here unmodified
+- `test/infrastructure/fleet_e2e.go` (`SetupFleetE2EInfrastructure`, `deployKuadrantRegistrations`) — source of truth for Path A's automation and this guide's hub-side steps
+- `test/infrastructure/fleetmetadatacache_remote_cluster.go` (`SetupRemoteClusterForFMC`) — source of truth for this guide's spoke-side steps
+- `test/infrastructure/workflowexecution_e2e_hybrid.go` (`createWorkflowJobExecutorRBAC`) — source of truth for B4's RBAC
+- [charts/kubernaut/README.md](../../../charts/kubernaut/README.md) — full Helm chart install reference (Secrets, Rego policies, LLM provider config)
+- [AUTONOMOUS_MODE_SETUP_GUIDE.md](./AUTONOMOUS_MODE_SETUP_GUIDE.md) / [INTERACTIVE_MODE_SETUP_GUIDE.md](./INTERACTIVE_MODE_SETUP_GUIDE.md) — the triggering path fleet mode layers onto; see "Fleet still needs a triggering path" above
+- [Issue #54: Fleet Management](https://github.com/jordigilh/kubernaut/issues/54)

--- a/docs/operations/deployment/INTERACTIVE_MODE_SETUP_GUIDE.md
+++ b/docs/operations/deployment/INTERACTIVE_MODE_SETUP_GUIDE.md
@@ -1,0 +1,198 @@
+# Interactive Mode Setup Guide (Console + APIFrontend + OIDC)
+
+**Status**: Operator-facing setup guide, condensed from the Helm chart's own reference
+(`charts/kubernaut/README.md`).
+**Audience**: Operators and SREs who want chat-driven investigation — a human (or an
+external agent) asks Kubernaut to investigate or remediate something on demand, via a
+browser console or directly against APIFrontend's MCP/API surface.
+**Authority**: `charts/kubernaut/README.md` ("Optional: Web Console", "Enable/Disable
+Gateway or APIFrontend"), Issue #2162, BR-PLATFORM-006.
+
+---
+
+## What you're building
+
+```
+Browser ──OIDC login──▶ oauth2-proxy (Console) ──▶ Console (static SPA)
+                                                          │ A2A chat
+                                                          ▼
+                                                     APIFrontend
+                                                          │ MCP tool calls (kubernaut_investigate, kubernaut_approve, ...)
+                                                          ▼
+                                RemediationRequest CRD created directly (no Gateway involved)
+                                                          │
+                                                          ▼
+                    SignalProcessing → AIAnalysis → RemediationWorkflow → WorkflowExecution
+```
+
+APIFrontend creates `RemediationRequest` CRs directly via the Kubernetes API when a chat
+investigation asks for one (`pkg/apifrontend/tools/af_create_rr.go`) — it never calls
+Gateway's webhook endpoint. Gateway and APIFrontend are independent entry points into the
+same pipeline (Issue #2162); this guide only sets up APIFrontend's.
+
+If you also want the alert-driven path, see
+[AUTONOMOUS_MODE_SETUP_GUIDE.md](./AUTONOMOUS_MODE_SETUP_GUIDE.md) — the two are
+independent and can both be enabled on the same install.
+
+### Does enabling this let Gateway/AlertManager "take over" too?
+
+No. Leave `gateway.enabled` at its Helm default (`true`) — it costs nothing to run
+alongside Interactive mode, because `gateway.auth.signalSources` (the actual
+authorization gate on who can call Gateway's webhook endpoint) defaults to an **empty
+list**. With no entry in it, Gateway rejects every request with `403` regardless of
+whether it's running — there's no external sender authorized to reach it until you
+explicitly add one (see [AUTONOMOUS_MODE_SETUP_GUIDE.md](./AUTONOMOUS_MODE_SETUP_GUIDE.md)
+step 1). Disabling Gateway outright is unnecessary defense-in-depth for a purely
+interactive deployment, not a required step.
+
+---
+
+## Prerequisites
+
+- A Kubernetes cluster with a dynamic-provisioning `StorageClass` (for PostgreSQL/Valkey)
+- Helm 3.12+
+- An API key from an LLM provider (OpenAI, Anthropic, etc.)
+- An OIDC provider (Keycloak, Dex, or any standards-compliant OIDC IdP) reachable from the
+  cluster, with a browser-login-capable client for Console and (optionally) an audience
+  claim for APIFrontend
+
+---
+
+## 1. Configure your OIDC provider
+
+Create an OIDC client for Console (confidential, redirect URI `https://<your console
+host>/oauth2/callback`). APIFrontend validates the resulting JWTs — either the simple
+single-provider form or the production multi-provider form:
+
+```yaml
+# Simple (dev/test convenience)
+apifrontend:
+  config:
+    auth:
+      issuerURL: "https://keycloak.example.com/realms/kagenti"
+
+# Production (multi-provider, #1436)
+apifrontend:
+  config:
+    auth:
+      jwtProviders:
+        - name: "keycloak"
+          issuerURL: "https://keycloak.example.com/realms/kagenti"
+          jwksURL: "http://keycloak-service.keycloak:8080/realms/kagenti/protocol/openid-connect/certs"
+          audiences: ["kubernaut-apifrontend"]
+          claimMappings:
+            username: "preferred_username"
+            groups: "groups"
+```
+
+If your IdP doesn't inject an audience claim naming `kubernaut-apifrontend` by default
+(Keycloak doesn't, out of the box), add a client scope with an audience mapper and assign
+it as a default scope on Console's client — otherwise APIFrontend's strict audience-list
+match rejects every console-issued token.
+
+## 2. Pre-create Console's OIDC client Secret
+
+```bash
+kubectl create secret generic console-oauth-creds \
+  --from-literal=client-id=kubernaut-console \
+  --from-literal=client-secret="$OIDC_CLIENT_SECRET" \
+  --from-literal=cookie-secret="$(openssl rand -base64 32 | head -c 32 | base64)" \
+  -n kubernaut-system
+```
+
+`cookie-secret` is a random 32-byte value oauth2-proxy uses to encrypt its session cookie —
+not from your OIDC provider.
+
+## 3. Install with Console + APIFrontend enabled
+
+Follow [charts/kubernaut/README.md](../../../charts/kubernaut/README.md)'s Quick Start for
+the namespace and the three credential Secrets (PostgreSQL, Valkey, LLM provider API key),
+plus your Rego policies, then install with Console and its OIDC wiring:
+
+```bash
+helm install kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
+  --namespace kubernaut-system \
+  --set global.llmProfiles.primary.provider=openai \
+  --set global.llmProfiles.primary.model=gpt-4o \
+  --set global.llmProfiles.primary.endpoint=https://api.openai.com/v1 \
+  --set global.llmProfiles.primary.credentialsSecretName=llm-credentials \
+  --set kubernautAgent.llmProfileRef=primary \
+  --set-file signalprocessing.policies.content=path/to/policy.rego \
+  --set-file aianalysis.policies.content=path/to/approval.rego \
+  --set apifrontend.config.auth.issuerURL="https://keycloak.example.com/realms/kagenti" \
+  --set console.enabled=true \
+  --set console.auth.secretName=console-oauth-creds \
+  --set console.ingress.host=console.apps.example.com \
+  --set console.ingress.enabled=true
+```
+
+`apifrontend.enabled` defaults to `true` — no need to set it. `console.enabled=true`
+requires `apifrontend.enabled=true` (Console proxies to APIFrontend only) and a resolvable
+OIDC issuer (either `apifrontend.config.auth.issuerURL` above, or
+`jwtProviders`) — the chart fails fast at `helm template`/`install` time, before anything
+is applied, if either is missing.
+
+`console.ingress.host` is **required** whenever `console.enabled=true`, even if you leave
+`console.ingress.enabled=false` (the default, per BR-PLATFORM-009's opt-in-only stance on
+externally exposing Kubernaut's ingress points) to front Console with your own
+Ingress/Route/mesh gateway instead — oauth2-proxy needs the browser-facing hostname for its
+OIDC redirect URL regardless of who creates the Ingress.
+
+## 4. RBAC: gate real tool calls, not just login
+
+Logging in successfully is not the same as being authorized to call MCP tools
+(`kubernaut_investigate`, `kubernaut_approve`, etc.) — those go through a real Kubernetes
+`SubjectAccessReview`. Two things commonly need explicit setup on a fresh OIDC realm with
+no prior human-user model:
+
+- A claim (typically `groups`) mapping the logged-in user to a role/persona your RBAC
+  config recognizes. Configure `apifrontend.config.rbac` with `roleBindings` mapping OIDC
+  groups to Kubernaut personas (e.g. `sre`).
+- `apifrontend.config.rbac.consoleAccessAuthorizationCheckEnabled` defaults to `false`
+  (#2150) — authentication-only, so a fresh install works with zero RBAC config for
+  dev/eval. Set it `true` once you've configured real personas/groups for production, to
+  additionally gate the console-access check itself (per-tool authorization already
+  applies either way).
+
+Without a matching group claim and role binding, the symptom looks like "login works, then
+every tool call silently fails" rather than an obvious auth error — check for `403`s from a
+real `SubjectAccessReview` denial, not a login/redirect loop.
+
+---
+
+## Verify
+
+```bash
+kubectl get pods -n kubernaut-system -l app=console,app=apifrontend
+```
+
+Open `https://<console.ingress.host>` in a browser, log in via your OIDC provider, and
+start a chat asking Kubernaut to investigate a real resource in your cluster. Confirm an
+`InvestigationSession`/`AgentSession` is created:
+
+```bash
+kubectl get investigationsessions,agentsessions -n kubernaut-system
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Console redirects to login in a loop, never completes | Missing/incorrect audience claim on the OIDC token for Console's own client ID | Add a self-referential audience mapper (`aud` must include `kubernaut-console` itself, not just `kubernaut-apifrontend`) |
+| Login succeeds, but every real tool call fails | No RBAC role binding for the logged-in user's group | See step 4 — configure `apifrontend.config.rbac.roleBindings` |
+| `helm install` fails before applying anything | Missing `console.auth.secretName`, OIDC issuer, or `console.ingress.host` while `console.enabled=true` | The chart's fail-fast validation names exactly which one is missing |
+| APIFrontend rejects every console-issued token outright | No audience mapper injecting `kubernaut-apifrontend` into `aud` | See step 1's note on audience mappers — common on a fresh Keycloak realm with no existing kubernaut-apifrontend-aware client scope |
+
+---
+
+## References
+
+- [charts/kubernaut/README.md](../../../charts/kubernaut/README.md) — full Helm chart reference
+- [Optional: Web Console](../../../charts/kubernaut/README.md#optional-web-console-br-platform-006)
+- [Enable/Disable Gateway or APIFrontend](../../../charts/kubernaut/README.md#enable-disable-gateway-or-apifrontend-issue-2162)
+- [AUTONOMOUS_MODE_SETUP_GUIDE.md](./AUTONOMOUS_MODE_SETUP_GUIDE.md) — the complementary alert-driven entry point
+- [FLEET_SETUP_GUIDE.md](./FLEET_SETUP_GUIDE.md) — layering multi-cluster fleet mode on top of this
+- `pkg/apifrontend/tools/af_create_rr.go` — source of truth for how AF creates `RemediationRequest` directly
+- [Issue #2162: Gateway/APIFrontend independent enable toggles](https://github.com/jordigilh/kubernaut/issues/2162)


### PR DESCRIPTION
## Summary

- `v1.6` was still labeled "in progress" with ServiceNow bundled in — the [milestone](https://github.com/jordigilh/kubernaut/milestone/7) is fully closed (0 open issues, `v1.6.0-rc7` tagged), and ServiceNow ([#1338](https://github.com/jordigilh/kubernaut/issues/1338)) actually ships in the separate v1.6.1 milestone. Updated the header to "release candidate" and tagged the ServiceNow bullet accordingly.
- Added the missing **Fleet Metadata Cache** row to the Services table (`cmd/fleetmetadatacache` has its own build/test/E2E targets but wasn't listed).
- Replaced the single Installation link (which only pointed to a docs-site page that's Operator-only content, with no Helm chart guide at all) with direct links to the Helm chart's own README and the Operator's own installation guide — each lives with its own code so it can't drift out of sync the way the docs-site link did.
- Added a Website link (`kubernaut.ai`) to the footer, alongside Issues/Discussions.

## Test plan

- [x] Doc-only change, no build/test impact
- [x] Verified all new/changed links resolve (Helm chart README, Operator quickstart guide, kubernaut.ai)
- [x] Verified milestone/issue status against the GitHub API before rewording the Roadmap section