### PR TITLE
fix(apifrontend): surface workflow_id during Analyzing, not just Executing

### DIFF
--- a/docs/architecture/decisions/DD-AF-008-status-subscribe-sse.md
+++ b/docs/architecture/decisions/DD-AF-008-status-subscribe-sse.md
@@ -75,15 +75,32 @@ Metadata uses raw CRD field names. The console computes derived values.
 
 | Phase | Metadata fields |
 |-------|----------------|
-| Pending, Processing, Analyzing, Cancelled | (none) |
-| AwaitingApproval | approval_request_name |
+| Pending, Processing, Cancelled | (none) |
+| Analyzing | workflow_id (once selected) |
+| AwaitingApproval | workflow_id, approval_request_name |
 | Executing | workflow_id, started_at |
-| Verifying | verification_deadline, started_at, ea_phase, stabilization_deadline |
-| Blocked | blocked_until, block_reason, block_message |
-| Completed | outcome |
-| Failed | failure_reason, failure_phase |
-| TimedOut | failure_phase |
-| Skipped | skip_reason |
+| Verifying | workflow_id, verification_deadline, started_at, ea_phase, stabilization_deadline |
+| Blocked | workflow_id, blocked_until, block_reason, block_message |
+| Completed | workflow_id, outcome |
+| Failed | workflow_id, failure_reason, failure_phase |
+| TimedOut | workflow_id, failure_phase |
+| Skipped | workflow_id, skip_reason |
+
+`workflow_id` is phase-independent (#2325): `BuildPhaseMetadata` sets it
+whenever `status.workflowSelection.selectedWorkflowRef` is non-nil,
+regardless of `OverallPhase`, rather than only for `Executing`. Selection
+completes during `Analyzing` -- tens of seconds before the phase transitions
+-- so gating the field on a later phase silently dropped it from the
+console's Analyzing-phase display.
+
+### RR Sub-Field Events Independent of Phase
+
+The stream also emits `status/update` with the *same* `phase` value when a
+tracked sub-field changes without an `OverallPhase` transition -- currently
+only `status.workflowSelection.selectedWorkflowRef`. This mirrors the EA
+sub-phase pattern below (same phase, updated metadata) and prevents a
+selection that lands mid-phase from being silently dropped until the next
+phase change (#2325).
 
 ### EA Sub-Phase Events During Verifying
 

--- a/docs/testing/2325/TEST_PLAN.md
+++ b/docs/testing/2325/TEST_PLAN.md
@@ -1,0 +1,114 @@
+# Test Plan: AF status/subscribe drops workflow-selection update during Analyzing
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut (lightweight variant for a
+> single-package bug fix; see `docs/testing/TEST_PLAN_TEMPLATE.md` for the full template)
+
+**Test Plan Identifier**: TP-2325-v1.0
+**Feature**: Fix two compounding bugs in the AF `status/subscribe` SSE stream that silently
+drop the workflow-selection update while `OverallPhase` stays `Analyzing`
+**Version**: 1.0
+**Created**: 2026-08-31
+**Status**: Active
+**Branch**: `fix/2325-af-status-stream-workflow-selection-drop`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+The Console's investigation view stays blank on `workflow_id` until `OverallPhase` reaches
+`Executing`, even though workflow selection completes tens of seconds earlier while the RR is
+still `Analyzing`. Two compounding bugs in `pkg/apifrontend/handler/` cause this: the SSE loop
+only emits on phase change, and the metadata builder only sets `workflow_id` for the `Executing`
+phase. This plan proves both bugs are fixed and guards against the SSE stream emitting spurious
+duplicate events as a side effect of loosening the emission gate.
+
+### 1.2 Objectives
+
+1. **workflow_id is phase-independent**: `BuildPhaseMetadata` returns `workflow_id` whenever
+   `status.workflowSelection.selectedWorkflowRef` is set, regardless of `OverallPhase`.
+2. **Selection changes emit mid-phase**: the `status/subscribe` SSE loop emits a `status/update`
+   when `status.workflowSelection` changes even if `OverallPhase` does not.
+3. **No regression**: a true no-op RR touch (neither phase nor workflow selection changed) must
+   not emit a spurious extra `status/update` event.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `make test-unit-apifrontend` |
+| Integration test pass rate | 100% | `make test-integration-apifrontend` |
+| E2E test pass rate (regression) | 100% | `make test-e2e-apifrontend` |
+| Backward compatibility | 0 regressions | Full `pkg/apifrontend/...` and `test/integration/apifrontend/...` suites pass unmodified |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- BR-API-008: workflow status tracking and real-time updates
+- [DD-AF-008](../../architecture/decisions/DD-AF-008-status-subscribe-sse.md): `status/subscribe` SSE contract (Per-Phase Metadata table + RR Sub-Field Events section updated by this fix)
+- Issue #2325: AF status stream drops the workflow-selection update
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Loosening the emission gate (phase OR workflow-ID change) causes duplicate/spurious `status/update` events on unrelated RR touches | Console re-renders unnecessarily; SSE bandwidth waste | Medium | IT-AF-2325-002 | Explicit regression-guard IT asserting a genuine no-op touch produces zero extra events |
+| R2 | `workflow_id` promoted to the phase-independent block leaks into phases where it was previously absent by design (e.g. `Blocked`) | Console displays a field it didn't expect for that phase | Low | UT-AF-2325-002, full `status_types_test.go` regression run | `workflow_id` is additive metadata (raw CRD field passthrough per DD-AF-008); existing per-phase tests for other phases assert exact keys present and continue to pass, proving no unexpected key removal/shape change elsewhere |
+
+### 3.1 Risk-to-Test Traceability
+
+R1 -> IT-AF-2325-002. R2 -> UT-AF-2325-002 plus full existing `status_types_test.go` suite (regression, unmodified).
+
+---
+
+## 4. Test Scenarios
+
+### 4.1 Unit Tests (`pkg/apifrontend/handler/status_types_test.go`)
+
+| Test ID | Scenario | FedRAMP Control | Assertion |
+|---------|----------|-----------------|-----------|
+| UT-AF-2325-001 | `Analyzing` phase + `workflowSelection.selectedWorkflowRef` set | SI-4 (monitoring) | `BuildPhaseMetadata` returns `workflow_id` |
+| UT-AF-2325-002 | `Analyzing` phase, no selection yet | SI-10 (input validation / no fabricated data) | `BuildPhaseMetadata` omits `workflow_id` |
+
+### 4.2 Integration Tests (`test/integration/apifrontend/status_subscribe_test.go`, envtest)
+
+| Test ID | Scenario | FedRAMP Control | Assertion |
+|---------|----------|-----------------|-----------|
+| IT-AF-2325-001 | RR created as `Analyzing`; `workflowSelection` populated mid-stream, phase unchanged | SI-4 | A second `status/update` event is received with `phase: "Analyzing"` and `metadata.workflow_id` set |
+| IT-AF-2325-002 | RR created as `Analyzing`; unrelated status field touched (no phase/selection change), then a real `Executing` transition | SI-4 (regression guard) | Exactly one event for the no-op window (zero extra), followed by exactly one `Executing` event |
+
+### 4.3 E2E (regression only, no new scenarios)
+
+This is a bug fix to an existing, well-covered endpoint — no new user journey is introduced, so
+no new E2E specs are added. `make test-e2e-apifrontend` (AF's dedicated Kind-cluster E2E suite,
+which already exercises `/a2a/status` SSE streaming) is run as a regression gate to confirm the
+loosened emission gate does not destabilize the live SSE path end-to-end.
+
+---
+
+## 5. Environment
+
+- **Unit + Integration**: local envtest (`KUBEBUILDER_ASSETS` via `setup-envtest`), run on the
+  dedicated helios08 host (`/root/kubernaut-2325`) due to local sandbox Podman/image-build
+  resource constraints.
+- **E2E**: Kind cluster on helios08, per `make test-e2e-apifrontend` (`test/e2e/apifrontend/...`).
+
+---
+
+## 6. Completion Criteria
+
+- [x] UT-AF-2325-001, UT-AF-2325-002 pass (`make test-unit-apifrontend` / local `go test`)
+- [ ] IT-AF-2325-001, IT-AF-2325-002 pass (`make test-integration-apifrontend` on helios08)
+- [ ] `make test-e2e-apifrontend` passes with zero regressions on helios08
+- [x] `go build ./...`, `golangci-lint run` clean on changed packages
+- [x] DD-AF-008 Per-Phase Metadata table and lifecycle notes updated

--- a/pkg/apifrontend/handler/status_handler.go
+++ b/pkg/apifrontend/handler/status_handler.go
@@ -65,15 +65,16 @@ func (h *StatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // event loop for a single status/subscribe connection (RR + EA watch
 // progress, diff baseline, and terminal-phase tracking).
 type subscribeStreamState struct {
-	ea                *eav1alpha1.EffectivenessAssessment
-	prevEA            *eav1alpha1.EffectivenessAssessment
-	rrWatcher         watch.Interface
-	eaWatcher         watch.Interface
-	eaCh              <-chan watch.Event
-	rrResourceVersion string
-	eaResourceVersion string
-	lastSeenPhase     string
-	isFinal           bool
+	ea                 *eav1alpha1.EffectivenessAssessment
+	prevEA             *eav1alpha1.EffectivenessAssessment
+	rrWatcher          watch.Interface
+	eaWatcher          watch.Interface
+	eaCh               <-chan watch.Event
+	rrResourceVersion  string
+	eaResourceVersion  string
+	lastSeenPhase      string
+	lastSeenWorkflowID string
+	isFinal            bool
 }
 
 // subscribeCleanup accumulates resource-cleanup closures (watch.Interface.Stop,
@@ -196,9 +197,10 @@ func writeSSEHeaders(w http.ResponseWriter) {
 func (h *StatusHandler) initSubscribeState(ctx context.Context, rr *remediationv1.RemediationRequest) *subscribeStreamState {
 	phase := string(rr.Status.OverallPhase)
 	st := &subscribeStreamState{
-		lastSeenPhase:     phase,
-		rrResourceVersion: rr.ResourceVersion,
-		isFinal:           tools.IsTerminalPhase(phase),
+		lastSeenPhase:      phase,
+		lastSeenWorkflowID: selectedWorkflowID(rr),
+		rrResourceVersion:  rr.ResourceVersion,
+		isFinal:            tools.IsTerminalPhase(phase),
 	}
 	if phase == string(remediationv1.PhaseVerifying) {
 		st.ea = h.fetchEA(ctx, rr)
@@ -313,10 +315,18 @@ func (h *StatusHandler) handleRRWatchEvent(
 	}
 	st.rrResourceVersion = rrObj.ResourceVersion
 	newPhase := string(rrObj.Status.OverallPhase)
-	if newPhase == st.lastSeenPhase {
+	newWorkflowID := selectedWorkflowID(rrObj)
+	// #2325: RCA, workflow discovery, selection, and target-alignment-gate
+	// validation all happen while OverallPhase stays "Analyzing" -- gating
+	// solely on phase equality silently dropped the selection update for
+	// the ~80s window before the phase actually moved. Also emit when
+	// status.workflowSelection changes, mirroring how the EA watch loop
+	// already emits on sub-field changes without requiring a phase change.
+	if newPhase == st.lastSeenPhase && newWorkflowID == st.lastSeenWorkflowID {
 		return true
 	}
 	st.lastSeenPhase = newPhase
+	st.lastSeenWorkflowID = newWorkflowID
 
 	if newPhase == string(remediationv1.PhaseVerifying) && st.eaCh == nil {
 		h.bootstrapEAWatch(ctx, rrObj, st, lc.Cleanup)
@@ -327,6 +337,17 @@ func (h *StatusHandler) handleRRWatchEvent(
 	h.writeStatusUpdate(lc.W, lc.Flusher, lc.Req.Params.RRID, newPhase, st.isFinal, meta)
 
 	return !st.isFinal
+}
+
+// selectedWorkflowID returns the currently-selected workflow ID, or "" if
+// none has been selected yet. Used to detect a workflow-selection change
+// independently of OverallPhase (#2325).
+func selectedWorkflowID(rr *remediationv1.RemediationRequest) string {
+	sel := rr.Status.GetWorkflowSelection()
+	if sel == nil || sel.SelectedWorkflowRef == nil {
+		return ""
+	}
+	return sel.SelectedWorkflowRef.WorkflowID
 }
 
 // bootstrapEAWatch starts the EA watch when the RR first transitions into

--- a/pkg/apifrontend/handler/status_types.go
+++ b/pkg/apifrontend/handler/status_types.go
@@ -77,6 +77,13 @@ func BuildPhaseMetadata(rr *remediationv1.RemediationRequest, ea *eav1alpha1.Eff
 	if rr.Spec.SignalName != "" {
 		meta["alert_name"] = rr.Spec.SignalName
 	}
+	// #2325: workflow_id is phase-independent -- selection completes while
+	// OverallPhase is still "Analyzing", tens of seconds before it moves to
+	// "Executing". Surface it as soon as it exists rather than gating on a
+	// later phase (SI-4).
+	if wf := rr.Status.GetWorkflowSelection().SelectedWorkflowRef; wf != nil {
+		meta["workflow_id"] = wf.WorkflowID
+	}
 
 	addPhaseSpecificMetadata(meta, rr, ea)
 
@@ -122,10 +129,8 @@ func addPhaseSpecificMetadata(meta map[string]any, rr *remediationv1.Remediation
 }
 
 // addExecutingPhaseMetadata populates phase metadata for PhaseExecuting.
+// workflow_id is set unconditionally in BuildPhaseMetadata (#2325), not here.
 func addExecutingPhaseMetadata(meta map[string]any, rr *remediationv1.RemediationRequest) {
-	if wf := rr.Status.GetWorkflowSelection().SelectedWorkflowRef; wf != nil {
-		meta["workflow_id"] = wf.WorkflowID
-	}
 	if st := rr.Status.GetPhaseProgress().ExecutingStartTime; st != nil {
 		meta["started_at"] = st.Format(time.RFC3339)
 	}

--- a/pkg/apifrontend/handler/status_types_test.go
+++ b/pkg/apifrontend/handler/status_types_test.go
@@ -210,6 +210,39 @@ var _ = Describe("BuildPhaseMetadata", func() {
 		Expect(meta).To(HaveKey("started_at"))
 	})
 
+	It("UT-AF-2325-001: Analyzing phase surfaces workflow_id once selected (SI-4)", func() {
+		rr := &remediationv1.RemediationRequest{
+			Status: remediationv1.RemediationRequestStatus{
+				OverallPhase: remediationv1.PhaseAnalyzing,
+				WorkflowSelection: &remediationv1.WorkflowSelection{
+					SelectedWorkflowRef: &remediationv1.WorkflowReference{
+						WorkflowID: "crashloop-rollback-v1",
+					},
+				},
+			},
+		}
+
+		meta := handler.BuildPhaseMetadata(rr, nil)
+
+		Expect(meta).To(HaveKeyWithValue("workflow_id", "crashloop-rollback-v1"),
+			"SI-4 (#2325): workflow_id must surface as soon as status.workflowSelection is "+
+				"populated, not only once OverallPhase reaches Executing -- selection can "+
+				"complete tens of seconds before the phase transitions away from Analyzing")
+	})
+
+	It("UT-AF-2325-002: Analyzing phase omits workflow_id when no workflow selected yet (SI-10)", func() {
+		rr := &remediationv1.RemediationRequest{
+			Status: remediationv1.RemediationRequestStatus{
+				OverallPhase: remediationv1.PhaseAnalyzing,
+			},
+		}
+
+		meta := handler.BuildPhaseMetadata(rr, nil)
+
+		Expect(meta).NotTo(HaveKey("workflow_id"),
+			"SI-10: must not fabricate a workflow_id before selection has actually happened")
+	})
+
 	It("UT-AF-1460-008: terminal phases return outcome/failure_reason/skip_reason", func() {
 		rr := &remediationv1.RemediationRequest{
 			Status: remediationv1.RemediationRequestStatus{

--- a/test/integration/apifrontend/status_subscribe_test.go
+++ b/test/integration/apifrontend/status_subscribe_test.go
@@ -577,4 +577,85 @@ var _ = Describe("status/subscribe SSE endpoint (IT)", func() {
 		}
 		Expect(found).To(BeTrue(), "must receive Executing event with both context and phase metadata")
 	})
+
+	It("IT-AF-2325-001: workflow selection during Analyzing emits status/update without a phase change (SI-4)", func() {
+		rr := createTestRR(ctx, "rr-analyzing-select", testNS, "Analyzing")
+		defer cleanupTestRR(ctx, rr.Name, testNS)
+
+		resp, err := http.Post(statusSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		time.Sleep(200 * time.Millisecond)
+		Expect(k8sClient.Get(ctx, crclient.ObjectKeyFromObject(rr), rr)).To(Succeed())
+		// OverallPhase deliberately left as "Analyzing" -- RCA, discovery, and
+		// selection all happen under this single phase value (#2325).
+		rr.Status.EnsureWorkflowSelection().SelectedWorkflowRef = &remediationv1.WorkflowReference{
+			WorkflowID: "crashloop-rollback-v1",
+		}
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+		events := collectSSEEvents(resp, 2, 5*time.Second)
+		Expect(len(events)).To(BeNumerically(">=", 2),
+			"#2325: must receive a second status/update once workflowSelection is populated, "+
+				"even though OverallPhase is still Analyzing")
+
+		var found bool
+		for _, evt := range events {
+			var data map[string]any
+			if json.Unmarshal([]byte(evt.Data), &data) != nil {
+				continue
+			}
+			inner, _ := data["params"].(map[string]any)
+			if inner == nil || inner["phase"] != "Analyzing" {
+				continue
+			}
+			meta, _ := inner["metadata"].(map[string]any)
+			if meta != nil && meta["workflow_id"] == "crashloop-rollback-v1" {
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue(),
+			"SI-4 (#2325): must receive an Analyzing-phase event carrying workflow_id once selected")
+	})
+
+	It("IT-AF-2325-002: unrelated RR touch with no phase or workflow-selection change emits no extra event (regression guard)", func() {
+		rr := createTestRR(ctx, "rr-analyzing-noop", testNS, "Analyzing")
+		defer cleanupTestRR(ctx, rr.Name, testNS)
+
+		resp, err := http.Post(statusSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		// Baseline: exactly 1 event (current-state on subscribe).
+		baseline := collectSSEEvents(resp, 1, 5*time.Second)
+		Expect(baseline).To(HaveLen(1))
+
+		time.Sleep(200 * time.Millisecond)
+		Expect(k8sClient.Get(ctx, crclient.ObjectKeyFromObject(rr), rr)).To(Succeed())
+		// Bump resourceVersion via an unrelated status field; phase and
+		// workflowSelection are both unchanged, so this must not emit.
+		now := metav1.Now()
+		rr.Status.EnsurePhaseProgress().AnalyzingStartTime = &now
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+		// Follow up with a real, expected transition so we have a positive
+		// signal that the stream is still alive and not just stalled.
+		time.Sleep(200 * time.Millisecond)
+		Expect(k8sClient.Get(ctx, crclient.ObjectKeyFromObject(rr), rr)).To(Succeed())
+		rr.Status.OverallPhase = remediationv1.PhaseExecuting
+		rr.Status.EnsureWorkflowSelection().SelectedWorkflowRef = &remediationv1.WorkflowReference{WorkflowID: "restart-v1"}
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+		events := collectSSEEvents(resp, 1, 5*time.Second)
+		Expect(events).To(HaveLen(1), "regression guard: only the Executing transition must be "+
+			"emitted -- the earlier no-op AnalyzingStartTime touch must not produce a duplicate event")
+
+		var data map[string]any
+		Expect(json.Unmarshal([]byte(events[0].Data), &data)).To(Succeed())
+		inner, _ := data["params"].(map[string]any)
+		Expect(inner["phase"]).To(Equal("Executing"))
+	})
 })


### PR DESCRIPTION
## Summary

Two compounding bugs silently dropped the workflow-selection update from the `status/subscribe` SSE stream:

- `handleRRWatchEvent` only emitted `status/update` on an `OverallPhase` change, so an RR mutation that only populated `WorkflowSelection` (no phase change) was dropped.
- `BuildPhaseMetadata` only set `workflow_id` inside the `PhaseExecuting` case, but selection completes tens of seconds before the phase actually moves to `Executing`.

Net effect: the Console's investigation view stayed blank on `workflow_id` until `Executing`, even though the workflow had already been selected.

Fix: emit `status/update` on a `workflowSelection` change independently of phase (mirrors the existing EA sub-phase pattern), and make `workflow_id` phase-independent metadata, keyed off `WorkflowSelection.SelectedWorkflowRef != nil` rather than the phase switch.

Closes #2325.

## Changes

- `pkg/apifrontend/handler/status_handler.go`: track `lastSeenWorkflowID` in `subscribeStreamState`; emit on workflow-selection change in addition to phase change.
- `pkg/apifrontend/handler/status_types.go`: promote `workflow_id` out of `addExecutingPhaseMetadata` into `BuildPhaseMetadata`'s phase-independent block.
- `docs/architecture/decisions/DD-AF-008-status-subscribe-sse.md`: updated per-phase metadata table and added explanatory notes on the phase-independent behavior.
- `docs/testing/2325/TEST_PLAN.md`: lightweight test plan for this fix.

## Test plan

- UT (`status_types_test.go`): `UT-AF-2325-001`/`002` prove `workflow_id` surfaces during `Analyzing` once selected, and is omitted when not yet selected. BR-API-008, FedRAMP SI-4/SI-10.
- IT (`status_subscribe_test.go`): `IT-AF-2325-001` proves a workflow-selection-only RR update emits `status/update` without a phase change; `IT-AF-2325-002` is a regression guard proving an unrelated no-op RR touch still emits zero extra events.
- All UT + IT green, run both locally and on a dedicated E2E host (`helios08`).
- E2E (`test-e2e-apifrontend`) hit `context deadline exceeded` on the DEX token endpoint on that host under load. Ran a control suite against unmodified `main` on the same host and got the identical failure signature, and confirmed DEX itself issues tokens correctly (200 OK, valid JWT) once queried with the right credentials outside the loaded suite -- this points to bcrypt-verification latency under this host's CPU contention exceeding the test's context deadline, not a regression from this change. Not something CI's isolated runners would hit.