### PR TITLE
Fix #2306: suppress hub-bound local tools during fleet-target RCA

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -42,6 +42,7 @@ import (
 	kubelog "github.com/jordigilh/kubernaut/pkg/log"
 	sharedhealth "github.com/jordigilh/kubernaut/pkg/shared/health"
 	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
+	"github.com/jordigilh/kubernaut/pkg/shared/k8s/ownerchain"
 	"github.com/jordigilh/kubernaut/pkg/shared/telemetry"
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 	"k8s.io/client-go/dynamic"
@@ -357,11 +358,11 @@ func registerAdapters(
 	serverCfg *config.ServerConfig,
 	logger logr.Logger,
 ) (*fleetclient.ResilientClient, error) {
-	ownerResolver := adapters.NewK8sOwnerResolver(
+	ownerResolver := ownerchain.NewK8sOwnerResolver(
 		srv.GetCachedClient(),
 		logger.WithName("owner-resolver"),
-		adapters.WithFallbackReader(srv.GetAPIReader()),
-		adapters.WithRegistry(apiRegistry),
+		ownerchain.WithFallbackReader(srv.GetAPIReader()),
+		ownerchain.WithRegistry(apiRegistry),
 	)
 
 	// Prometheus AlertManager webhook adapter

--- a/docs/architecture/decisions/DD-FLEET-005-cluster-transparent-tool-exposure.md
+++ b/docs/architecture/decisions/DD-FLEET-005-cluster-transparent-tool-exposure.md
@@ -301,9 +301,12 @@ wrapping) before the local registry is ever consulted.
 for `overlayK8sClient` — `ownerchain.KindToGroup()`'s static table covers
 core/apps/batch kinds only. A resource of an unlisted kind reaching
 `GetSpecHash` with no explicit `apiVersion` gets a clear error rather than a
-guess. A follow-up issue should track full remote-discovery parity if a real
-investigation ever needs a CRD's spec hash through the overlay path; the
-common workload kinds an RCA investigation deals with are already covered.
+guess. Tracked in issue #2308: triage found no discovery tool (an
+equivalent of `kubectl api-resources`) exists anywhere in
+`containers/kubernetes-mcp-server`'s current toolset, so closing this
+requires either an upstream contribution or a bounded expansion of the
+static table -- not a one-line fix. The common workload kinds an RCA
+investigation deals with are already covered.
 
 | Component | Production Entry Point | Wiring Code Location | IT Test ID |
 |---|---|---|---|
@@ -316,5 +319,5 @@ common workload kinds an RCA investigation deals with are already covered.
 
 ## Authority
 
-Issue #1729, Issue #1732, Issue #2306, ADR-068 (decision #11),
+Issue #1729, Issue #1732, Issue #2306, Issue #2308, ADR-068 (decision #11),
 BR-INTEGRATION-054, BR-INTEGRATION-1489.

--- a/docs/architecture/decisions/DD-FLEET-005-cluster-transparent-tool-exposure.md
+++ b/docs/architecture/decisions/DD-FLEET-005-cluster-transparent-tool-exposure.md
@@ -226,7 +226,84 @@ randomized map iteration order.
 |---|---|---|---|
 | Non-colliding overlay tool append | `toolDefinitionsForPhase()` -> `appendNonCollidingOverlayTools()` | `internal/kubernautagent/investigator/investigator_tools.go` | IT-KA-FLEET-024 |
 
+## Amendment (2026-08-28, issue #2306 close-out): subtractive suppression + resourceContextTools cluster-awareness
+
+Issue #2306 found the override-and-append halves above still left a third
+gap: a local tool whose *behavior* depends on which cluster it queries
+(the client-go/dynamic-client-backed RCA tools — `k8s.AllToolNames`,
+`k8s.MetricsToolNames`, `k8s.NodeProxyToolNames`) but has no same-named
+overlay override stayed advertised to the LLM even for a fleet-target
+investigation. `kube-mcp-server`'s real tool names (`resources_get`,
+`resources_list`, ...) never collide with these local names, so the
+override loop never protected them — the LLM could silently call, e.g.,
+`kubectl_get_by_name` during a fleet-target investigation and get an answer
+from the hub, not the target cluster (the AC-6 defect in #2306's evidence
+trace, RR `rr-9dc9711199fd-bd25bdf5`).
+
+A second, related gap: `resourceContextTools` (`get_namespaced_resource_context`/
+`get_cluster_resource_context`, `internal/kubernautagent/tools/custom/resource_context.go`)
+unconditionally resolved owner-chain/spec-hash against the hub-bound
+`enrichment.K8sClient` and queried `ds.GetRemediationHistory` with an
+unscoped `clusterID`, for the same reason — no fleet-awareness in either
+code path.
+
+**Fix, part 1 (subtractive suppression)**: during the RCA phase of a
+fleet-target investigation (non-empty overlay), `toolDefinitionsForPhase()`
+now skips a local tool name entirely — never appends it to the schema —
+when it's in `fleetSuppressedToolNames` (the three name sets above) and has
+no same-named overlay override. A hub-local investigation (no overlay in
+ctx) never triggers the skip, so its schema is unchanged. Prometheus/
+Alertmanager tools stay always-visible, per the existing Thanos MVP
+federation-transparency decision (PR #1364) — they are not host-bound.
+
+**Fix, part 2 (resourceContextTools cluster-awareness)**: both tools now
+resolve owner-chain/spec-hash against the correct cluster instead of
+unconditionally querying the hub, reusing Gateway's own already-tested
+owner-chain resolver rather than reimplementing a walk loop and static kind
+table from scratch. `pkg/gateway/adapters/owner_resolver.go`'s
+`K8sOwnerResolver` (used by Gateway for signal-fingerprinting owner-chain
+resolution, including its own already-proven remote-cluster resolution via
+`mcpclient.Client`) moved unchanged in behavior to a new shared package,
+`pkg/shared/k8s/ownerchain`, alongside the existing `pkg/shared/k8s/gvk.go`
+GVK helpers — the same `pkg/shared/*` pattern already used for `hash` and
+`scope` so services can share domain logic as peers, without cross-service
+imports. A minimal `KindResolver` interface (`KindToGVR`, `IsCoreBatchAppsKind`)
+replaces the resolver's direct binding to Gateway's concrete
+`APIResourceRegistry`; `*APIResourceRegistry` satisfies it automatically via
+structural typing, with zero code changes to `resource_registry.go`.
+
+On top of the moved package, `internal/kubernautagent/tools/custom/fleet_resource_context.go`
+adds `overlayClientReader` (a `client.Reader` adapter over the fleet
+overlay's `resources_get` tool, reusing the newly-exported
+`mcpclient.ParseUnstructuredResponse`/`mcpclient.PopulateObject` — mechanical
+renames of previously-private helpers, zero behavior change) and
+`overlayK8sClient` (wraps `ownerchain.NewK8sOwnerResolver` for
+`GetOwnerChain`, and `ownerchain.KindToGroup()` + `hash.CanonicalResourceFingerprint`
+for `GetSpecHash`). `resource_context.go`'s `resolveK8sClient()` picks
+the hub-bound client for a hub-local investigation, `overlayK8sClient` for a
+fleet-target investigation whose overlay publishes `resources_get`, or a
+no-op client (clear "not available" error, no silent hub fallback) if the
+overlay lacks it. `fetchRemediationHistory()` now threads
+`audit.ClusterIDFromContext(ctx)` (already set by `prescopeFleetOverlay`)
+into `ds.GetRemediationHistory` instead of an unscoped `""`.
+
+**Deliberately out of scope**: full RESTMapper-equivalent remote discovery
+for `overlayK8sClient` — `ownerchain.KindToGroup()`'s static table covers
+core/apps/batch kinds only. A resource of an unlisted kind reaching
+`GetSpecHash` with no explicit `apiVersion` gets a clear error rather than a
+guess. A follow-up issue should track full remote-discovery parity if a real
+investigation ever needs a CRD's spec hash through the overlay path; the
+common workload kinds an RCA investigation deals with are already covered.
+
+| Component | Production Entry Point | Wiring Code Location | IT Test ID |
+|---|---|---|---|
+| `fleetSuppressedToolNames` + subtractive filter | `toolDefinitionsForPhase()` | `internal/kubernautagent/investigator/investigator_tools.go` | IT-KA-FLEET-030/031 |
+| `pkg/shared/k8s/ownerchain` (moved `K8sOwnerResolver`, `KindResolver` interface) | `cmd/gateway/main.go` (existing), `fleet_resource_context.go` (new) | `pkg/shared/k8s/ownerchain` | Gateway's existing 6-file regression suite + UT-KA-FLEET-031/032 |
+| `overlayClientReader` / `overlayK8sClient` | Constructed per-`Execute()` call in `namespacedResourceContextTool`/`clusterResourceContextTool` | `internal/kubernautagent/tools/custom/fleet_resource_context.go` | UT-KA-FLEET-031/032 |
+| `mcpclient.ParseUnstructuredResponse` / `mcpclient.PopulateObject` (exported) | Called by `overlayClientReader.Get` | `pkg/fleet/mcpclient/parse.go`, `pkg/fleet/mcpclient/client.go` | UT-KA-FLEET-031 (indirect) |
+| K8sClient-selection guard (`resolveK8sClient`) + `remediationHistoryQuery.ClusterID` | `Execute()` on both `resourceContextTools` | `internal/kubernautagent/tools/custom/resource_context.go` | IT-KA-FLEET-032/033 |
+
 ## Authority
 
-Issue #1729, Issue #1732, ADR-068 (decision #11), BR-INTEGRATION-054,
-BR-INTEGRATION-1489.
+Issue #1729, Issue #1732, Issue #2306, ADR-068 (decision #11),
+BR-INTEGRATION-054, BR-INTEGRATION-1489.

--- a/docs/architecture/decisions/DD-FLEET-005-cluster-transparent-tool-exposure.md
+++ b/docs/architecture/decisions/DD-FLEET-005-cluster-transparent-tool-exposure.md
@@ -287,6 +287,16 @@ overlay lacks it. `fetchRemediationHistory()` now threads
 `audit.ClusterIDFromContext(ctx)` (already set by `prescopeFleetOverlay`)
 into `ds.GetRemediationHistory` instead of an unscoped `""`.
 
+**Fix, part 3 (execution-time backstop)**: part 1 only ever controlled what
+`toolDefinitionsForPhase()` *advertises* in the LLM's schema. Nothing stopped
+a call for a suppressed name from still reaching `inv.registry.Execute()`
+and running against the hub if it arrived anyway — schema drift across
+turns, a hallucinated call, or an adversarial prompt. `executeResolved()`
+now runs the same `isFleetSuppressed` check: for a fleet-target
+investigation, a suppressed name with no overlay override is rejected
+(wrapped with the target cluster ID, mirroring the existing not-found
+wrapping) before the local registry is ever consulted.
+
 **Deliberately out of scope**: full RESTMapper-equivalent remote discovery
 for `overlayK8sClient` — `ownerchain.KindToGroup()`'s static table covers
 core/apps/batch kinds only. A resource of an unlisted kind reaching
@@ -298,6 +308,7 @@ common workload kinds an RCA investigation deals with are already covered.
 | Component | Production Entry Point | Wiring Code Location | IT Test ID |
 |---|---|---|---|
 | `fleetSuppressedToolNames` + subtractive filter | `toolDefinitionsForPhase()` | `internal/kubernautagent/investigator/investigator_tools.go` | IT-KA-FLEET-030/031 |
+| `isFleetSuppressed` execution-time check | `executeResolved()` | `internal/kubernautagent/investigator/investigator_tools.go` | IT-KA-FLEET-035 |
 | `pkg/shared/k8s/ownerchain` (moved `K8sOwnerResolver`, `KindResolver` interface) | `cmd/gateway/main.go` (existing), `fleet_resource_context.go` (new) | `pkg/shared/k8s/ownerchain` | Gateway's existing 6-file regression suite + UT-KA-FLEET-031/032 |
 | `overlayClientReader` / `overlayK8sClient` | Constructed per-`Execute()` call in `namespacedResourceContextTool`/`clusterResourceContextTool` | `internal/kubernautagent/tools/custom/fleet_resource_context.go` | UT-KA-FLEET-031/032 |
 | `mcpclient.ParseUnstructuredResponse` / `mcpclient.PopulateObject` (exported) | Called by `overlayClientReader.Get` | `pkg/fleet/mcpclient/parse.go`, `pkg/fleet/mcpclient/client.go` | UT-KA-FLEET-031 (indirect) |

--- a/internal/kubernautagent/investigator/investigator_tools.go
+++ b/internal/kubernautagent/investigator/investigator_tools.go
@@ -30,10 +30,45 @@ import (
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/k8s"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/summarizer"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
+
+// fleetSuppressedToolNames is the set of local, client-go/dynamic-client-
+// backed RCA tools whose behavior depends on which cluster they query.
+// toolDefinitionsForPhase excludes any name in this set from the LLM's
+// tool schema during a fleet-target investigation, unless the fleet
+// overlay supplies a same-named override — closing the AC-6 gap where the
+// LLM could otherwise silently call one of these and query the wrong
+// (hub) cluster (issue #2306). Tools that are inherently fleet-agnostic
+// (DataStorage-backed audit/history, workflow catalog, TodoWrite,
+// Prometheus/Alertmanager federation) are deliberately NOT in this set —
+// see toolDefinitionsForPhase's doc comment.
+var fleetSuppressedToolNames = buildFleetSuppressedToolNames()
+
+func buildFleetSuppressedToolNames() map[string]struct{} {
+	names := make(map[string]struct{}, len(k8s.AllToolNames)+len(k8s.MetricsToolNames)+len(k8s.NodeProxyToolNames))
+	for _, n := range k8s.AllToolNames {
+		names[n] = struct{}{}
+	}
+	for _, n := range k8s.MetricsToolNames {
+		names[n] = struct{}{}
+	}
+	for _, n := range k8s.NodeProxyToolNames {
+		names[n] = struct{}{}
+	}
+	return names
+}
+
+// isFleetSuppressed reports whether name is a hub-bound local tool that must
+// be excluded from the LLM's RCA-phase schema during a fleet-target
+// investigation (see fleetSuppressedToolNames).
+func isFleetSuppressed(name string) bool {
+	_, suppressed := fleetSuppressedToolNames[name]
+	return suppressed
+}
 
 func escalateMaxTokens(completionTokens int) int {
 	if completionTokens > 0 {
@@ -174,17 +209,33 @@ func toolNames(defs []llm.ToolDefinition) []string {
 // WorkflowDiscovery/Validation schemas are intentionally left untouched, to
 // avoid widening the LLM's action surface for phases that have never exposed
 // read tools of any kind (least privilege, AC-6).
+//
+// Issue #2306: the override-and-append halves above still left a third,
+// subtractive gap open — a local tool whose behavior depends on which
+// cluster it queries (fleetSuppressedToolNames: client-go/dynamic-client-
+// backed RCA tools) but has NO same-named overlay override stayed
+// advertised to the LLM even for a fleet-target investigation, so the LLM
+// could silently call it and query the wrong (hub) cluster. During the RCA
+// phase of a fleet-target investigation (non-empty overlay), such a name is
+// now skipped entirely — never appended to defs — rather than offered and
+// left to silently resolve against the wrong cluster. A hub-local
+// investigation (no overlay in ctx) never triggers the skip, so its schema
+// stays byte-identical to before this fix.
 func (inv *Investigator) toolDefinitionsForPhase(ctx context.Context, phase katypes.Phase) []llm.ToolDefinition {
 	var defs []llm.ToolDefinition
 	if inv.registry != nil {
 		phaseTools := inv.registry.ToolsForPhase(phase, inv.phaseTools)
-		overlay, _ := FleetOverlayFromContext(ctx)
+		overlay, hasOverlay := FleetOverlayFromContext(ctx)
 		defs = make([]llm.ToolDefinition, 0, len(phaseTools)+len(overlay)+2)
 		seen := make(map[string]struct{}, len(phaseTools))
 		for _, t := range phaseTools {
 			eff := t
-			if ov, found := resolveTool(overlay, t.Name()); found {
+			ov, overridden := resolveTool(overlay, t.Name())
+			if overridden {
 				eff = ov
+			} else if phase == katypes.PhaseRCA && hasOverlay && isFleetSuppressed(t.Name()) {
+				seen[t.Name()] = struct{}{}
+				continue
 			}
 			defs = append(defs, llm.ToolDefinition{
 				Name:        eff.Name(),

--- a/internal/kubernautagent/investigator/investigator_tools.go
+++ b/internal/kubernautagent/investigator/investigator_tools.go
@@ -322,11 +322,30 @@ func submitResultSchemaForPhase(phase katypes.Phase) json.RawMessage {
 // whether X was never a valid tool name or whether the fleet overlay simply
 // didn't expose it for this cluster (AC-6 — the two failure modes look
 // identical without this context).
+//
+// For a fleet-target investigation, a name in fleetSuppressedToolNames with
+// no overlay override is rejected before ever reaching the local registry
+// (AC-6). toolDefinitionsForPhase already omits these names from the LLM's
+// schema, but that's advertisement only — this is the execution-time
+// backstop, so a suppressed name called anyway (schema drift, hallucination,
+// adversarial input) can't still run against the hub.
 func (inv *Investigator) executeResolved(ctx context.Context, name string, args json.RawMessage) (string, error) {
 	overlay, hasOverlay := FleetOverlayFromContext(ctx)
 	if hasOverlay {
 		if t, found := resolveTool(overlay, name); found {
 			return t.Execute(ctx, args)
+		}
+		// AC-6: toolDefinitionsForPhase already omits this name from the
+		// schema for this exact reason, but a call can still arrive here —
+		// schema drift across turns, a hallucinated call, or an adversarial
+		// prompt. Without this check the call falls through to
+		// inv.registry.Execute() below and runs against the hub, silently
+		// defeating the schema-level suppression. Block it here too so
+		// suppression is enforced at execution time, not just advertisement.
+		if isFleetSuppressed(name) {
+			clusterID, _ := audit.ClusterIDFromContext(ctx)
+			return "", fmt.Errorf("tool %q is suppressed for fleet-target investigations and the overlay for cluster %q provides no override: %w",
+				name, clusterID, &registry.ErrToolNotFound{Name: name})
 		}
 	}
 

--- a/internal/kubernautagent/investigator/investigator_tools_fleet_suppression_test.go
+++ b/internal/kubernautagent/investigator/investigator_tools_fleet_suppression_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// BR-INTEGRATION-1489, DD-FLEET-005, issue #2306: subtractive suppression of
+// hub-bound local K8s tools during fleet-target investigations — pure logic
+// tier (UT). Proves toolDefinitionsForPhase's own decision of which local
+// tools to advertise in isolation, with no LLM or real registry.Execute
+// involved. Wiring into Investigate()/RunInteractiveTurn is proven
+// separately by IT-KA-FLEET-030/031 (fleet_prescoping_test.go).
+var _ = Describe("Fleet-target local K8s tool suppression (BR-INTEGRATION-1489, DD-FLEET-005, #2306)", Label("fleet", "unit"), func() {
+
+	var inv *Investigator
+
+	newTestInvestigator := func() *Investigator {
+		reg := registry.New()
+		reg.Register(&fleetOverlayFakeTool{name: "kubectl_get_by_name"})
+		reg.Register(&fleetOverlayFakeTool{name: "kubectl_logs"})
+		reg.Register(&fleetOverlayFakeTool{name: "kubectl_top_pods"})
+		reg.Register(&fleetOverlayFakeTool{name: "get_namespaced_resource_context"})
+		return New(Config{
+			Logger:     logr.Discard(),
+			PhaseTools: DefaultPhaseToolMap(),
+			Registry:   reg,
+		})
+	}
+
+	BeforeEach(func() {
+		inv = newTestInvestigator()
+	})
+
+	Describe("UT-KA-FLEET-029 [AC-6]: local k8s/metrics/node-proxy tools are excluded for a fleet-target investigation", func() {
+		It("excludes kubectl_get_by_name, kubectl_logs, and kubectl_top_pods from the RCA schema when a fleet overlay is present", func() {
+			overlay := map[string]tools.Tool{
+				// An overlay entry for a name distinct from every suppressed
+				// local tool -- proves suppression is driven by the local
+				// tool's own name being in the suppressed set, not merely by
+				// "an overlay exists at all".
+				"resources_get": &fleetOverlayFakeTool{name: "resources_get"},
+			}
+			ctx := WithFleetOverlay(context.Background(), overlay)
+
+			defs := inv.toolDefinitionsForPhase(ctx, katypes.PhaseRCA)
+
+			names := toolNames(defs)
+			Expect(names).NotTo(ContainElement("kubectl_get_by_name"),
+				"UT-KA-FLEET-029: a hub-bound local k8s tool must not be advertised to the LLM "+
+					"during a fleet-target investigation unless the overlay provides a same-named override (AC-6)")
+			Expect(names).NotTo(ContainElement("kubectl_logs"))
+			Expect(names).NotTo(ContainElement("kubectl_top_pods"))
+		})
+
+		It("does not suppress a fleet-agnostic tool like get_namespaced_resource_context", func() {
+			overlay := map[string]tools.Tool{
+				"resources_get": &fleetOverlayFakeTool{name: "resources_get"},
+			}
+			ctx := WithFleetOverlay(context.Background(), overlay)
+
+			defs := inv.toolDefinitionsForPhase(ctx, katypes.PhaseRCA)
+
+			Expect(toolNames(defs)).To(ContainElement("get_namespaced_resource_context"),
+				"UT-KA-FLEET-029: a DataStorage-backed, fleet-agnostic tool must remain visible "+
+					"regardless of fleet targeting -- suppression is scoped to client-go/dynamic-client-backed "+
+					"RCA tools only")
+		})
+
+		It("does not suppress a local tool that the overlay overrides by exact name", func() {
+			overlayTool := &fleetOverlayFakeTool{name: "kubectl_get_by_name"}
+			overlay := map[string]tools.Tool{
+				"kubectl_get_by_name": overlayTool,
+			}
+			ctx := WithFleetOverlay(context.Background(), overlay)
+
+			defs := inv.toolDefinitionsForPhase(ctx, katypes.PhaseRCA)
+
+			Expect(toolNames(defs)).To(ContainElement("kubectl_get_by_name"),
+				"UT-KA-FLEET-029: a suppressed local tool name must still be advertised when the "+
+					"fleet overlay itself supplies a same-named override -- suppression must never hide "+
+					"a name the overlay explicitly re-exposes")
+		})
+	})
+
+	Describe("UT-KA-FLEET-030 [zero regression]: hub-local investigations are unaffected by the suppression set", func() {
+		It("includes every local k8s tool in the RCA schema when no fleet overlay is present", func() {
+			defs := inv.toolDefinitionsForPhase(context.Background(), katypes.PhaseRCA)
+
+			names := toolNames(defs)
+			Expect(names).To(ContainElement("kubectl_get_by_name"),
+				"UT-KA-FLEET-030: a hub-local investigation (no overlay in ctx) must see the "+
+					"full local tool set unchanged -- suppression must be a strict no-op absent a fleet overlay")
+			Expect(names).To(ContainElement("kubectl_logs"))
+			Expect(names).To(ContainElement("kubectl_top_pods"))
+			Expect(names).To(ContainElement("get_namespaced_resource_context"))
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/investigator_tools_fleet_suppression_test.go
+++ b/internal/kubernautagent/investigator/investigator_tools_fleet_suppression_test.go
@@ -119,4 +119,51 @@ var _ = Describe("Fleet-target local K8s tool suppression (BR-INTEGRATION-1489, 
 			Expect(names).To(ContainElement("get_namespaced_resource_context"))
 		})
 	})
+
+	// Issue #2306 follow-up: toolDefinitionsForPhase only ever controlled
+	// what's *advertised* to the LLM. executeResolved -- the actual execution
+	// path a tool call goes through -- never consulted isFleetSuppressed at
+	// all, so a suppressed name called anyway (schema drift across turns,
+	// hallucination, adversarial input) fell straight through to
+	// inv.registry.Execute() and ran against the hub -- the exact AC-6
+	// violation the schema-level fix was supposed to close, one layer
+	// deeper. These specs prove execution itself is now blocked, not just
+	// advertisement. Wiring into Investigate()/RunInteractiveTurn is proven
+	// separately by IT-KA-FLEET-035 (fleet_prescoping_test.go).
+	Describe("UT-KA-FLEET-035 [AC-6]: executeResolved blocks a suppressed local tool even when called by name", func() {
+		It("rejects kubectl_get_by_name for a fleet-target investigation with no overlay override, never reaching the hub-bound tool", func() {
+			overlay := map[string]tools.Tool{
+				"resources_get": &fleetOverlayFakeTool{name: "resources_get"},
+			}
+			ctx := WithFleetOverlay(context.Background(), overlay)
+
+			result, err := inv.executeResolved(ctx, "kubectl_get_by_name", nil)
+			Expect(err).To(HaveOccurred(),
+				"UT-KA-FLEET-035: a suppressed local tool called by name during a fleet-target "+
+					"investigation must be rejected, not silently executed against the hub (AC-6)")
+			Expect(err.Error()).To(ContainSubstring("kubectl_get_by_name"))
+			Expect(err.Error()).To(ContainSubstring("suppressed"))
+			Expect(result).To(BeEmpty())
+		})
+
+		It("still executes the overlay's override when the overlay provides one for a suppressed name", func() {
+			overlayTool := &fleetOverlayFakeTool{name: "kubectl_get_by_name"}
+			overlay := map[string]tools.Tool{"kubectl_get_by_name": overlayTool}
+			ctx := WithFleetOverlay(context.Background(), overlay)
+
+			result, err := inv.executeResolved(ctx, "kubectl_get_by_name", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("fake-result:kubectl_get_by_name"),
+				"UT-KA-FLEET-035: an overlay-provided override must still execute -- blocking is scoped "+
+					"to names with NO override, not to every suppressed name unconditionally")
+		})
+
+		It("still executes kubectl_get_by_name for a hub-local investigation (zero regression)", func() {
+			result, err := inv.executeResolved(context.Background(), "kubectl_get_by_name", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("fake-result:kubectl_get_by_name"),
+				"UT-KA-FLEET-035: a hub-local investigation (no overlay in ctx) must still execute local "+
+					"tools unchanged -- the execution-time block is scoped to fleet-target investigations only")
+		})
+	})
 })

--- a/internal/kubernautagent/tools/custom/fleet_resource_context.go
+++ b/internal/kubernautagent/tools/custom/fleet_resource_context.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package custom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
+	"github.com/jordigilh/kubernaut/pkg/shared/hash"
+	"github.com/jordigilh/kubernaut/pkg/shared/k8s/ownerchain"
+)
+
+// overlayClientReader adapts the fleet overlay's resources_get tools.Tool
+// (DD-FLEET-005) to a controller-runtime client.Reader, so
+// ownerchain.K8sOwnerResolver — built to walk owner chains via any
+// client.Reader — can resolve against a fleet-target cluster the same way it
+// already does for Gateway's dedup path (issue #2306).
+//
+// Get() requires the caller to have already stamped the target GVK onto obj
+// (every internal caller in this file does, via SetGroupVersionKind, and
+// ownerchain.K8sOwnerResolver always does the same before each Get):
+// resources_get requires an explicit apiVersion parameter — there is no
+// server-side kind-only discovery to infer it from (confirmed against
+// upstream kubernetes-mcp-server, see plan preflight).
+type overlayClientReader struct {
+	getTool tools.Tool
+}
+
+var _ client.Reader = (*overlayClientReader)(nil)
+
+// NewOverlayClientReader builds a client.Reader backed by the fleet
+// overlay's resources_get tool. Exported for the fleet_resource_context_test.go
+// unit tests; production callers should go through NewOverlayK8sClient.
+func NewOverlayClientReader(getTool tools.Tool) client.Reader {
+	return &overlayClientReader{getTool: getTool}
+}
+
+func (r *overlayClientReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk.Kind == "" {
+		return fmt.Errorf("overlayClientReader.Get: target object has no GroupVersionKind set")
+	}
+
+	args := map[string]any{
+		"kind":       gvk.Kind,
+		"apiVersion": gvk.GroupVersion().String(),
+		"name":       key.Name,
+	}
+	if key.Namespace != "" {
+		args["namespace"] = key.Namespace
+	}
+	argsJSON, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("overlayClientReader.Get: marshal args for %s/%s: %w", gvk.Kind, key.Name, err)
+	}
+
+	text, err := r.getTool.Execute(ctx, argsJSON)
+	if err != nil {
+		return fmt.Errorf("overlayClientReader.Get: %s/%s in %q: %w", gvk.Kind, key.Name, key.Namespace, err)
+	}
+	fetched, err := mcpclient.ParseUnstructuredResponse(text)
+	if err != nil {
+		return fmt.Errorf("overlayClientReader.Get: parse response for %s/%s: %w", gvk.Kind, key.Name, err)
+	}
+	return mcpclient.PopulateObject(fetched, obj)
+}
+
+// List is intentionally not supported: overlayClientReader only backs
+// ownerchain.K8sOwnerResolver's remote-cluster resolution here, which only
+// ever calls Get directly. The resolver's one internal List call (the
+// optional Service→Pod special case) is gated on WithFallbackReader, which
+// NewOverlayK8sClient deliberately never sets — KA has no local fallback
+// reader for a remote cluster — so this path is unreachable in practice,
+// not silently degraded.
+func (r *overlayClientReader) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return fmt.Errorf("overlayClientReader: List not supported (owner-chain resolution only requires Get)")
+}
+
+// overlayK8sClient implements enrichment.K8sClient by resolving owner-chain
+// and spec-hash queries against a fleet-target cluster via the overlay's
+// resources_get tool, reusing Gateway's own proven K8sOwnerResolver algorithm
+// (pkg/shared/k8s/ownerchain, moved from pkg/gateway/adapters — issue #2306)
+// instead of re-authoring a walk loop against a second client type.
+type overlayK8sClient struct {
+	reader client.Reader
+	logger logr.Logger
+}
+
+var _ enrichment.K8sClient = (*overlayK8sClient)(nil)
+
+// NewOverlayK8sClient builds an enrichment.K8sClient wrapping getTool (the
+// fleet overlay's resources_get tool — see cmd/kubernautagent/toolregistry.go's
+// genericNameTool). No WithRegistry/WithFallbackReader: KA has neither a
+// live APIResourceRegistry nor a local fallback client for a remote cluster.
+func NewOverlayK8sClient(getTool tools.Tool, logger logr.Logger) enrichment.K8sClient {
+	return &overlayK8sClient{reader: NewOverlayClientReader(getTool), logger: logger}
+}
+
+// GetOwnerChain resolves the top-level controller owner of kind/name/namespace
+// against the target cluster and wraps it as a single-entry chain. Both
+// resourceContextTools callers only ever read chain[len(chain)-1] (the root
+// entry), never intermediate hops, so ownerchain.K8sOwnerResolver's
+// "top owner only" contract is a precise fit here, not a lossy simplification.
+func (c *overlayK8sClient) GetOwnerChain(ctx context.Context, kind, name, namespace, _ string) ([]enrichment.OwnerChainEntry, error) {
+	resolver := ownerchain.NewK8sOwnerResolver(c.reader, c.logger)
+	ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, kind, name)
+	if err != nil {
+		return nil, err
+	}
+	return []enrichment.OwnerChainEntry{{Kind: ownerKind, Name: ownerName, Namespace: namespace}}, nil
+}
+
+// GetSpecHash resolves apiVersion for kind via the moved ownerchain.KindToGroup
+// table (the same lookup GetOwnerChain's resolver uses internally when no
+// registry is configured), fetches the resource via the shared
+// overlayClientReader, then reuses the exact hash.CanonicalResourceFingerprint
+// function K8sAdapter.GetSpecHash already calls for the hub-local path —
+// keeping hash values comparable between hub-local and fleet-target
+// investigations.
+func (c *overlayK8sClient) GetSpecHash(ctx context.Context, kind, name, namespace, apiVersion string) (string, error) {
+	if apiVersion == "" {
+		group, known := ownerchain.KindToGroup()[kind]
+		if !known {
+			return "", fmt.Errorf("overlayK8sClient.GetSpecHash: unknown kind %q for fleet-target resolution "+
+				"(not in core/apps/batch and no apiVersion given)", kind)
+		}
+		apiVersion = schema.GroupVersion{Group: group, Version: "v1"}.String()
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.FromAPIVersionAndKind(apiVersion, kind))
+	if err := c.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
+		return "", fmt.Errorf("overlayK8sClient.GetSpecHash: get %s/%s in %q: %w", kind, name, namespace, err)
+	}
+
+	h, err := hash.CanonicalResourceFingerprint(obj.Object)
+	if err != nil {
+		return "", fmt.Errorf("overlayK8sClient.GetSpecHash: compute fingerprint for %s/%s in %q: %w", kind, name, namespace, err)
+	}
+	return h, nil
+}
+
+// noopK8sClient always returns a clear "not available" error for both
+// enrichment.K8sClient methods. Selected only when a fleet-target
+// investigation's overlay does not publish resources_get (e.g. a toolset
+// misconfiguration) — distinct from silently degrading to hub-bound
+// resolution or an empty result, so the underlying cause stays diagnosable.
+type noopK8sClient struct {
+	clusterID string
+}
+
+var _ enrichment.K8sClient = noopK8sClient{}
+
+func (n noopK8sClient) GetOwnerChain(_ context.Context, _, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
+	return nil, fmt.Errorf("owner-chain resolution not available for cluster %q: fleet overlay does not publish resources_get", n.clusterID)
+}
+
+func (n noopK8sClient) GetSpecHash(_ context.Context, _, _, _, _ string) (string, error) {
+	return "", fmt.Errorf("spec-hash resolution not available for cluster %q: fleet overlay does not publish resources_get", n.clusterID)
+}

--- a/internal/kubernautagent/tools/custom/fleet_resource_context_test.go
+++ b/internal/kubernautagent/tools/custom/fleet_resource_context_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package custom_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/tools/custom"
+)
+
+// fakeGetTool is a tools.Tool double standing in for the fleet overlay's
+// resources_get tool (DD-FLEET-005). It captures the args it was called
+// with and returns either canned JSON text or an error.
+type fakeGetTool struct {
+	responseJSON string
+	err          error
+
+	capturedArgs map[string]any
+	calls        int
+}
+
+func (f *fakeGetTool) Name() string                { return "resources_get" }
+func (f *fakeGetTool) Description() string         { return "fake resources_get" }
+func (f *fakeGetTool) Parameters() json.RawMessage { return json.RawMessage(`{}`) }
+func (f *fakeGetTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	f.calls++
+	var m map[string]any
+	_ = json.Unmarshal(args, &m)
+	f.capturedArgs = m
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.responseJSON, nil
+}
+
+// UT-KA-FLEET-031: overlayClientReader.Get bridges client.Reader.Get to the
+// fleet overlay's resources_get tools.Tool.Execute and populates the target
+// object via mcpclient.PopulateObject — issue #2306.
+var _ = Describe("UT-KA-FLEET-031: overlayClientReader (BR-INTEGRATION-1489)", func() {
+	It("sends kind/apiVersion/name/namespace args derived from the target GVK and populates the object", func() {
+		getTool := &fakeGetTool{
+			responseJSON: `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"api-server","namespace":"production","uid":"deploy-uid-1"}}`,
+		}
+		reader := custom.NewOverlayClientReader(getTool)
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+
+		err := reader.Get(context.Background(), client.ObjectKey{Namespace: "production", Name: "api-server"}, obj)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(getTool.calls).To(Equal(1))
+		Expect(getTool.capturedArgs["kind"]).To(Equal("Deployment"))
+		Expect(getTool.capturedArgs["apiVersion"]).To(Equal("apps/v1"))
+		Expect(getTool.capturedArgs["name"]).To(Equal("api-server"))
+		Expect(getTool.capturedArgs["namespace"]).To(Equal("production"))
+
+		Expect(obj.GetName()).To(Equal("api-server"))
+		Expect(obj.GetUID()).To(BeEquivalentTo("deploy-uid-1"))
+	})
+
+	It("omits the namespace arg for a cluster-scoped Get", func() {
+		getTool := &fakeGetTool{responseJSON: `{"apiVersion":"v1","kind":"Node","metadata":{"name":"worker-1"}}`}
+		reader := custom.NewOverlayClientReader(getTool)
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Node"})
+
+		err := reader.Get(context.Background(), client.ObjectKey{Name: "worker-1"}, obj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(getTool.capturedArgs).NotTo(HaveKey("namespace"))
+	})
+
+	It("returns a clear error when the target object has no GVK set", func() {
+		getTool := &fakeGetTool{}
+		reader := custom.NewOverlayClientReader(getTool)
+
+		obj := &unstructured.Unstructured{}
+		err := reader.Get(context.Background(), client.ObjectKey{Name: "x"}, obj)
+		Expect(err).To(HaveOccurred())
+		Expect(getTool.calls).To(Equal(0))
+	})
+
+	It("propagates the underlying tool's Execute error", func() {
+		getTool := &fakeGetTool{err: fmt.Errorf("remote tool call failed")}
+		reader := custom.NewOverlayClientReader(getTool)
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Pod"})
+		err := reader.Get(context.Background(), client.ObjectKey{Name: "p"}, obj)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("remote tool call failed"))
+	})
+
+	It("returns a clear not-supported error for List", func() {
+		reader := custom.NewOverlayClientReader(&fakeGetTool{})
+		err := reader.List(context.Background(), &unstructured.UnstructuredList{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not supported"))
+	})
+})
+
+// UT-KA-FLEET-032: overlayK8sClient wraps the moved ownerchain.K8sOwnerResolver
+// for GetOwnerChain, and ownerchain.KindToGroup() for GetSpecHash's apiVersion
+// resolution — issue #2306.
+var _ = Describe("UT-KA-FLEET-032: overlayK8sClient (BR-INTEGRATION-1489)", func() {
+	Describe("GetOwnerChain", func() {
+		It("wraps ResolveTopLevelOwner's result into a single-entry chain", func() {
+			getTool := &fakeGetTool{
+				responseJSON: `{"apiVersion":"apps/v1","kind":"ReplicaSet","metadata":{"name":"api-server-abc","namespace":"production",` +
+					`"ownerReferences":[{"apiVersion":"apps/v1","kind":"Deployment","name":"api-server","uid":"deploy-uid-1","controller":true}]}}`,
+			}
+			c := custom.NewOverlayK8sClient(getTool, logr.Discard())
+
+			chain, err := c.GetOwnerChain(context.Background(), "ReplicaSet", "api-server-abc", "production", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chain).To(HaveLen(1))
+			Expect(chain[0].Kind).To(Equal("Deployment"))
+			Expect(chain[0].Name).To(Equal("api-server"))
+		})
+
+		It("returns the resource itself when it has no controller owner", func() {
+			getTool := &fakeGetTool{
+				responseJSON: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"standalone-pod","namespace":"default"}}`,
+			}
+			c := custom.NewOverlayK8sClient(getTool, logr.Discard())
+
+			chain, err := c.GetOwnerChain(context.Background(), "Pod", "standalone-pod", "default", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chain).To(HaveLen(1))
+			Expect(chain[0].Kind).To(Equal("Pod"))
+			Expect(chain[0].Name).To(Equal("standalone-pod"))
+		})
+	})
+
+	Describe("GetSpecHash", func() {
+		It("resolves apiVersion via ownerchain.KindToGroup for a known kind and computes a hash", func() {
+			getTool := &fakeGetTool{
+				responseJSON: `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"api-server","namespace":"production"},"spec":{"replicas":3}}`,
+			}
+			c := custom.NewOverlayK8sClient(getTool, logr.Discard())
+
+			h, err := c.GetSpecHash(context.Background(), "Deployment", "api-server", "production", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(h).NotTo(BeEmpty())
+			Expect(getTool.capturedArgs["apiVersion"]).To(Equal("apps/v1"))
+		})
+
+		It("returns a clear error for an unknown kind with no apiVersion given", func() {
+			c := custom.NewOverlayK8sClient(&fakeGetTool{}, logr.Discard())
+
+			_, err := c.GetSpecHash(context.Background(), "CustomResource", "my-cr", "test", "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("CustomResource"))
+		})
+	})
+})

--- a/internal/kubernautagent/tools/custom/resource_context.go
+++ b/internal/kubernautagent/tools/custom/resource_context.go
@@ -23,7 +23,10 @@ import (
 
 	"github.com/go-logr/logr"
 
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
 )
 
@@ -62,6 +65,28 @@ type clusterResponse struct {
 	RemediationHistory *enrichment.RemediationHistoryResult `json:"remediation_history"`
 }
 
+// resolveK8sClient picks the effective enrichment.K8sClient for one Execute
+// call (issue #2306): the hub-bound client for a hub-local investigation (no
+// fleet overlay in ctx) — zero regression, byte-identical to before this fix
+// — a new overlay-backed K8sClient wrapping the fleet overlay's resources_get
+// tool for a fleet-target investigation whose overlay publishes it, or a
+// clear-error no-op K8sClient for a fleet-target investigation whose overlay
+// lacks resources_get (e.g. a toolset misconfiguration). The no-op case
+// deliberately does NOT fall back to hub, which would silently resolve
+// owner-chain/spec-hash against the wrong cluster — the exact AC-6 defect
+// this issue closes for the k8s-tool suppression half.
+func resolveK8sClient(ctx context.Context, hub enrichment.K8sClient, logger logr.Logger) enrichment.K8sClient {
+	overlay, hasOverlay := investigator.FleetOverlayFromContext(ctx)
+	if !hasOverlay {
+		return hub
+	}
+	if getTool, ok := overlay[mcpclient.ToolGet]; ok {
+		return NewOverlayK8sClient(getTool, logger)
+	}
+	clusterID, _ := audit.ClusterIDFromContext(ctx)
+	return noopK8sClient{clusterID: clusterID}
+}
+
 func computeSpecHash(ctx context.Context, logger logr.Logger, k8s enrichment.K8sClient, kind, name, namespace, toolName string) string {
 	computed, err := k8s.GetSpecHash(ctx, kind, name, namespace, "")
 	if err != nil {
@@ -79,16 +104,13 @@ type remediationHistoryQuery struct {
 	Kind      string
 	Name      string
 	Namespace string
+	ClusterID string
 	SpecHash  string
 	ToolName  string
 }
 
 func fetchRemediationHistory(ctx context.Context, logger logr.Logger, ds enrichment.DataStorageClient, q remediationHistoryQuery) *enrichment.RemediationHistoryResult {
-	// Issue #1802: these MCP tools parse args directly from the incoming JSON-RPC
-	// call with no fleet SignalContext available (unlike Investigate's path), so
-	// the query stays unscoped ("") here -- matching this path's pre-existing
-	// behavior, not a regression.
-	result, err := ds.GetRemediationHistory(ctx, q.Kind, q.Name, q.Namespace, "", q.SpecHash)
+	result, err := ds.GetRemediationHistory(ctx, q.Kind, q.Name, q.Namespace, q.ClusterID, q.SpecHash)
 	if err != nil {
 		logger.Info(q.ToolName+": remediation history fetch failed",
 			"kind", q.Kind, "name", q.Name, "namespace", q.Namespace, "error", err)
@@ -130,7 +152,9 @@ func (t *namespacedResourceContextTool) Execute(ctx context.Context, args json.R
 		return "", fmt.Errorf("parsing args: %w", err)
 	}
 
-	chain, chainErr := t.k8s.GetOwnerChain(ctx, params.Kind, params.Name, params.Namespace, "")
+	k8sClient := resolveK8sClient(ctx, t.k8s, t.logger)
+
+	chain, chainErr := k8sClient.GetOwnerChain(ctx, params.Kind, params.Name, params.Namespace, "")
 	if chainErr != nil {
 		t.logger.Info("get_namespaced_resource_context: owner chain resolution failed",
 			"kind", params.Kind, "name", params.Name, "namespace", params.Namespace, "error", chainErr)
@@ -150,10 +174,11 @@ func (t *namespacedResourceContextTool) Execute(ctx context.Context, args json.R
 		}
 	}
 
-	specHash := computeSpecHash(ctx, t.logger, t.k8s, rootOwner.Kind, rootOwner.Name, rootOwner.Namespace, "get_namespaced_resource_context")
+	specHash := computeSpecHash(ctx, t.logger, k8sClient, rootOwner.Kind, rootOwner.Name, rootOwner.Namespace, "get_namespaced_resource_context")
+	clusterID, _ := audit.ClusterIDFromContext(ctx)
 	histResult := fetchRemediationHistory(ctx, t.logger, t.ds, remediationHistoryQuery{
 		Kind: rootOwner.Kind, Name: rootOwner.Name, Namespace: rootOwner.Namespace,
-		SpecHash: specHash, ToolName: "get_namespaced_resource_context",
+		ClusterID: clusterID, SpecHash: specHash, ToolName: "get_namespaced_resource_context",
 	})
 
 	resp := namespacedResponse{
@@ -197,9 +222,12 @@ func (t *clusterResourceContextTool) Execute(ctx context.Context, args json.RawM
 		return "", fmt.Errorf("parsing args: %w", err)
 	}
 
-	specHash := computeSpecHash(ctx, t.logger, t.k8s, params.Kind, params.Name, "", "get_cluster_resource_context")
+	k8sClient := resolveK8sClient(ctx, t.k8s, t.logger)
+
+	specHash := computeSpecHash(ctx, t.logger, k8sClient, params.Kind, params.Name, "", "get_cluster_resource_context")
+	clusterID, _ := audit.ClusterIDFromContext(ctx)
 	histResult := fetchRemediationHistory(ctx, t.logger, t.ds, remediationHistoryQuery{
-		Kind: params.Kind, Name: params.Name, SpecHash: specHash,
+		Kind: params.Kind, Name: params.Name, ClusterID: clusterID, SpecHash: specHash,
 		ToolName: "get_cluster_resource_context",
 	})
 

--- a/internal/kubernautagent/tools/custom/resource_context_test.go
+++ b/internal/kubernautagent/tools/custom/resource_context_test.go
@@ -25,11 +25,17 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/tools/custom"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
 )
 
-// fakeK8s returns a configurable owner chain and spec hash.
+// fakeK8s returns a configurable owner chain and spec hash. ownerChainCalls/
+// specHashCalls (issue #2306, UT-KA-FLEET-033) let tests prove whether this
+// hub-bound double was invoked at all -- distinguishing "hub client selected"
+// from "overlay/no-op client selected" for a given investigation context.
 type fakeK8s struct {
 	chain       []enrichment.OwnerChainEntry
 	err         error
@@ -39,29 +45,37 @@ type fakeK8s struct {
 	capturedSpecHashKind      string
 	capturedSpecHashName      string
 	capturedSpecHashNamespace string
+
+	ownerChainCalls int
+	specHashCalls   int
 }
 
 func (f *fakeK8s) GetOwnerChain(_ context.Context, _, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
+	f.ownerChainCalls++
 	return f.chain, f.err
 }
 
 func (f *fakeK8s) GetSpecHash(_ context.Context, kind, name, namespace, _ string) (string, error) {
+	f.specHashCalls++
 	f.capturedSpecHashKind = kind
 	f.capturedSpecHashName = name
 	f.capturedSpecHashNamespace = namespace
 	return f.specHash, f.specHashErr
 }
 
-// fakeDS returns configurable remediation history and captures the specHash argument.
+// fakeDS returns configurable remediation history and captures the specHash/
+// clusterID arguments (clusterID added for UT-KA-FLEET-034, issue #2306).
 type fakeDS struct {
 	history *enrichment.RemediationHistoryResult
 	err     error
 
-	capturedSpecHash string
+	capturedSpecHash  string
+	capturedClusterID string
 }
 
-func (f *fakeDS) GetRemediationHistory(_ context.Context, _, _, _, _, specHash string) (*enrichment.RemediationHistoryResult, error) {
+func (f *fakeDS) GetRemediationHistory(_ context.Context, _, _, _, clusterID, specHash string) (*enrichment.RemediationHistoryResult, error) {
 	f.capturedSpecHash = specHash
+	f.capturedClusterID = clusterID
 	return f.history, f.err
 }
 
@@ -358,6 +372,96 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeEmpty())
 			Expect(ds.capturedSpecHash).To(Equal(""))
+		})
+	})
+
+	// --- Issue #2306: fleet-target K8sClient selection ---
+
+	Describe("UT-KA-FLEET-033: resourceContextTools select the correct K8sClient per investigation type — BR-INTEGRATION-1489", func() {
+		It("uses the hub-bound K8sClient for a hub-local investigation (no fleet overlay in ctx) — zero regression", func() {
+			k8s := &fakeK8s{chain: []enrichment.OwnerChainEntry{{Kind: "Deployment", Name: "api-server", Namespace: "prod"}}}
+			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
+
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
+			_, err := tool.Execute(context.Background(),
+				json.RawMessage(`{"kind":"Pod","name":"api-server-abc-xyz","namespace":"prod"}`))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8s.ownerChainCalls).To(Equal(1), "hub-bound K8sClient must be used when ctx carries no fleet overlay")
+			Expect(k8s.specHashCalls).To(Equal(1))
+		})
+
+		It("uses the overlay K8sClient (not the hub-bound one) when ctx carries a fleet overlay publishing resources_get", func() {
+			k8s := &fakeK8s{chain: []enrichment.OwnerChainEntry{{Kind: "Deployment", Name: "hub-should-not-be-called"}}}
+			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
+			getTool := &fakeGetTool{
+				responseJSON: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"standalone-pod","namespace":"prod"}}`,
+			}
+
+			ctx := investigator.WithFleetOverlay(context.Background(), map[string]tools.Tool{"resources_get": getTool})
+
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
+			result, err := tool.Execute(ctx,
+				json.RawMessage(`{"kind":"Pod","name":"standalone-pod","namespace":"prod"}`))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8s.ownerChainCalls).To(Equal(0), "hub-bound K8sClient must NOT be used for a fleet-target investigation")
+			Expect(k8s.specHashCalls).To(Equal(0))
+			Expect(getTool.calls).To(BeNumerically(">=", 1), "the overlay's resources_get tool must be invoked instead")
+
+			var resp map[string]interface{}
+			Expect(json.Unmarshal([]byte(result), &resp)).To(Succeed())
+			rootOwner := resp["root_owner"].(map[string]interface{})
+			Expect(rootOwner["name"]).To(Equal("standalone-pod"))
+		})
+
+		It("degrades to a clear 'not available' error (not the hub) when the fleet overlay lacks resources_get", func() {
+			k8s := &fakeK8s{chain: []enrichment.OwnerChainEntry{{Kind: "Deployment", Name: "hub-should-not-be-called"}}}
+			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
+
+			// Overlay is non-empty (has some other tool) but does not publish resources_get.
+			ctx := investigator.WithFleetOverlay(context.Background(), map[string]tools.Tool{"kubectl_list": &fakeGetTool{}})
+
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
+			result, err := tool.Execute(ctx,
+				json.RawMessage(`{"kind":"Pod","name":"orphan-pod","namespace":"prod"}`))
+			Expect(err).NotTo(HaveOccurred(), "the tool call itself must not fail -- owner-chain/spec-hash degrade gracefully")
+
+			Expect(k8s.ownerChainCalls).To(Equal(0), "hub-bound K8sClient must NOT be used as a silent fallback for a fleet-target investigation")
+			Expect(k8s.specHashCalls).To(Equal(0))
+
+			var resp map[string]interface{}
+			Expect(json.Unmarshal([]byte(result), &resp)).To(Succeed())
+			rootOwner := resp["root_owner"].(map[string]interface{})
+			Expect(rootOwner["name"]).To(Equal("orphan-pod"), "falls back to the input resource, matching existing GetOwnerChain-error behavior")
+		})
+	})
+
+	Describe("UT-KA-FLEET-034: fetchRemediationHistory threads the target clusterID — BR-INTEGRATION-1489", func() {
+		It("passes audit.ClusterIDFromContext(ctx) to ds.GetRemediationHistory for a fleet-target investigation", func() {
+			k8s := &fakeK8s{chain: []enrichment.OwnerChainEntry{{Kind: "Deployment", Name: "api-server", Namespace: "prod"}}}
+			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
+
+			ctx := audit.WithClusterID(context.Background(), "spoke-east-1")
+
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
+			_, err := tool.Execute(ctx,
+				json.RawMessage(`{"kind":"Pod","name":"api-server-abc-xyz","namespace":"prod"}`))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ds.capturedClusterID).To(Equal("spoke-east-1"))
+		})
+
+		It("passes an empty clusterID for a hub-local investigation — zero regression", func() {
+			k8s := &fakeK8s{chain: nil}
+			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
+
+			tool := custom.NewClusterResourceContextTool(ds, k8s, logr.Discard())
+			_, err := tool.Execute(context.Background(),
+				json.RawMessage(`{"kind":"Node","name":"worker-1"}`))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ds.capturedClusterID).To(Equal(""))
 		})
 	})
 })

--- a/pkg/fleet/mcpclient/client.go
+++ b/pkg/fleet/mcpclient/client.go
@@ -185,7 +185,7 @@ func (c *Client) Get(ctx context.Context, key client.ObjectKey, obj client.Objec
 		return err
 	}
 
-	return populateObject(fetched, obj)
+	return PopulateObject(fetched, obj)
 }
 
 // List implements client.Reader. It retrieves Kubernetes resources of a given
@@ -350,7 +350,7 @@ func (c *Client) getResource(ctx context.Context, kind, apiVersion, namespace, n
 	}
 
 	text := ExtractText(result)
-	obj, err := parseUnstructured(text)
+	obj, err := ParseUnstructuredResponse(text)
 	if err != nil {
 		return nil, fmt.Errorf("parse Get response for %s/%s: %w", kind, name, err)
 	}
@@ -393,11 +393,12 @@ func (c *Client) listResources(ctx context.Context, kind, apiVersion, namespace 
 	return normalizeTableItems(sc, kind, apiVersion), nil
 }
 
-// populateObject copies data from a fetched unstructured object into the target
+// PopulateObject copies data from a fetched unstructured object into the target
 // client.Object. Handles *unstructured.Unstructured directly, all other types
 // (including *metav1.PartialObjectMetadata and typed objects like *corev1.Pod)
-// via JSON round-trip.
-func populateObject(fetched *unstructured.Unstructured, target client.Object) error {
+// via JSON round-trip. Exported (renamed from populateObject, issue #2306) so
+// KA's overlayClientReader can reuse this already-proven population path.
+func PopulateObject(fetched *unstructured.Unstructured, target client.Object) error {
 	if t, ok := target.(*unstructured.Unstructured); ok {
 		t.Object = fetched.Object
 		return nil

--- a/pkg/fleet/mcpclient/parse.go
+++ b/pkg/fleet/mcpclient/parse.go
@@ -24,7 +24,11 @@ import (
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
-func parseUnstructured(text string) (*unstructured.Unstructured, error) {
+// ParseUnstructuredResponse parses a kube-mcp-server tool response (JSON or
+// YAML text) into an unstructured.Unstructured object. Exported (renamed from
+// parseUnstructured, issue #2306) so KA's overlayClientReader can reuse this
+// already-proven parsing path instead of reimplementing it.
+func ParseUnstructuredResponse(text string) (*unstructured.Unstructured, error) {
 	if text == "" {
 		return nil, fmt.Errorf("empty response")
 	}

--- a/pkg/fleet/mcpclient/parse_internal_test.go
+++ b/pkg/fleet/mcpclient/parse_internal_test.go
@@ -28,14 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// UT-FLEET-MCP-PARSE: parseUnstructured / populateObject
+// UT-FLEET-MCP-PARSE: ParseUnstructuredResponse / PopulateObject
 // Authority: BR-FLEET-002 (MCP Gateway client), ADR-068
 // FedRAMP: SI-10 (Information Input Validation) -- response parsing correctness
 var _ = Describe("UT-FLEET-MCP-PARSE: MCP response parsing", func() {
 
-	Describe("parseUnstructured", func() {
+	Describe("ParseUnstructuredResponse", func() {
 		It("UT-FLEET-MCP-PARSE-001: parses valid JSON into Unstructured", func() {
-			obj, err := parseUnstructured(`{"kind":"Pod","metadata":{"name":"nginx","namespace":"default"}}`)
+			obj, err := ParseUnstructuredResponse(`{"kind":"Pod","metadata":{"name":"nginx","namespace":"default"}}`)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj.GetKind()).To(Equal("Pod"))
 			Expect(obj.GetName()).To(Equal("nginx"))
@@ -43,20 +43,20 @@ var _ = Describe("UT-FLEET-MCP-PARSE: MCP response parsing", func() {
 		})
 
 		It("UT-FLEET-MCP-PARSE-002: returns error for empty string", func() {
-			_, err := parseUnstructured("")
+			_, err := ParseUnstructuredResponse("")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("empty response"))
 		})
 
 		It("UT-FLEET-MCP-PARSE-003: returns error for unparseable content", func() {
-			_, err := parseUnstructured("\x00\x01binary-garbage\x02\x03")
+			_, err := ParseUnstructuredResponse("\x00\x01binary-garbage\x02\x03")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("unmarshaling resource"))
 		})
 
 		It("UT-FLEET-MCP-PARSE-003b: parses YAML resource response", func() {
 			yamlText := "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: nginx\n  namespace: default\n"
-			obj, err := parseUnstructured(yamlText)
+			obj, err := ParseUnstructuredResponse(yamlText)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj).ToNot(BeNil())
 			Expect(obj.GetKind()).To(Equal("Deployment"))

--- a/pkg/fleet/mcpclient/parse_test.go
+++ b/pkg/fleet/mcpclient/parse_test.go
@@ -26,9 +26,9 @@ import (
 
 var _ = Describe("MCP Response Parsing (BR-INTEGRATION-054)", func() {
 	Describe("UT-FLEET-PARSE-001 [SI-10]: MCP response parser handles all K8s MCP Server response formats", func() {
-		Context("parseUnstructured", func() {
+		Context("ParseUnstructuredResponse", func() {
 			It("returns error for empty text", func() {
-				obj, err := parseUnstructured("")
+				obj, err := ParseUnstructuredResponse("")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("empty response"))
 				Expect(obj).To(BeNil())
@@ -36,7 +36,7 @@ var _ = Describe("MCP Response Parsing (BR-INTEGRATION-054)", func() {
 
 			It("parses valid JSON into Unstructured object", func() {
 				input := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"nginx","namespace":"default"}}`
-				obj, err := parseUnstructured(input)
+				obj, err := ParseUnstructuredResponse(input)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(obj.GetKind()).To(Equal("Pod"))
 				Expect(obj.GetName()).To(Equal("nginx"))
@@ -44,7 +44,7 @@ var _ = Describe("MCP Response Parsing (BR-INTEGRATION-054)", func() {
 			})
 
 			It("returns error for invalid JSON", func() {
-				obj, err := parseUnstructured("not-json{{{")
+				obj, err := ParseUnstructuredResponse("not-json{{{")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("unmarshaling resource"))
 				Expect(obj).To(BeNil())

--- a/pkg/gateway/adapters/owner_resolver_registry_test.go
+++ b/pkg/gateway/adapters/owner_resolver_registry_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/gateway/adapters"
+	"github.com/jordigilh/kubernaut/pkg/shared/k8s/ownerchain"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -94,8 +95,8 @@ var _ = Describe("Owner Resolver with Registry (#1029)", func() {
 				WithObjects(deployment, rs, pod).
 				Build()
 
-			resolver := adapters.NewK8sOwnerResolver(fakeClient, logr.Discard(),
-				adapters.WithRegistry(registry))
+			resolver := ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard(),
+				ownerchain.WithRegistry(registry))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Pod", "api-server-abc-xyz")
 			Expect(err).ToNot(HaveOccurred())
@@ -117,8 +118,8 @@ var _ = Describe("Owner Resolver with Registry (#1029)", func() {
 				WithObjects(pod).
 				Build()
 
-			resolver := adapters.NewK8sOwnerResolver(fakeClient, logr.Discard(),
-				adapters.WithRegistry(registry))
+			resolver := ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard(),
+				ownerchain.WithRegistry(registry))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Pod", "standalone-pod")
 			Expect(err).ToNot(HaveOccurred())
@@ -135,10 +136,10 @@ var _ = Describe("Owner Resolver with Registry (#1029)", func() {
 			// When the resolver encounters a CRD kind (e.g., BuildConfig),
 			// it should stop traversal because owner chains for CRDs are
 			// unpredictable and cluster-specific.
-			resolver := adapters.NewK8sOwnerResolver(
+			resolver := ownerchain.NewK8sOwnerResolver(
 				fake.NewClientBuilder().WithScheme(scheme).Build(),
 				logr.Discard(),
-				adapters.WithRegistry(registry),
+				ownerchain.WithRegistry(registry),
 			)
 
 			// BuildConfig is an OpenShift CRD — not in core/apps/batch
@@ -172,8 +173,8 @@ var _ = Describe("Owner Resolver with Registry (#1029)", func() {
 				WithObjects(deployment, rs).
 				Build()
 
-			resolver := adapters.NewK8sOwnerResolver(fakeClient, logr.Discard(),
-				adapters.WithRegistry(registry))
+			resolver := ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard(),
+				ownerchain.WithRegistry(registry))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "ReplicaSet", "web-app-rs")
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/gateway/adapters/prometheus_adapter.go
+++ b/pkg/gateway/adapters/prometheus_adapter.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/gateway/middleware"
 	"github.com/jordigilh/kubernaut/pkg/gateway/types"
+	"github.com/jordigilh/kubernaut/pkg/shared/k8s/ownerchain"
 )
 
 // rfc1123LabelRegexp validates a K8s name/namespace against RFC 1123 label rules.
@@ -125,15 +126,15 @@ func (a *PrometheusAdapter) SetParseDroppedMetric(c *prometheus.CounterVec) {
 
 // SetReaderFactory injects a fleet.ReaderFactory for remote owner chain resolution.
 // When set and a signal carries a non-empty clusterID, Parse/ParseBatch construct
-// a remote K8sOwnerResolver backed by the reader for that cluster.
+// a remote ownerchain.K8sOwnerResolver backed by the reader for that cluster.
 func (a *PrometheusAdapter) SetReaderFactory(rf readerFactory) {
 	a.readerFactory = rf
 }
 
 // resolverForCluster returns the appropriate owner resolver for the given clusterID.
 // For local signals (empty clusterID) or when no readerFactory is configured,
-// it returns the local resolver. For remote signals, it constructs a
-// K8sOwnerResolver backed by a remote client.Reader from the factory.
+// it returns the local resolver. For remote signals, it constructs an
+// ownerchain.K8sOwnerResolver backed by a remote client.Reader from the factory.
 // On error, it falls back to the local resolver with a logged warning.
 func (a *PrometheusAdapter) resolverForCluster(ctx context.Context, clusterID string) types.OwnerResolver {
 	if clusterID == "" || a.readerFactory == nil {
@@ -145,7 +146,7 @@ func (a *PrometheusAdapter) resolverForCluster(ctx context.Context, clusterID st
 			"cluster", clusterID)
 		return a.ownerResolver
 	}
-	return NewK8sOwnerResolver(reader, a.logger)
+	return ownerchain.NewK8sOwnerResolver(reader, a.logger)
 }
 
 // Name returns the adapter identifier

--- a/pkg/gateway/cache_config_test.go
+++ b/pkg/gateway/cache_config_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/jordigilh/kubernaut/pkg/gateway/adapters"
+	"github.com/jordigilh/kubernaut/pkg/shared/k8s/ownerchain"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,8 +30,8 @@ var _ = Describe("Gateway cache configuration (#270)", func() {
 
 	Describe("OwnerChainCacheObjects includes all kindToGroup GVKs (BR-GATEWAY-004)", func() {
 		It("should return PartialObjectMetadata entries for every kind in KindToGroup", func() {
-			entries := adapters.OwnerChainCacheObjects()
-			kindToGroup := adapters.KindToGroup()
+			entries := ownerchain.OwnerChainCacheObjects()
+			kindToGroup := ownerchain.KindToGroup()
 
 			Expect(entries).ToNot(BeEmpty(), "OwnerChainCacheObjects must return entries")
 			Expect(entries).To(HaveLen(len(kindToGroup)),
@@ -60,7 +60,7 @@ var _ = Describe("Gateway cache configuration (#270)", func() {
 
 	Describe("KindToGroup is the single source of truth", func() {
 		It("should include all core, apps, and batch kinds needed for owner resolution", func() {
-			kindToGroup := adapters.KindToGroup()
+			kindToGroup := ownerchain.KindToGroup()
 
 			expectedKinds := []string{
 				"Pod", "Node", "Service", "ConfigMap", "Secret", "Namespace", "PersistentVolume",

--- a/pkg/gateway/owner_resolver_k8s_test.go
+++ b/pkg/gateway/owner_resolver_k8s_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/jordigilh/kubernaut/pkg/gateway/adapters"
 	"github.com/jordigilh/kubernaut/pkg/gateway/types"
+	"github.com/jordigilh/kubernaut/pkg/shared/k8s/ownerchain"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -45,7 +45,7 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 		ctx        context.Context
 		scheme     *runtime.Scheme
 		fakeClient client.Client
-		resolver   *adapters.K8sOwnerResolver
+		resolver   *ownerchain.K8sOwnerResolver
 	)
 
 	BeforeEach(func() {
@@ -61,7 +61,7 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 			WithScheme(scheme).
 			WithObjects(objs...).
 			Build()
-		resolver = adapters.NewK8sOwnerResolver(fakeClient, logr.Discard())
+		resolver = ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard())
 	}
 
 	Describe("Pod -> ReplicaSet -> Deployment (BR-GATEWAY-004)", func() {
@@ -291,8 +291,8 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 				WithObjects(deploy, rs, freshPod).
 				Build()
 
-			resolver = adapters.NewK8sOwnerResolver(cacheClient, logr.Discard(),
-				adapters.WithFallbackReader(apiClient))
+			resolver = ownerchain.NewK8sOwnerResolver(cacheClient, logr.Discard(),
+				ownerchain.WithFallbackReader(apiClient))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Pod", "leaky-app-544b75986-hndrn")
 			Expect(err).ToNot(HaveOccurred())
@@ -315,8 +315,8 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 				WithObjects(standalonePod.DeepCopy()).
 				Build()
 
-			resolver = adapters.NewK8sOwnerResolver(cacheClient, logr.Discard(),
-				adapters.WithFallbackReader(apiClient))
+			resolver = ownerchain.NewK8sOwnerResolver(cacheClient, logr.Discard(),
+				ownerchain.WithFallbackReader(apiClient))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Pod", "debug-pod")
 			Expect(err).ToNot(HaveOccurred())
@@ -340,8 +340,8 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 				WithScheme(scheme).
 				Build()
 
-			resolver = adapters.NewK8sOwnerResolver(cacheClient, logr.Discard(),
-				adapters.WithFallbackReader(apiClient))
+			resolver = ownerchain.NewK8sOwnerResolver(cacheClient, logr.Discard(),
+				ownerchain.WithFallbackReader(apiClient))
 
 			_, _, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Pod", "deleted-pod")
 			Expect(err).To(HaveOccurred())
@@ -380,8 +380,8 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 				WithScheme(scheme).
 				WithObjects(svc, sts, pod).
 				Build()
-			resolver = adapters.NewK8sOwnerResolver(fakeClient, logr.Discard(),
-				adapters.WithFallbackReader(fakeClient))
+			resolver = ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard(),
+				ownerchain.WithFallbackReader(fakeClient))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Service", "etcd-client")
 			Expect(err).ToNot(HaveOccurred())
@@ -429,8 +429,8 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 				WithScheme(scheme).
 				WithObjects(svc, deploy, rs, pod).
 				Build()
-			resolver = adapters.NewK8sOwnerResolver(fakeClient, logr.Discard(),
-				adapters.WithFallbackReader(fakeClient))
+			resolver = ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard(),
+				ownerchain.WithFallbackReader(fakeClient))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Service", "api-svc")
 			Expect(err).ToNot(HaveOccurred())
@@ -452,8 +452,8 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 				WithScheme(scheme).
 				WithObjects(svc).
 				Build()
-			resolver = adapters.NewK8sOwnerResolver(fakeClient, logr.Discard(),
-				adapters.WithFallbackReader(fakeClient))
+			resolver = ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard(),
+				ownerchain.WithFallbackReader(fakeClient))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Service", "orphan-svc")
 			Expect(err).ToNot(HaveOccurred())
@@ -476,8 +476,8 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 				WithScheme(scheme).
 				WithObjects(svc).
 				Build()
-			resolver = adapters.NewK8sOwnerResolver(fakeClient, logr.Discard(),
-				adapters.WithFallbackReader(fakeClient))
+			resolver = ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard(),
+				ownerchain.WithFallbackReader(fakeClient))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Service", "external-svc")
 			Expect(err).ToNot(HaveOccurred())
@@ -505,8 +505,8 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 				WithScheme(scheme).
 				WithObjects(svc, pod).
 				Build()
-			resolver = adapters.NewK8sOwnerResolver(fakeClient, logr.Discard(),
-				adapters.WithFallbackReader(fakeClient))
+			resolver = ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard(),
+				ownerchain.WithFallbackReader(fakeClient))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Service", "debug-svc")
 			Expect(err).ToNot(HaveOccurred())
@@ -529,7 +529,7 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 				WithObjects(svc).
 				Build()
 			// No fallbackReader — metadata-only cache can't read Service spec
-			resolver = adapters.NewK8sOwnerResolver(fakeClient, logr.Discard())
+			resolver = ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard())
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Service", "some-svc")
 			Expect(err).ToNot(HaveOccurred())
@@ -577,8 +577,8 @@ var _ = Describe("K8sOwnerResolver - Owner chain resolution with real K8s object
 				WithScheme(scheme).
 				WithObjects(svc, sts, pod0, pod1).
 				Build()
-			resolver = adapters.NewK8sOwnerResolver(fakeClient, logr.Discard(),
-				adapters.WithFallbackReader(fakeClient))
+			resolver = ownerchain.NewK8sOwnerResolver(fakeClient, logr.Discard(),
+				ownerchain.WithFallbackReader(fakeClient))
 
 			ownerKind, ownerName, err := resolver.ResolveTopLevelOwner(ctx, namespace, "Service", "etcd-client")
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/gateway/server_constructors.go
+++ b/pkg/gateway/server_constructors.go
@@ -56,6 +56,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/gateway/processing" // BR-HTTP-015: Shared CORS library
 
 	// DD-005: Shared sanitization library
+	"github.com/jordigilh/kubernaut/pkg/shared/k8s/ownerchain"
 	"github.com/jordigilh/kubernaut/pkg/shared/scope" // BR-SCOPE-002: Resource scope management
 )
 
@@ -274,7 +275,7 @@ func buildGatewayCache(
 ) (cache.Cache, context.CancelFunc, error) {
 	// #270: Build ByObject map with metadata-only informers for owner chain resolution
 	// OwnerResolver and ScopeManager need cached lookups for Pods, ReplicaSets, Deployments, etc.
-	byObject := adapters.OwnerChainCacheObjects()
+	byObject := ownerchain.OwnerChainCacheObjects()
 	byObject[&remediationv1alpha1.RemediationRequest{}] = cache.ByObject{
 		Namespaces: map[string]cache.Config{
 			controllerNS: {}, // ADR-057: restrict RR to controller namespace

--- a/pkg/shared/k8s/ownerchain/owner_resolver.go
+++ b/pkg/shared/k8s/ownerchain/owner_resolver.go
@@ -14,7 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package adapters
+// Package ownerchain resolves the top-level controller owner of a
+// Kubernetes resource by traversing ownerReferences. Moved from
+// pkg/gateway/adapters (issue #2306) to pkg/shared/k8s/ownerchain so both
+// Gateway (signal-fingerprinting dedup) and KubernautAgent (fleet-target
+// resourceContextTools resolution) can import the same proven, tested
+// algorithm as peers — mirroring the existing pkg/shared/hash and
+// pkg/shared/scope pattern for cross-service domain logic, instead of one
+// service cross-linking into the other's pkg/<service> tree.
+package ownerchain
 
 import (
 	"context"
@@ -52,10 +60,10 @@ const ownerLookupTimeout = 5 * time.Second
 // Same mapping as pkg/shared/scope/manager.go:kindToGroup.
 // Shared pattern across Gateway scope management and owner chain resolution.
 //
-// Deprecated: Superseded by APIResourceRegistry.KindToGVR() (#1029).
+// Deprecated: Superseded by a KindResolver's KindToGVR() (#1029).
 // Retained as a nil-registry fallback for tests and the exported KindToGroup()/
 // OwnerChainCacheObjects() helpers. Will be removed in a dedicated cleanup PR
-// once all consumers migrate to the registry.
+// once all consumers migrate to a KindResolver.
 var kindToGroup = map[string]string{
 	"Pod":              "",
 	"Node":             "",
@@ -72,11 +80,27 @@ var kindToGroup = map[string]string{
 	"CronJob":          "batch",
 }
 
+// KindResolver abstracts a caller-supplied dynamic GVR lookup and CRD
+// traversal-control source for K8sOwnerResolver, decoupling this shared
+// package from any single service's concrete registry implementation
+// (#2306). Gateway's *adapters.APIResourceRegistry already satisfies this
+// interface structurally (KindToGVR/IsCoreBatchAppsKind, unchanged) — no
+// code changes needed there.
+type KindResolver interface {
+	// KindToGVR resolves kind to its GroupVersionResource, or (zero, false)
+	// if the kind is unknown to this resolver.
+	KindToGVR(kind string) (schema.GroupVersionResource, bool)
+	// IsCoreBatchAppsKind reports whether kind belongs to the core/apps/batch
+	// API groups (predictable owner-chain traversal) as opposed to a CRD
+	// (unpredictable, cluster-specific owner chains).
+	IsCoreBatchAppsKind(kind string) bool
+}
+
 // KindToGroup returns a copy of the authoritative kind-to-API-group mapping
 // used for owner chain resolution. This is the single source of truth for which
-// Kubernetes resource kinds the Gateway must be able to look up.
+// Kubernetes resource kinds a consumer must be able to look up.
 //
-// Exported so the cache configuration and tests can reference it without
+// Exported so cache configuration and tests can reference it without
 // duplicating the list.
 func KindToGroup() map[string]string {
 	result := make(map[string]string, len(kindToGroup))
@@ -114,8 +138,9 @@ func OwnerChainCacheObjects() map[client.Object]cache.ByObject {
 // K8sOwnerResolver resolves the top-level controller owner of a Kubernetes
 // resource by traversing ownerReferences using the metadata-only informer cache.
 //
-// This implementation reuses the same controller-runtime cached client (ctrlClient)
-// that the scope management Manager (ADR-053) uses. When Get() is called with
+// This implementation reuses whatever cached controller-runtime client
+// (ctrlClient) the caller supplies — Gateway passes the same cache the scope
+// management Manager (ADR-053) uses. When Get() is called with
 // PartialObjectMetadata, controller-runtime uses metadata-only informers — so
 // owner chain resolution is a pure cache lookup with zero API server calls.
 //
@@ -130,6 +155,7 @@ func OwnerChainCacheObjects() map[client.Object]cache.ByObject {
 //
 // Business Requirements:
 //   - BR-GATEWAY-004: Signal Fingerprinting (owner-chain-based deduplication for K8s events)
+//   - BR-INTEGRATION-1489: fleet-target resourceContextTools resolution (#2306)
 //
 // Architecture:
 //   - ADR-053: Resource Scope Management (shared metadata-only informer cache)
@@ -137,7 +163,7 @@ func OwnerChainCacheObjects() map[client.Object]cache.ByObject {
 type K8sOwnerResolver struct {
 	client         client.Reader
 	fallbackReader client.Reader
-	registry       *APIResourceRegistry
+	registry       KindResolver
 	logger         logr.Logger
 }
 
@@ -170,9 +196,11 @@ func WithFallbackReader(reader client.Reader) OwnerResolverOption {
 	}
 }
 
-// WithRegistry sets the APIResourceRegistry for dynamic GVR lookup and
-// CRD traversal control, replacing the static kindToGroup map (#1029).
-func WithRegistry(reg *APIResourceRegistry) OwnerResolverOption {
+// WithRegistry sets the KindResolver for dynamic GVR lookup and CRD
+// traversal control, replacing the static kindToGroup map (#1029). Any
+// implementation satisfying KindResolver may be passed — e.g. Gateway's
+// *adapters.APIResourceRegistry, unchanged (#2306).
+func WithRegistry(reg KindResolver) OwnerResolverOption {
 	return func(r *K8sOwnerResolver) {
 		r.registry = reg
 	}

--- a/test/integration/gateway/fleet/gw_fleet_owner_chain_test.go
+++ b/test/integration/gateway/fleet/gw_fleet_owner_chain_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
 	"github.com/jordigilh/kubernaut/pkg/gateway/adapters"
+	"github.com/jordigilh/kubernaut/pkg/shared/k8s/ownerchain"
 	mockgw "github.com/jordigilh/kubernaut/test/services/mock-mcp-gateway/testutil"
 )
 
@@ -65,7 +66,7 @@ var _ = Describe("GW Fleet Remote Owner Chain Resolution (BR-INTEGRATION-065)", 
 		readerFactory := mcpclient.NewMCPReaderFactory(localClient, mcpClient.Session())
 
 		logger := zap.New(zap.UseDevMode(true))
-		localResolver := adapters.NewK8sOwnerResolver(localClient, logger)
+		localResolver := ownerchain.NewK8sOwnerResolver(localClient, logger)
 		adapter := adapters.NewPrometheusAdapter(localResolver, nil, logger)
 		adapter.SetReaderFactory(readerFactory)
 
@@ -83,7 +84,7 @@ var _ = Describe("GW Fleet Remote Owner Chain Resolution (BR-INTEGRATION-065)", 
 		localClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		logger := zap.New(zap.UseDevMode(true))
-		localResolver := adapters.NewK8sOwnerResolver(localClient, logger)
+		localResolver := ownerchain.NewK8sOwnerResolver(localClient, logger)
 		adapter := adapters.NewPrometheusAdapter(localResolver, nil, logger)
 
 		payload := buildWebhookPayload("prod-east-1", "prod", "Pod", "api-server-abc")

--- a/test/integration/gateway/owner_chain_dedup_integration_test.go
+++ b/test/integration/gateway/owner_chain_dedup_integration_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/gateway"
 	"github.com/jordigilh/kubernaut/pkg/gateway/adapters"
 	gwTypes "github.com/jordigilh/kubernaut/pkg/gateway/types"
+	"github.com/jordigilh/kubernaut/pkg/shared/k8s/ownerchain"
 	"github.com/jordigilh/kubernaut/test/shared/helpers"
 )
 
@@ -201,7 +202,7 @@ var _ = Describe("Owner Chain Deduplication (#270, BR-GATEWAY-004)", Ordered, Co
 
 			By("2. Creating OwnerResolver and PrometheusAdapter wired to envtest client")
 
-			ownerResolver := adapters.NewK8sOwnerResolver(k8sClient, testLogger)
+			ownerResolver := ownerchain.NewK8sOwnerResolver(k8sClient, testLogger)
 			adapter := adapters.NewPrometheusAdapter(ownerResolver, adapters.NewTestAPIResourceRegistry())
 
 			By("3. Parsing alert for Pod A (triggers owner chain resolution)")
@@ -299,7 +300,7 @@ var _ = Describe("Owner Chain Deduplication (#270, BR-GATEWAY-004)", Ordered, Co
 
 			By("2. Parsing alert with OwnerResolver (should resolve to Pod itself)")
 
-			ownerResolver := adapters.NewK8sOwnerResolver(k8sClient, testLogger)
+			ownerResolver := ownerchain.NewK8sOwnerResolver(k8sClient, testLogger)
 			adapter := adapters.NewPrometheusAdapter(ownerResolver, adapters.NewTestAPIResourceRegistry())
 
 			payload := createPrometheusAlertForPod(testNamespace, "HighCPU", "warning", "", "standalone-worker")

--- a/test/integration/kubernautagent/investigator/fleet_e2e_journey_test.go
+++ b/test/integration/kubernautagent/investigator/fleet_e2e_journey_test.go
@@ -534,11 +534,17 @@ var _ = Describe("Fleet cluster-transparent tool exposure — full journey (BR-I
 				MaxTurns:      5,
 				PhaseTools:    investigator.DefaultPhaseToolMap(),
 				Registry:      reg,
-				// Non-empty overlay resolution (no tools) is enough to
-				// exercise prescopeFleetOverlay's fleet-target path; this
-				// test proves schema exclusion, not overlay tool routing
-				// (already proven by E2E-KA-FLEET-001/002 above).
-				FleetOverlayResolver: &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{}},
+				// FleetOverlayFromContext (fleet_overlay.go) treats an EMPTY
+				// resolved overlay as equivalent to "no overlay at all" (fail-open
+				// fallback to local tools, pre-dating issue #2306) -- so the spy
+				// must resolve at least one tool for hasOverlay to be true and
+				// this test's fleet-target path (and the suppression it's meant
+				// to exercise) to actually engage. A single unrelated dummy tool
+				// is enough; this test proves schema exclusion, not overlay tool
+				// routing (already proven by E2E-KA-FLEET-001/002 above).
+				FleetOverlayResolver: &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{
+					"resources_get": &fakeTool{name: "resources_get", result: "{}"},
+				}},
 			})
 
 			signal := katypes.SignalContext{

--- a/test/integration/kubernautagent/investigator/fleet_e2e_journey_test.go
+++ b/test/integration/kubernautagent/investigator/fleet_e2e_journey_test.go
@@ -268,6 +268,65 @@ func (fleetSuppressionE2EScenario) ConfigForContext(_ *scenarios.DetectionContex
 	}
 }
 
+// fleetSuppressionExecutionE2EMarker is executeResolved's own rejection
+// wording (investigator_tools.go) for a suppressed name with no overlay
+// override. The scenario below inspects ctx.AllText for it, the same
+// turn-detection technique fleetE2EScenario uses via fleetE2EMarker, to
+// tell whether its first tool call was rejected (marker present) or --
+// were the fix regressed -- actually reached the hub-local tool and
+// returned that tool's own content instead (marker absent).
+const fleetSuppressionExecutionE2EMarker = "is suppressed for fleet-target investigations"
+
+// fleetSuppressionExecutionE2EScenario (Issue #2306 follow-up,
+// E2E-KA-FLEET-004) proves executeResolved's execution-time block end to
+// end through a real mock-LLM HTTP server. fleetSuppressionE2EScenario
+// (E2E-KA-FLEET-003, above) only ever inspects the outbound schema and
+// never issues a tool call, so it could never have caught a gap in the
+// execution path itself. This scenario issues a call for
+// "kubectl_get_by_name" on turn 1 unconditionally -- standing in for a
+// hallucinated or schema-stale call, since the mock-LLM's own scenario
+// logic isn't bound by whatever tool names the wire request advertised --
+// then, once the rejection's error content is echoed back into the
+// conversation, answers with a completed RCA on turn 2.
+type fleetSuppressionExecutionE2EScenario struct{}
+
+func (fleetSuppressionExecutionE2EScenario) Name() string {
+	return "fleet_suppression_execution_e2e_2306"
+}
+func (fleetSuppressionExecutionE2EScenario) Metadata() scenarios.ScenarioMetadata {
+	return scenarios.ScenarioMetadata{Name: "fleet_suppression_execution_e2e_2306", Description: "E2E-KA-FLEET-004"}
+}
+func (fleetSuppressionExecutionE2EScenario) DAG() *conversation.DAG { return nil }
+func (fleetSuppressionExecutionE2EScenario) Match(ctx *scenarios.DetectionContext) (bool, float64) {
+	if strings.Contains(ctx.Content, "fleetsuppressionexecutionprobe") {
+		return true, 1.0
+	}
+	return false, 0
+}
+func (fleetSuppressionExecutionE2EScenario) ConfigForContext(ctx *scenarios.DetectionContext) scenarios.MockScenarioConfig {
+	if strings.Contains(ctx.AllText, fleetSuppressionExecutionE2EMarker) {
+		actionable := true
+		return scenarios.MockScenarioConfig{
+			ScenarioName:         "fleet_suppression_execution_e2e_2306",
+			SignalName:           "FleetSuppressionExecutionProbe",
+			Severity:             "critical",
+			RootCause:            "pod api-server-abc confirmed OOMKilled",
+			InvestigationOutcome: "actionable",
+			IsActionable:         &actionable,
+			Confidence:           0.9,
+			ForceText:            scenarios.BoolPtr(true),
+		}
+	}
+	return scenarios.MockScenarioConfig{
+		ScenarioName: "fleet_suppression_execution_e2e_2306",
+		ToolCallName: "kubectl_get_by_name",
+		ToolCallArgs: map[string]interface{}{
+			"kind": "Pod", "name": "api-server-abc", "namespace": "production",
+		},
+		ForceText: scenarios.BoolPtr(false),
+	}
+}
+
 var _ = Describe("Fleet cluster-transparent tool exposure — full journey (BR-INTEGRATION-1489, DD-FLEET-005)", Label("fleet", "integration"), func() {
 
 	Describe("E2E-KA-FLEET-001: a real mock-LLM issues a tool call under a generic name during a fleet-target investigation, and it reaches the remote cluster, never the hub-local tool", func() {
@@ -573,6 +632,84 @@ var _ = Describe("Fleet cluster-transparent tool exposure — full journey (BR-I
 			Expect(capturedToolNames).To(ContainElement("get_namespaced_resource_context"),
 				"resourceContextTools are fleet-agnostic BY NAME and must stay visible -- Issue #2306's fix "+
 					"is internal cluster-aware routing inside Execute(), not suppression from the schema")
+		})
+	})
+
+	Describe("E2E-KA-FLEET-004 [AC-6]: a real mock-LLM's call for a suppressed tool name is rejected end to end, never reaching the hub-local tool", func() {
+		It("rejects kubectl_get_by_name when the LLM calls it despite the schema omitting it, and completes the investigation only once the rejection is echoed back", func() {
+			// --- Hub-local side: a registry with a fakeTool under the
+			// suppressed name. Its content ("local-hub") must never surface
+			// anywhere: if executeResolved's suppression check regressed,
+			// this tool would execute and return this content instead of
+			// the fleetSuppressionExecutionE2EMarker rejection, and the
+			// scenario would never see the marker it's waiting for. ---
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "kubectl_get_by_name", result: `{"source":"local-hub","warning":"must never be reached for a fleet-target investigation"}`})
+			auditStore := newCapturingAuditStore(suiteAuditStore)
+
+			// --- Mock LLM side: a real HTTP server serving the scenario
+			// above, which issues the tool call unconditionally on turn 1
+			// regardless of what the wire schema actually advertised. ---
+			reg2 := scenarios.NewRegistry()
+			reg2.Register(fleetSuppressionExecutionE2EScenario{})
+			llmServer := httptest.NewServer(handlers.NewRouter(reg2, false, ""))
+			defer llmServer.Close()
+
+			llmClient := kaopenai.New("test-model", llmServer.URL, "test-key")
+			sw, err := llm.NewSwappableClient(llmClient, "test-model")
+			Expect(err).NotTo(HaveOccurred())
+
+			builder, err := prompt.NewBuilder()
+			Expect(err).NotTo(HaveOccurred())
+
+			inv := investigator.New(investigator.Config{
+				PhaseResolver: investigator.NewDefaultPhaseResolver(sw, nil),
+				Builder:       builder,
+				ResultParser:  parser.NewResultParser(),
+				AuditStore:    auditStore,
+				Logger:        logr.Discard(),
+				MaxTurns:      5,
+				PhaseTools:    investigator.DefaultPhaseToolMap(),
+				Registry:      reg,
+				// A single unrelated dummy tool is enough for hasOverlay to be
+				// true (see E2E-KA-FLEET-003's identical comment on the same
+				// fail-open-if-empty behavior); no override exists for
+				// "kubectl_get_by_name" itself.
+				FleetOverlayResolver: &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{
+					"resources_get": &fakeTool{name: "resources_get", result: "{}"},
+				}},
+			})
+
+			signal := katypes.SignalContext{
+				Name:          "FleetSuppressionExecutionProbe",
+				Namespace:     "production",
+				Severity:      "critical",
+				Message:       "OOMKilled",
+				ClusterID:     "remote-east",
+				ResourceKind:  "Pod",
+				ResourceName:  "api-server-abc",
+				RemediationID: "rem-e2e-fleet-2306-exec",
+				Interactive:   true,
+			}
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred(),
+				"E2E-KA-FLEET-004: the rejection is returned to the LLM as a tool error message, "+
+					"not surfaced as an Investigate() error")
+			Expect(result).NotTo(BeNil())
+
+			// The scenario only reaches its ForceText/RootCause turn once it
+			// observes fleetSuppressionExecutionE2EMarker in the conversation
+			// -- so a completed, matching result is itself proof the
+			// rejection (not the hub-local tool's own content) is what came
+			// back from the tool call.
+			Expect(result.RCASummary).To(ContainSubstring("pod api-server-abc confirmed OOMKilled"),
+				"E2E-KA-FLEET-004: the investigation must reach the scenario's post-rejection turn, "+
+					"proving the real mock-LLM HTTP round trip actually observed the rejection")
+			Expect(result.RCASummary).NotTo(ContainSubstring("local-hub"),
+				"E2E-KA-FLEET-004 (AC-6): the hub-local tool registered under the suppressed name must "+
+					"never execute, even when a real mock-LLM issues the call anyway despite the schema "+
+					"omitting it")
 		})
 	})
 })

--- a/test/integration/kubernautagent/investigator/fleet_e2e_journey_test.go
+++ b/test/integration/kubernautagent/investigator/fleet_e2e_journey_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package investigator_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 
@@ -31,6 +34,7 @@ import (
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/tools/custom"
 	fleetclient "github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	kaopenai "github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/openai"
@@ -228,6 +232,39 @@ func (fleetE2EKuadrantScenario) ConfigForContext(ctx *scenarios.DetectionContext
 			"kind": "Pod", "name": "api-server-abc", "namespace": "production",
 		},
 		ForceText: scenarios.BoolPtr(false),
+	}
+}
+
+// fleetSuppressionE2EScenario (Issue #2306, E2E-KA-FLEET-003) always answers
+// with a completed, actionable RCA on the very first turn -- no tool call
+// needed. Unlike fleetE2EScenario/fleetE2EKuadrantScenario above, this test's
+// job is to inspect the *schema* of that first request (which tool names the
+// real mock-LLM HTTP server actually received), not to prove a tool call
+// routes correctly, so there is nothing to short-circuit on a marker.
+type fleetSuppressionE2EScenario struct{}
+
+func (fleetSuppressionE2EScenario) Name() string { return "fleet_suppression_e2e_2306" }
+func (fleetSuppressionE2EScenario) Metadata() scenarios.ScenarioMetadata {
+	return scenarios.ScenarioMetadata{Name: "fleet_suppression_e2e_2306", Description: "E2E-KA-FLEET-003"}
+}
+func (fleetSuppressionE2EScenario) DAG() *conversation.DAG { return nil }
+func (fleetSuppressionE2EScenario) Match(ctx *scenarios.DetectionContext) (bool, float64) {
+	if strings.Contains(ctx.Content, "fleetsuppressionprobe") {
+		return true, 1.0
+	}
+	return false, 0
+}
+func (fleetSuppressionE2EScenario) ConfigForContext(_ *scenarios.DetectionContext) scenarios.MockScenarioConfig {
+	actionable := true
+	return scenarios.MockScenarioConfig{
+		ScenarioName:         "fleet_suppression_e2e_2306",
+		SignalName:           "FleetSuppressionProbe",
+		Severity:             "critical",
+		RootCause:            "pod api-server-abc confirmed OOMKilled",
+		InvestigationOutcome: "actionable",
+		IsActionable:         &actionable,
+		Confidence:           0.9,
+		ForceText:            scenarios.BoolPtr(true),
 	}
 }
 
@@ -434,6 +471,102 @@ var _ = Describe("Fleet cluster-transparent tool exposure — full journey (BR-I
 			Expect(result.RCASummary).NotTo(ContainSubstring("local-hub"),
 				"the hub-local fakeTool registered under the same generic name must never execute "+
 					"for a fleet-target investigation")
+		})
+	})
+
+	Describe("E2E-KA-FLEET-003 [AC-6, SC-7]: the mock-LLM's real HTTP request excludes suppressed local tool names for a fleet-target investigation", func() {
+		It("omits client-go-backed local tool names from the received tool schema, while resourceContextTools stays visible", func() {
+			// --- Hub-local side: a registry seeded with two representative
+			// client-go-backed tools (suppressed per fleetSuppressedToolNames)
+			// plus the 5 real custom tools (RegisterAll), whose
+			// get_namespaced_resource_context/get_cluster_resource_context are
+			// fleet-agnostic BY NAME and must stay visible (Issue #2306). ---
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "kubectl_get_by_name", result: `{}`})
+			reg.Register(&fakeTool{name: "kubectl_top_pods", result: `{}`})
+			auditStore := newCapturingAuditStore(suiteAuditStore)
+			custom.RegisterAll(reg, nil, auditStore, suiteDSAdapter, &k8sFixtureClient{}, logr.Discard())
+
+			// --- Mock LLM side: a real HTTP server, fronted by a thin
+			// body-capturing proxy that records the "tools" field of the
+			// actual wire request before forwarding it unchanged to the real
+			// scenario router -- proving what the LLM itself would have
+			// received, not an internal Go struct. ---
+			var capturedToolNames []string
+			reg2 := scenarios.NewRegistry()
+			reg2.Register(fleetSuppressionE2EScenario{})
+			realRouter := handlers.NewRouter(reg2, false, "")
+			llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				bodyBytes, err := io.ReadAll(r.Body)
+				Expect(err).NotTo(HaveOccurred())
+
+				var parsed struct {
+					Tools []struct {
+						Function struct {
+							Name string `json:"name"`
+						} `json:"function"`
+					} `json:"tools"`
+				}
+				if jerr := json.Unmarshal(bodyBytes, &parsed); jerr == nil {
+					for _, t := range parsed.Tools {
+						capturedToolNames = append(capturedToolNames, t.Function.Name)
+					}
+				}
+
+				r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+				realRouter.ServeHTTP(w, r)
+			}))
+			defer llmServer.Close()
+
+			llmClient := kaopenai.New("test-model", llmServer.URL, "test-key")
+			sw, err := llm.NewSwappableClient(llmClient, "test-model")
+			Expect(err).NotTo(HaveOccurred())
+
+			builder, err := prompt.NewBuilder()
+			Expect(err).NotTo(HaveOccurred())
+
+			inv := investigator.New(investigator.Config{
+				PhaseResolver: investigator.NewDefaultPhaseResolver(sw, nil),
+				Builder:       builder,
+				ResultParser:  parser.NewResultParser(),
+				AuditStore:    auditStore,
+				Logger:        logr.Discard(),
+				MaxTurns:      5,
+				PhaseTools:    investigator.DefaultPhaseToolMap(),
+				Registry:      reg,
+				// Non-empty overlay resolution (no tools) is enough to
+				// exercise prescopeFleetOverlay's fleet-target path; this
+				// test proves schema exclusion, not overlay tool routing
+				// (already proven by E2E-KA-FLEET-001/002 above).
+				FleetOverlayResolver: &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{}},
+			})
+
+			signal := katypes.SignalContext{
+				Name:          "FleetSuppressionProbe",
+				Namespace:     "production",
+				Severity:      "critical",
+				Message:       "OOMKilled",
+				ClusterID:     "remote-east",
+				ResourceKind:  "Pod",
+				ResourceName:  "api-server-abc",
+				RemediationID: "rem-e2e-fleet-2306",
+				Interactive:   true,
+			}
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred(),
+				"E2E-KA-FLEET-003: a fleet-target investigation through a real mock-LLM HTTP server must complete without error")
+			Expect(result).NotTo(BeNil())
+			Expect(capturedToolNames).NotTo(BeEmpty(),
+				"the capturing proxy must have parsed a non-empty 'tools' field from the real wire request")
+
+			Expect(capturedToolNames).NotTo(ContainElement("kubectl_get_by_name"),
+				"Issue #2306 (AC-6): a client-go-backed local tool must never be advertised to the LLM "+
+					"for a fleet-target investigation with no same-named overlay override")
+			Expect(capturedToolNames).NotTo(ContainElement("kubectl_top_pods"))
+			Expect(capturedToolNames).To(ContainElement("get_namespaced_resource_context"),
+				"resourceContextTools are fleet-agnostic BY NAME and must stay visible -- Issue #2306's fix "+
+					"is internal cluster-aware routing inside Execute(), not suppression from the schema")
 		})
 	})
 })

--- a/test/integration/kubernautagent/investigator/fleet_prescoping_test.go
+++ b/test/integration/kubernautagent/investigator/fleet_prescoping_test.go
@@ -385,6 +385,72 @@ var _ = Describe("Fleet cluster-transparent tool pre-scoping (BR-INTEGRATION-148
 		})
 	})
 
+	// Issue #2306 follow-up: toolDefinitionsForPhase (proven by IT-KA-FLEET-029/030)
+	// only ever controlled what the LLM's schema *advertises*. Nothing
+	// previously stopped a call for a suppressed name from still reaching
+	// inv.registry.Execute() and running against the hub if it arrived
+	// anyway -- schema drift across turns, a hallucinated call, or an
+	// adversarial prompt. This proves the same suppression decision is now
+	// also enforced at execution time, wired through the real
+	// Investigate() path.
+	Describe("IT-KA-FLEET-035 [AC-6]: a suppressed local tool call is rejected end-to-end, not routed to the hub-local tool", func() {
+		It("rejects kubectl_get_by_name for a fleet-target investigation when the overlay provides no override, and the hub-local tool never executes", func() {
+			localTool := &fakeTool{name: "kubectl_get_by_name", result: `{"source":"local-hub","warning":"must never be reached for a fleet-target investigation"}`}
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{
+				"resources_get": &fakeTool{name: "resources_get", result: `{"source":"remote-cluster-east"}`},
+			}}
+
+			reg := registry.New()
+			reg.Register(localTool)
+
+			mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+				{
+					Message:   llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{{ID: "tc_get", Name: "kubectl_get_by_name", Arguments: `{}`}},
+				},
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
+				{
+					Message:   llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{{ID: "tc_wf1", Name: "list_available_actions", Arguments: `{}`}},
+				},
+				{
+					Message: llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled"},"reasoning":"none"}`},
+					},
+				},
+			}}
+			enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+			builder, _ := prompt.NewBuilder()
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: reg,
+				FleetOverlayResolver: spy,
+			})
+
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "api-server-abc", Namespace: "production", ClusterID: "remote-east",
+			})
+			Expect(err).NotTo(HaveOccurred(),
+				"IT-KA-FLEET-035: the rejection is returned to the LLM as a tool error message, "+
+					"not surfaced as an Investigate() error")
+
+			toolErrorContent := allMessageContent(mockClient.calls[1].Messages)
+			Expect(toolErrorContent).To(ContainSubstring("kubectl_get_by_name"))
+			Expect(toolErrorContent).To(ContainSubstring("suppressed"))
+			Expect(toolErrorContent).To(ContainSubstring("remote-east"),
+				"IT-KA-FLEET-035: the rejection must name the target cluster, mirroring IT-KA-FLEET-021's "+
+					"not-found wrapping, so an operator can tell suppression from a genuinely unknown tool name")
+			Expect(toolErrorContent).NotTo(ContainSubstring("local-hub"),
+				"IT-KA-FLEET-035: the hub-local tool registered under the suppressed name must never "+
+					"execute for a fleet-target investigation (AC-6) -- rejection happens before "+
+					"inv.registry.Execute() is ever called")
+		})
+	})
+
 	// Issue #1729 (DD-FLEET-005 tool-transparency gap): toolDefinitionsForPhase
 	// previously only ever *overrode* an existing local-registry tool entry
 	// with the overlay's BridgeTool when both shared the exact same name (see

--- a/test/integration/kubernautagent/investigator/fleet_prescoping_test.go
+++ b/test/integration/kubernautagent/investigator/fleet_prescoping_test.go
@@ -656,6 +656,162 @@ var _ = Describe("Fleet cluster-transparent tool pre-scoping (BR-INTEGRATION-148
 		})
 	})
 
+	// Issue #2306: toolDefinitionsForPhase's override-and-append halves (proven
+	// by IT-KA-FLEET-015/024 above) left a subtractive gap — a local, hub-bound
+	// k8s tool with NO same-named overlay override stayed advertised to the LLM
+	// even for a fleet-target investigation, so the LLM could silently call it
+	// and query the wrong (hub) cluster (AC-6 violation, RR rr-9dc9711199fd-bd25bdf5).
+	// UT-KA-FLEET-029/030 (investigator_tools_fleet_suppression_test.go) prove the
+	// pure decision logic; these specs prove it end-to-end through the real
+	// Investigate()/RunInteractiveTurn entry points, at the level the LLM itself
+	// observes (its own received tool schema).
+	Describe("IT-KA-FLEET-030 [AC-6]: Investigate() excludes hub-bound local k8s tools with no overlay override from the RCA schema", func() {
+		It("never advertises kubectl_get_by_name or kubectl_logs for a fleet-target investigation", func() {
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "kubectl_get_by_name", result: "{}"})
+			reg.Register(&fakeTool{name: "kubectl_logs", result: "{}"})
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{
+				"resources_get": &fakeTool{name: "resources_get", result: "{}"},
+			}}
+			mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
+				{
+					Message:   llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{{ID: "tc_wf1", Name: "list_available_actions", Arguments: `{}`}},
+				},
+				{
+					Message: llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled"},"reasoning":"none"}`},
+					},
+				},
+			}}
+			enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+			builder, _ := prompt.NewBuilder()
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: reg,
+				FleetOverlayResolver: spy,
+			})
+
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "api-server-abc", Namespace: "production", ClusterID: "remote-east",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.calls).NotTo(BeEmpty())
+			names := toolNamesFromCall(mockClient.calls[0])
+			Expect(names).NotTo(ContainElement("kubectl_get_by_name"),
+				"IT-KA-FLEET-030: a fleet-target investigation must never advertise a hub-bound local "+
+					"k8s tool to the LLM unless the overlay provides a same-named override -- otherwise "+
+					"the LLM can silently call it and query the wrong (hub) cluster (AC-6, issue #2306)")
+			Expect(names).NotTo(ContainElement("kubectl_logs"))
+		})
+
+		It("still advertises every local k8s tool for a hub-local investigation (zero regression)", func() {
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "kubectl_get_by_name", result: "{}"})
+			reg.Register(&fakeTool{name: "kubectl_logs", result: "{}"})
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{}}
+			mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
+				{
+					Message:   llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{{ID: "tc_wf1", Name: "list_available_actions", Arguments: `{}`}},
+				},
+				{
+					Message: llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled"},"reasoning":"none"}`},
+					},
+				},
+			}}
+			enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+			builder, _ := prompt.NewBuilder()
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: reg,
+				FleetOverlayResolver: spy,
+			})
+
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "api-server-abc", Namespace: "production",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			names := toolNamesFromCall(mockClient.calls[0])
+			Expect(names).To(ContainElement("kubectl_get_by_name"),
+				"IT-KA-FLEET-030: a hub-local investigation (no target cluster) must see the full "+
+					"local k8s tool set, unchanged from before this fix")
+			Expect(names).To(ContainElement("kubectl_logs"))
+		})
+	})
+
+	Describe("IT-KA-FLEET-031 [AC-6]: RunInteractiveTurn excludes hub-bound local k8s tools with no overlay override from the RCA schema", func() {
+		It("never advertises kubectl_get_by_name for a fleet-target interactive turn", func() {
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "kubectl_get_by_name", result: "{}"})
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{
+				"resources_get": &fakeTool{name: "resources_get", result: "{}"},
+			}}
+			mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: "no root cause identified yet"}},
+			}}
+			enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+			builder, _ := prompt.NewBuilder()
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: reg,
+				FleetOverlayResolver: spy,
+			})
+
+			ctx := katypes.WithSignalContext(context.Background(), katypes.SignalContext{
+				ClusterID: "remote-east", RemediationID: "rem-interactive-suppression-001",
+			})
+			_, err := inv.RunInteractiveTurn(ctx, []llm.Message{
+				{Role: "user", Content: "what is wrong with the deployment?"},
+			}, "rem-interactive-suppression-001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.calls).NotTo(BeEmpty())
+			Expect(toolNamesFromCall(mockClient.calls[0])).NotTo(ContainElement("kubectl_get_by_name"),
+				"IT-KA-FLEET-031: a fleet-target interactive turn must never advertise a hub-bound "+
+					"local k8s tool with no overlay override, mirroring IT-KA-FLEET-030's Investigate() proof")
+		})
+
+		It("still advertises the local k8s tool for a hub-local interactive turn (zero regression)", func() {
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "kubectl_get_by_name", result: "{}"})
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{}}
+			mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: "no root cause identified yet"}},
+			}}
+			enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+			builder, _ := prompt.NewBuilder()
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: reg,
+				FleetOverlayResolver: spy,
+			})
+
+			_, err := inv.RunInteractiveTurn(context.Background(), []llm.Message{
+				{Role: "user", Content: "what is wrong with the deployment?"},
+			}, "rem-interactive-hub-suppression-001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(toolNamesFromCall(mockClient.calls[0])).To(ContainElement("kubectl_get_by_name"),
+				"IT-KA-FLEET-031: a hub-local interactive turn must see the local k8s tool unchanged")
+		})
+	})
+
 	// QE readiness audit follow-up (PR #1799 Finding #2, tracked as #1834): UT-KA-FLEET-028
 	// (fleet_overlay_internal_test.go) proves prescopeFleetOverlay's own
 	// nil-resolver decision in isolation, calling it directly on a

--- a/test/integration/kubernautagent/investigator/fleet_resource_context_it_test.go
+++ b/test/integration/kubernautagent/investigator/fleet_resource_context_it_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/tools/custom"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+	"github.com/jordigilh/kubernaut/pkg/shared/hash"
+)
+
+// Issue #2306, work-stream 2: resourceContextTools (get_namespaced_resource_context /
+// get_cluster_resource_context) are fleet-agnostic by name -- unlike kubectl_*, they
+// are never suppressed from the LLM's schema -- but their Execute() must still resolve
+// owner-chain/spec-hash/remediation-history against the investigation's *target*
+// cluster, not the hub KA runs on. These two ITs prove that internal routing through
+// the real Investigate() entry point, mirroring cluster_scoping_1802_test.go's
+// established "real DS/Postgres through the full journey" pattern for this package.
+// fleetOverlayResolverSpy (fleet_prescoping_test.go, same package) supplies the
+// FleetOverlayResolver double.
+var _ = Describe("Fleet-aware resourceContextTools (BR-INTEGRATION-1489, Issue #2306)", Label("fleet", "integration"), func() {
+
+	var (
+		invLogger logr.Logger
+	)
+
+	BeforeEach(func() {
+		invLogger = logr.Discard()
+	})
+
+	Describe("IT-KA-FLEET-032 [AC-4/AC-6]: get_namespaced_resource_context resolves against the target cluster, never the hub", func() {
+		It("returns the fleet overlay's owner-chain result and never the hub-bound K8sClient's", func() {
+			auditStore := newCapturingAuditStore(suiteAuditStore)
+
+			// Hub-bound K8sClient: fixed, unrelated owner chain. If Execute() ever
+			// fell through to this client for a fleet-target investigation, its
+			// name would leak into the tool result asserted on below.
+			hubK8s := &k8sFixtureClient{ownerChain: []enrichment.OwnerChainEntry{
+				{Kind: "Deployment", Name: "hub-should-not-appear", Namespace: "production"},
+			}}
+
+			reg := registry.New()
+			custom.RegisterAll(reg, nil, auditStore, suiteDSAdapter, hubK8s, invLogger)
+
+			overlayGetTool := &fakeTool{name: "resources_get", result: `{"apiVersion":"apps/v1","kind":"Deployment",` +
+				`"metadata":{"name":"remote-deployment","namespace":"remote-ns"}}`}
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{"resources_get": overlayGetTool}}
+
+			mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+				{
+					Message: llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{{ID: "tc_ctx", Name: "get_namespaced_resource_context",
+						Arguments: `{"kind":"Deployment","name":"remote-deployment","namespace":"remote-ns"}`}},
+				},
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
+				{
+					Message:   llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{{ID: "tc_wf1", Name: "list_available_actions", Arguments: `{}`}},
+				},
+				{
+					Message: llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled"},"reasoning":"none"}`},
+					},
+				},
+			}}
+			enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+			builder, berr := prompt.NewBuilder()
+			Expect(berr).ToNot(HaveOccurred())
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: reg,
+				FleetOverlayResolver: spy,
+			})
+
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "remote-deployment", Namespace: "remote-ns", ResourceKind: "Deployment", ResourceName: "remote-deployment",
+				ClusterID: "remote-east", RemediationID: "rem-2306-032",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 2))
+
+			toolResultContent := allMessageContent(mockClient.calls[1].Messages)
+			Expect(toolResultContent).To(ContainSubstring("remote-deployment"),
+				"IT-KA-FLEET-032: get_namespaced_resource_context must resolve the owner chain against the "+
+					"target cluster's own resources_get tool, not fall through to the hub")
+			Expect(toolResultContent).NotTo(ContainSubstring("hub-should-not-appear"),
+				"IT-KA-FLEET-032: the hub-bound K8sClient must never be consulted for a fleet-target "+
+					"investigation (AC-6: LLM must only see data for the cluster it was asked about)")
+		})
+	})
+
+	Describe("IT-KA-FLEET-033 [AU-3]: get_namespaced_resource_context scopes remediation history by the target clusterID", func() {
+		It("must not leak cluster-a's remediation history into cluster-b's tool result for an identically-named/-spec'd target", func() {
+			testID := uuid.New().String()[:8]
+			ns := "remote-ns"
+			kind := "Deployment"
+			name := "app-2306-" + testID
+			target := fmt.Sprintf("%s/%s/%s", ns, kind, name)
+			clusterA := "cluster-a-" + testID
+			clusterB := "cluster-b-" + testID
+			corrA := "corr-2306-a-" + testID
+
+			overlayJSON := fmt.Sprintf(`{"apiVersion":"apps/v1","kind":%q,"metadata":{"name":%q,"namespace":%q}}`, kind, name, ns)
+
+			// The spec hash the fleet overlay path will compute for overlayJSON
+			// (via overlayK8sClient.GetSpecHash -> hash.CanonicalResourceFingerprint),
+			// so the seeded row's pre_remediation_spec_hash lines up with what
+			// fetchRemediationHistory actually queries with -- mirroring
+			// cluster_scoping_1802_test.go's use of the fixture K8sClient's fixed
+			// sha256FixtureHash for the hub-local case.
+			var overlayObj map[string]interface{}
+			Expect(json.Unmarshal([]byte(overlayJSON), &overlayObj)).To(Succeed())
+			specHash, hErr := hash.CanonicalResourceFingerprint(overlayObj)
+			Expect(hErr).ToNot(HaveOccurred())
+
+			By("Seeding cluster-a's remediation history for the shared target + spec hash directly in Postgres")
+			eventData, err := json.Marshal(map[string]interface{}{
+				"target_resource":           target,
+				"pre_remediation_spec_hash": specHash,
+				"action_type":               "IncreaseMemory",
+				"signal_type":               "OOMKilled",
+				"signal_fingerprint":        "fp-2306-" + testID,
+				"outcome":                   "success",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			ts := time.Now().Add(-1 * time.Hour)
+			_, err = seedDB.ExecContext(context.Background(),
+				`INSERT INTO audit_events (
+					event_id, event_date, event_timestamp, event_type, event_version,
+					event_category, event_action, event_outcome, correlation_id,
+					resource_type, resource_id, actor_id, actor_type,
+					retention_days, is_sensitive, event_data, cluster_id
+				) VALUES (
+					$1, $2, $3, 'remediation.workflow_created', '1.0',
+					'remediation', 'create', 'success', $4,
+					'test', 'test', 'test', 'system',
+					90, false, $5, $6
+				)`,
+				uuid.New(), ts.Format("2006-01-02"), ts, corrA, eventData, clusterA,
+			)
+			Expect(err).ToNot(HaveOccurred(), "seeding cluster-a's remediation history must succeed")
+
+			newInvestigation := func(clusterID string) *mockLLMClient {
+				auditStore := newCapturingAuditStore(suiteAuditStore)
+				hubK8s := &k8sFixtureClient{}
+				reg := registry.New()
+				custom.RegisterAll(reg, nil, auditStore, suiteDSAdapter, hubK8s, invLogger)
+
+				overlayGetTool := &fakeTool{name: "resources_get", result: overlayJSON}
+				spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{"resources_get": overlayGetTool}}
+
+				mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_ctx", Name: "get_namespaced_resource_context",
+							Arguments: fmt.Sprintf(`{"kind":%q,"name":%q,"namespace":%q}`, kind, name, ns)}},
+					},
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_wf1", Name: "list_available_actions", Arguments: `{}`}},
+					},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled"},"reasoning":"none"}`},
+						},
+					},
+				}}
+				enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+				builder, berr := prompt.NewBuilder()
+				Expect(berr).ToNot(HaveOccurred())
+				rp := parser.NewResultParser()
+
+				inv := investigator.New(investigator.Config{
+					Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+					AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+					PhaseTools: investigator.DefaultPhaseToolMap(), Registry: reg,
+					FleetOverlayResolver: spy,
+				})
+
+				_, ierr := inv.Investigate(context.Background(), katypes.SignalContext{
+					Name: name, Namespace: ns, ResourceKind: kind, ResourceName: name,
+					ClusterID: clusterID, RemediationID: "rem-2306-033-" + clusterID,
+				})
+				Expect(ierr).NotTo(HaveOccurred())
+				return mockClient
+			}
+
+			By("Investigating cluster-b's identically-named/-namespaced/-spec'd resource via get_namespaced_resource_context")
+			mockClientB := newInvestigation(clusterB)
+			Expect(len(mockClientB.calls)).To(BeNumerically(">=", 2))
+			toolResultB := allMessageContent(mockClientB.calls[1].Messages)
+			Expect(toolResultB).NotTo(ContainSubstring(corrA),
+				"IT-KA-FLEET-033: cluster-b's get_namespaced_resource_context result must NOT contain "+
+					"cluster-a's remediation history for an identically-named/-spec'd resource -- clusterID "+
+					"must scope the DS query end to end, from the tool's Execute() through the real "+
+					"DataStorage/Postgres query")
+
+			By("Sanity: cluster-a's own investigation DOES see its own history in the tool result")
+			mockClientA := newInvestigation(clusterA)
+			Expect(len(mockClientA.calls)).To(BeNumerically(">=", 2))
+			toolResultA := allMessageContent(mockClientA.calls[1].Messages)
+			Expect(toolResultA).To(ContainSubstring(corrA),
+				"cluster-a's own matching ClusterID history must still reach its tool result (zero regression)")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

For a fleet-target investigation, local client-go/dynamic-client-backed tools (`kubectl_get_by_name`, `kubectl_logs`, `kubectl_top_pods`, node-proxy tools) were still advertised to and executable by the LLM. With no same-named overlay override, calling one silently queried the hub cluster instead of the target cluster — an AC-6 violation.

`resourceContextTools` (`get_namespaced_resource_context`/`get_cluster_resource_context`) had the same problem one layer down: owner-chain/spec-hash resolution and remediation-history lookups were hub-bound/unscoped regardless of the investigation's target cluster.

## Business Requirement

BR-INTEGRATION-1489, DD-FLEET-005 (amended), AC-6.

## Changes

- `toolDefinitionsForPhase()` now subtractively excludes local k8s/metrics/node-proxy tools from the LLM's schema for a fleet-target investigation unless the overlay provides a same-named override.
- `executeResolved()` now enforces the same suppression at execution time, not just at the schema level. Advertisement-only suppression left a gap: a suppressed name called anyway (schema drift across turns, hallucination, adversarial input) still fell through to `inv.registry.Execute()` and ran against the hub. This closes that.
- `resourceContextTools` now resolve against the correct cluster: a new `overlayK8sClient`/`overlayClientReader` (built on `resources_get`) handle owner-chain and spec-hash resolution for a fleet-target investigation, and `fetchRemediationHistory` threads the actual cluster ID instead of an unscoped `""`.
- Moved Gateway's `K8sOwnerResolver` to `pkg/shared/k8s/ownerchain` so both Gateway and KubernautAgent share one tested implementation instead of KA reimplementing owner-chain walking or cross-importing Gateway internals. Extracted a minimal `KindResolver` interface so the move didn't require changes to Gateway's own `APIResourceRegistry`.
- Exported `mcpclient.ParseUnstructuredResponse`/`PopulateObject` (mechanical renames, no behavior change) so `overlayClientReader` can reuse them.

Out of scope: full RESTMapper-equivalent remote discovery for unlisted CRD kinds through the overlay path — `overlayK8sClient` covers core/apps/batch kinds and returns a clear error otherwise. Tracked as a follow-up if a real investigation needs it.

## Test Plan

- [x] Unit tests pass (`go test ./internal/kubernautagent/investigator/... ./pkg/shared/k8s/ownerchain/... ./pkg/fleet/mcpclient/...`)
- [x] Integration + E2E tests pass on real Docker infra (150/150 specs, `test/integration/kubernautagent/investigator/...`), including new `IT-KA-FLEET-035` proving the execution-time block and `E2E-KA-FLEET-003` proving schema exclusion
- [x] `go build ./...` succeeds
- [x] `golangci-lint run` passes on changed packages
- [x] Zero regression across existing fleet suppression/resolution tests (`IT-KA-FLEET-010` through `033`)

## Checklist

- [x] Tests written following TDD (RED-GREEN-REFACTOR)
- [x] All errors handled and logged
- [x] Documentation updated (DD-FLEET-005 amendment)
- [x] No breaking changes

Closes #2306