### PR TITLE
fix(audit): lowercase actor_type (#2317) + verify-chain false positives / write-path fork (#2318)

### DIFF
--- a/docs/tests/533/TEST_PLAN.md
+++ b/docs/tests/533/TEST_PLAN.md
@@ -192,7 +192,7 @@ Format: `{TIER}-{SERVICE}-{ISSUE_NUMBER}-{SEQUENCE}`
 **Acceptance Criteria**:
 - All 8 ADR-034 envelope fields are present and non-None
 - `event_category` matches the HAPI service constant ("aiagent")
-- `actor_type` == "Service" and `actor_id` == "kubernaut-agent"
+- `actor_type` == "service" and `actor_id` == "kubernaut-agent"
 
 ---
 
@@ -293,7 +293,7 @@ Format: `{TIER}-{SERVICE}-{ISSUE_NUMBER}-{SEQUENCE}`
 - `event_type` == "aiagent.enrichment.failed"
 - `event_action` == "enrichment_failed"
 - `event_outcome` == "failure"
-- `actor_type` == "Service"
+- `actor_type` == "service"
 - `actor_id` == "kubernaut-agent"
 
 **Acceptance Criteria**:

--- a/internal/kubernautagent/audit/coverage_668_test.go
+++ b/internal/kubernautagent/audit/coverage_668_test.go
@@ -33,7 +33,8 @@ import (
 
 // goconst dedup: test-fixture literals deduplicated below.
 const (
-	testModel = "test-model"
+	testModel         = "test-model"
+	testPromptPreview = "ping"
 )
 
 // batchSpy implements pkg/audit.DataStorageClient for buffered store tests (BR-AI-056 audit trail).
@@ -165,7 +166,7 @@ var _ = Describe("Kubernaut Agent audit coverage 668 (BR-KA-197 DD-AUDIT-002)", 
 			event.EventOutcome = audit.OutcomeSuccess
 			event.Data["model"] = testModel
 			event.Data["prompt_length"] = 4
-			event.Data["prompt_preview"] = "ping"
+			event.Data["prompt_preview"] = testPromptPreview
 
 			Expect(store.StoreAudit(context.Background(), event)).To(Succeed())
 			Expect(store.Close()).To(Succeed())
@@ -174,6 +175,51 @@ var _ = Describe("Kubernaut Agent audit coverage 668 (BR-KA-197 DD-AUDIT-002)", 
 			Expect(batch).To(HaveLen(1))
 			Expect(batch[0].EventType).To(Equal(audit.EventTypeLLMRequest))
 			Expect(batch[0].CorrelationID).To(Equal("corr-buf-668"))
+		})
+
+		It("UT-KA-2317-001: defaults ActorType=service and ActorID=kubernaut-agent (ADR-034 lowercase convention)", func() {
+			spy := &batchSpy{}
+			store, err := audit.NewBufferedDSAuditStore(spy, logr.Discard(), audit.WithBatchSize(1))
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = store.Close() }()
+
+			event := audit.NewEvent(audit.EventTypeLLMRequest, "corr-2317-default")
+			event.EventAction = audit.ActionLLMRequest
+			event.EventOutcome = audit.OutcomeSuccess
+			event.Data["model"] = testModel
+			event.Data["prompt_length"] = 4
+			event.Data["prompt_preview"] = testPromptPreview
+
+			Expect(store.StoreAudit(context.Background(), event)).To(Succeed())
+			Expect(store.Flush(context.Background())).To(Succeed())
+
+			batch := spy.lastBatch()
+			Expect(batch).To(HaveLen(1))
+			Expect(batch[0].ActorType.Value).To(Equal("service"))
+			Expect(batch[0].ActorID.Value).To(Equal("kubernaut-agent"))
+		})
+
+		It("UT-KA-2317-002: sets ActorType=user and ActorID=ActingUser when ActingUser is set", func() {
+			spy := &batchSpy{}
+			store, err := audit.NewBufferedDSAuditStore(spy, logr.Discard(), audit.WithBatchSize(1))
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = store.Close() }()
+
+			event := audit.NewEvent(audit.EventTypeLLMRequest, "corr-2317-user")
+			event.EventAction = audit.ActionLLMRequest
+			event.EventOutcome = audit.OutcomeSuccess
+			event.ActingUser = "jane@example.com"
+			event.Data["model"] = testModel
+			event.Data["prompt_length"] = 4
+			event.Data["prompt_preview"] = testPromptPreview
+
+			Expect(store.StoreAudit(context.Background(), event)).To(Succeed())
+			Expect(store.Flush(context.Background())).To(Succeed())
+
+			batch := spy.lastBatch()
+			Expect(batch).To(HaveLen(1))
+			Expect(batch[0].ActorType.Value).To(Equal("user"))
+			Expect(batch[0].ActorID.Value).To(Equal("jane@example.com"))
 		})
 
 		It("Flush pushes buffered events to DataStorage without closing the worker", func() {

--- a/internal/kubernautagent/audit/ds_buffered_store.go
+++ b/internal/kubernautagent/audit/ds_buffered_store.go
@@ -98,10 +98,10 @@ func (s *BufferedDSAuditStore) StoreAudit(ctx context.Context, event *AuditEvent
 		CorrelationID:  event.CorrelationID,
 	}
 	if event.ActingUser != "" {
-		req.ActorType.SetTo("User")
+		req.ActorType.SetTo("user")
 		req.ActorID.SetTo(event.ActingUser)
 	} else {
-		bActorType := "Service"
+		bActorType := "service"
 		bActorID := "kubernaut-agent"
 		if event.ActorID != "" {
 			bActorID = event.ActorID

--- a/internal/kubernautagent/audit/ds_store.go
+++ b/internal/kubernautagent/audit/ds_store.go
@@ -50,10 +50,10 @@ func (s *DSAuditStore) StoreAudit(ctx context.Context, event *AuditEvent) error 
 		CorrelationID:  event.CorrelationID,
 	}
 	if event.ActingUser != "" {
-		req.ActorType.SetTo("User")
+		req.ActorType.SetTo("user")
 		req.ActorID.SetTo(event.ActingUser)
 	} else {
-		actorType := "Service"
+		actorType := "service"
 		actorID := "kubernaut-agent"
 		if event.ActorID != "" {
 			actorID = event.ActorID

--- a/internal/kubernautagent/audit/ds_store_audit_parity_test.go
+++ b/internal/kubernautagent/audit/ds_store_audit_parity_test.go
@@ -79,7 +79,7 @@ var _ = Describe("KA Audit Parity — TP-433-AUDIT-SOC2", func() {
 	})
 
 	Describe("UT-KA-433-AP-003: StoreAudit sets ActorType and ActorID", func() {
-		It("should set ActorType=Service and ActorID=kubernaut-agent on ogen request", func() {
+		It("should set ActorType=service and ActorID=kubernaut-agent on ogen request (ADR-034 lowercase convention)", func() {
 			recorder := &fakeOgenClient{}
 			store := audit.NewDSAuditStore(recorder)
 
@@ -89,7 +89,7 @@ var _ = Describe("KA Audit Parity — TP-433-AUDIT-SOC2", func() {
 			Expect(recorder.calls).To(HaveLen(1))
 
 			req := recorder.calls[0]
-			Expect(req.ActorType.Value).To(Equal("Service"))
+			Expect(req.ActorType.Value).To(Equal("service"))
 			Expect(req.ActorID.Value).To(Equal("kubernaut-agent"))
 		})
 	})

--- a/internal/kubernautagent/audit/emitter_test.go
+++ b/internal/kubernautagent/audit/emitter_test.go
@@ -247,11 +247,11 @@ var _ = Describe("Kubernaut Agent Audit Emitter — #433", func() {
 
 	Describe("BR-AUDIT-005 #998: Audit actor attribution from context", func() {
 		It("UT-KA-998-001: WithActor sets actor retrievable via ActorFromContext", func() {
-			ctx := audit.WithActor(context.Background(), "user@example.com", "User")
+			ctx := audit.WithActor(context.Background(), "user@example.com", "user")
 			actorID, actorType, ok := audit.ActorFromContext(ctx)
 			Expect(ok).To(BeTrue())
 			Expect(actorID).To(Equal("user@example.com"))
-			Expect(actorType).To(Equal("User"))
+			Expect(actorType).To(Equal("user"))
 		})
 
 		It("UT-KA-998-002: ActorFromContext returns false on bare context", func() {
@@ -261,26 +261,26 @@ var _ = Describe("Kubernaut Agent Audit Emitter — #433", func() {
 
 		It("UT-KA-998-003: StoreBestEffort auto-populates actor from context when event fields are empty", func() {
 			store := &mockAuditStore{}
-			ctx := audit.WithActor(context.Background(), "analyst@corp.io", "User")
+			ctx := audit.WithActor(context.Background(), "analyst@corp.io", "user")
 			event := audit.NewEvent(audit.EventTypeLLMRequest, "corr-998")
 
 			audit.StoreBestEffort(ctx, store, event, logr.Discard())
 			Expect(store.events).To(HaveLen(1))
 			Expect(store.events[0].ActorID).To(Equal("analyst@corp.io"))
-			Expect(store.events[0].ActorType).To(Equal("User"))
+			Expect(store.events[0].ActorType).To(Equal("user"))
 		})
 
 		It("UT-KA-998-004: StoreBestEffort preserves explicitly set actor fields", func() {
 			store := &mockAuditStore{}
-			ctx := audit.WithActor(context.Background(), "context-user", "User")
+			ctx := audit.WithActor(context.Background(), "context-user", "user")
 			event := audit.NewEvent(audit.EventTypeLLMRequest, "corr-998")
 			event.ActorID = "system-override"
-			event.ActorType = "Service"
+			event.ActorType = "service"
 
 			audit.StoreBestEffort(ctx, store, event, logr.Discard())
 			Expect(store.events).To(HaveLen(1))
 			Expect(store.events[0].ActorID).To(Equal("system-override"))
-			Expect(store.events[0].ActorType).To(Equal("Service"))
+			Expect(store.events[0].ActorType).To(Equal("service"))
 		})
 
 		It("UT-KA-998-005: StoreBestEffort leaves actor empty when no context actor and no event actor", func() {

--- a/internal/kubernautagent/mcp/reconstruct_test.go
+++ b/internal/kubernautagent/mcp/reconstruct_test.go
@@ -183,7 +183,7 @@ func makeLLMRequestEvent(correlationID, prompt string, ts time.Time) ogenclient.
 		EventOutcome:   ogenclient.AuditEventEventOutcomeSuccess,
 		CorrelationID:  correlationID,
 	}
-	evt.ActorType.SetTo("Service")
+	evt.ActorType.SetTo("service")
 	evt.ActorID.SetTo("kubernaut-agent")
 	payload := ogenclient.LLMRequestPayload{
 		EventType:     ogenclient.LLMRequestPayloadEventTypeAiagentLlmRequest,
@@ -207,7 +207,7 @@ func makeLLMResponseEvent(correlationID, analysis string, ts time.Time) ogenclie
 		EventOutcome:   ogenclient.AuditEventEventOutcomeSuccess,
 		CorrelationID:  correlationID,
 	}
-	evt.ActorType.SetTo("Service")
+	evt.ActorType.SetTo("service")
 	evt.ActorID.SetTo("kubernaut-agent")
 	payload := ogenclient.LLMResponsePayload{
 		EventType:       ogenclient.LLMResponsePayloadEventTypeAiagentLlmResponse,

--- a/migrations/019_audit_events_insert_seq.sql
+++ b/migrations/019_audit_events_insert_seq.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+-- Migration: 019_audit_events_insert_seq
+-- Issue #2318: hash-chain verification/write-ordering false positives
+-- FedRAMP AU-9: Protection of Audit Information
+-- SOC2 CC7.2 / CC8.1: Monitoring for anomalies; tamper-evident audit trail
+--
+-- getPreviousEventHash (pkg/datastorage/repository/audit_events_hashchain.go)
+-- picks the hash-chain predecessor via
+-- `ORDER BY event_timestamp DESC, event_id DESC LIMIT 1`. event_id is a
+-- client-generated UUID (unrelated to insertion order), so on a same-second
+-- write burst for one correlation_id, the DESC tiebreak can select the wrong
+-- (not-actually-latest) predecessor, silently forking the chain at write
+-- time. insert_seq replaces that ambiguous tiebreak with a true, monotonic
+-- write-order column.
+--
+-- Sequence lives on the parent partitioned table and is shared across all
+-- partitions (a per-partition BIGSERIAL/IDENTITY would create independent
+-- sequences per partition and reintroduce the same ordering ambiguity this
+-- migration exists to close).
+--
+-- No backfill: this migration does not support upgrading an existing
+-- installation in place. Adopting it requires a fresh database. See
+-- DD-AUDIT-009 and the migrations/README.md note on CREATE INDEX vs.
+-- CREATE INDEX CONCURRENTLY inside Goose's transaction envelope.
+CREATE SEQUENCE audit_events_insert_seq;
+
+ALTER TABLE audit_events
+    ADD COLUMN insert_seq BIGINT NOT NULL DEFAULT nextval('audit_events_insert_seq');
+
+ALTER SEQUENCE audit_events_insert_seq OWNED BY audit_events.insert_seq;
+
+COMMENT ON COLUMN audit_events.insert_seq IS
+    'Monotonic write-order tiebreak for hash-chain predecessor lookup and verify-chain ordering (Issue #2318). Shared sequence across all partitions -- do not replace with a per-partition serial/identity column.';
+
+CREATE INDEX idx_audit_events_correlation_insert_seq
+    ON audit_events (correlation_id, insert_seq);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_audit_events_correlation_insert_seq;
+ALTER TABLE audit_events DROP COLUMN IF EXISTS insert_seq;
+DROP SEQUENCE IF EXISTS audit_events_insert_seq;

--- a/pkg/datastorage/repository/audit_events_hashchain.go
+++ b/pkg/datastorage/repository/audit_events_hashchain.go
@@ -183,13 +183,18 @@ func (r *AuditEventsRepository) getPreviousEventHash(ctx context.Context, tx *sq
 	}
 
 	// Step 2: Query last event hash for this correlation_id
+	// Issue #2318: insert_seq (migration 019) is a monotonic write-order
+	// column, unlike event_id (a client-generated UUID unrelated to
+	// insertion order). Ordering by event_timestamp/event_id could pick a
+	// stale predecessor on a same-timestamp write burst, silently forking
+	// the hash chain at write time.
 	var previousHash sql.NullString
 	query := `
 		SELECT event_hash
 		FROM audit_events
 		WHERE correlation_id = $1
 		  AND event_hash IS NOT NULL
-		ORDER BY event_timestamp DESC, event_id DESC
+		ORDER BY insert_seq DESC
 		LIMIT 1
 	`
 

--- a/pkg/datastorage/server/audit_verify_chain_handler.go
+++ b/pkg/datastorage/server/audit_verify_chain_handler.go
@@ -206,7 +206,7 @@ func (s *Server) queryVerifyChainEvents(ctx context.Context, correlationID strin
 		FROM audit_events
 		WHERE correlation_id = $1
 		  AND event_hash IS NOT NULL
-		ORDER BY event_timestamp ASC, event_id ASC
+		ORDER BY insert_seq ASC
 		LIMIT $2
 	`
 
@@ -324,35 +324,47 @@ func assignVerifyChainNullableFields(event *repository.AuditEvent, cols verifyCh
 	event.ErrorMessage = cols.errorMessage.String
 }
 
-// verifyEventChain walks events in order, recomputing each event's expected
-// hash (GAP-05: algorithm-aware, honors each event's own hash_algorithm) and
-// comparing it against the stored hash and previous_event_hash link,
-// appending any mismatches to response.TamperedEvents and updating
-// response.IsValid/VerifiedEvents in place. Extracted from verifyHashChain
-// (GO-ANTIPATTERN-AUDIT-2026-07-01 Wave 3) — pure code motion, no behavior
-// change.
+// verifyEventChain verifies each event's hash-chain integrity using its own
+// stored previous_event_hash pointer plus a topology map built from the
+// whole event set, rather than a global previousHash carried forward across
+// a caller-supplied ordering.
+//
+// Issue #2318: the prior implementation assumed events arrived in true
+// chain order and compared each event's previous_event_hash against a
+// running variable seeded from the *previous slice element*. Same-timestamp
+// write bursts made that assumption false (event_id, a client-generated
+// UUID, is not a reliable ordering tiebreak -- see migration
+// 019_audit_events_insert_seq.sql), so a correctly-chained set of events
+// handed back in the wrong order was reported as tampered: a cascading
+// false positive. Verifying each event against its own claimed predecessor
+// makes the result independent of input order.
+//
+// DD-AUDIT-009 also adds two checks the old linear walk could not express:
+//   - dangling previous_event_hash: an event's claimed predecessor is not
+//     present in the retrieved set (lost row, or forged pointer)
+//   - fork: more than one event claims the same previous_event_hash (including
+//     more than one genesis event, keyed by the empty string)
+//
+// GAP-05: algorithm-aware, honors each event's own hash_algorithm.
 func verifyEventChain(response *VerifyChainResponse, events []*repository.AuditEvent, hmacKey []byte) error {
-	previousHash := ""
+	hashToEvent := make(map[string]*repository.AuditEvent, len(events))
 	for _, event := range events {
-		expectedHash, err := repository.CalculateHashForVerification(hmacKey, previousHash, event)
+		hashToEvent[event.EventHash] = event
+	}
+
+	predecessorClaimCounts := make(map[string]int, len(events))
+	for _, event := range events {
+		predecessorClaimCounts[event.PreviousEventHash]++
+	}
+
+	for _, event := range events {
+		expectedHash, err := repository.CalculateHashForVerification(hmacKey, event.PreviousEventHash, event)
 		if err != nil {
 			return err
 		}
 
-		// Verify previous_event_hash matches
-		if event.PreviousEventHash != previousHash {
-			response.IsValid = false
-			response.TamperedEvents = append(response.TamperedEvents, TamperedEvent{
-				EventID:        event.EventID.String(),
-				EventTimestamp: event.EventTimestamp,
-				ExpectedHash:   "",
-				ActualHash:     "",
-				PreviousHash:   previousHash,
-				Message:        "Previous hash mismatch: event claims different previous_event_hash",
-			})
-		}
+		verifyEventTopology(response, event, hashToEvent, predecessorClaimCounts)
 
-		// Verify event_hash matches calculated hash
 		if event.EventHash != expectedHash {
 			response.IsValid = false
 			response.TamperedEvents = append(response.TamperedEvents, TamperedEvent{
@@ -360,15 +372,41 @@ func verifyEventChain(response *VerifyChainResponse, events []*repository.AuditE
 				EventTimestamp: event.EventTimestamp,
 				ExpectedHash:   expectedHash,
 				ActualHash:     event.EventHash,
-				PreviousHash:   previousHash,
+				PreviousHash:   event.PreviousEventHash,
 				Message:        "Event hash mismatch: event data has been tampered",
 			})
 		} else {
 			response.VerifiedEvents++
 		}
-
-		// Update previous hash for next iteration
-		previousHash = event.EventHash
 	}
 	return nil
+}
+
+// verifyEventTopology checks event's previous_event_hash pointer against the
+// rest of the chain: dangling (predecessor not present in the retrieved
+// set) and fork (another event claims the same predecessor). Split from
+// verifyEventChain so each check stays independently readable (100go.co:
+// avoid deep nesting in a single loop body).
+func verifyEventTopology(response *VerifyChainResponse, event *repository.AuditEvent, hashToEvent map[string]*repository.AuditEvent, predecessorClaimCounts map[string]int) {
+	if event.PreviousEventHash != "" {
+		if _, ok := hashToEvent[event.PreviousEventHash]; !ok {
+			response.IsValid = false
+			response.TamperedEvents = append(response.TamperedEvents, TamperedEvent{
+				EventID:        event.EventID.String(),
+				EventTimestamp: event.EventTimestamp,
+				PreviousHash:   event.PreviousEventHash,
+				Message:        "Dangling previous hash: event's claimed predecessor is not present in the retrieved chain",
+			})
+		}
+	}
+
+	if predecessorClaimCounts[event.PreviousEventHash] > 1 {
+		response.IsValid = false
+		response.TamperedEvents = append(response.TamperedEvents, TamperedEvent{
+			EventID:        event.EventID.String(),
+			EventTimestamp: event.EventTimestamp,
+			PreviousHash:   event.PreviousEventHash,
+			Message:        "Chain fork detected: multiple events claim the same previous_event_hash",
+		})
+	}
 }

--- a/pkg/datastorage/server/audit_verify_chain_ordering_test.go
+++ b/pkg/datastorage/server/audit_verify_chain_ordering_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
+)
+
+// buildChainEvent constructs an AuditEvent with a computed EventHash chained
+// off previousHash, mirroring what AuditEventsRepository.Create would
+// persist. Test-only helper for verifyEventChain fixtures (Issue #2318).
+func buildChainEvent(id uuid.UUID, corrID, previousHash string, index int) *repository.AuditEvent {
+	event := &repository.AuditEvent{
+		EventID:           id,
+		EventTimestamp:    time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC), // same-second write burst
+		EventType:         "test.verify_chain_order",
+		EventCategory:     "test",
+		EventAction:       "verify",
+		EventOutcome:      "success",
+		CorrelationID:     corrID,
+		ResourceType:      "test-resource",
+		ResourceID:        "res",
+		ActorID:           "test-actor",
+		ActorType:         "service",
+		RetentionDays:     30,
+		EventData:         map[string]interface{}{"index": index},
+		PreviousEventHash: previousHash,
+		HashAlgorithm:     repository.HashAlgorithmSHA256Unkeyed,
+	}
+	hash, err := repository.CalculateHashForVerification(nil, previousHash, event)
+	Expect(err).ToNot(HaveOccurred())
+	event.EventHash = hash
+	return event
+}
+
+// Issue #2318 / DD-AUDIT-009: verifyEventChain must verify each event using
+// its own stored previous_event_hash pointer, not a global order
+// reconstructed from (event_timestamp, event_id). These tests feed
+// deliberately scrambled input order to prove the verification result no
+// longer depends on it.
+var _ = Describe("verifyEventChain order-independence (Issue #2318, DD-AUDIT-009)", func() {
+	It("UT-DS-2318-101: verifies a genuinely valid chain correctly regardless of input order", func() {
+		corrID := "verify-order-valid"
+		event1 := buildChainEvent(uuid.New(), corrID, "", 1)
+		event2 := buildChainEvent(uuid.New(), corrID, event1.EventHash, 2)
+		event3 := buildChainEvent(uuid.New(), corrID, event2.EventHash, 3)
+
+		// Same-timestamp tiebreak ambiguity (the #2318 symptom) can hand
+		// verifyEventChain events in a scrambled, non-chain order.
+		scrambled := []*repository.AuditEvent{event1, event3, event2}
+
+		response := &VerifyChainResponse{IsValid: true, TamperedEvents: []TamperedEvent{}}
+		Expect(verifyEventChain(response, scrambled, nil)).To(Succeed())
+
+		Expect(response.IsValid).To(BeTrue(),
+			"a genuinely valid hash chain must verify as valid regardless of the order events are supplied in (Issue #2318)")
+		Expect(response.VerifiedEvents).To(Equal(3))
+		Expect(response.TamperedEvents).To(BeEmpty())
+	})
+
+	It("UT-DS-2318-102: flags an event whose event_data was tampered with, regardless of order", func() {
+		corrID := "verify-order-tampered"
+		event1 := buildChainEvent(uuid.New(), corrID, "", 1)
+		event2 := buildChainEvent(uuid.New(), corrID, event1.EventHash, 2)
+		event3 := buildChainEvent(uuid.New(), corrID, event2.EventHash, 3)
+
+		// Tamper with event2's data AFTER its hash was computed: event2.EventHash
+		// no longer matches its own content. Must surface regardless of scan order.
+		event2.EventData = map[string]interface{}{"index": 999}
+
+		response := &VerifyChainResponse{IsValid: true, TamperedEvents: []TamperedEvent{}}
+		Expect(verifyEventChain(response, []*repository.AuditEvent{event3, event1, event2}, nil)).To(Succeed())
+
+		Expect(response.IsValid).To(BeFalse())
+		Expect(tamperedEventIDs(response)).To(ContainElement(event2.EventID.String()))
+	})
+
+	It("UT-DS-2318-103: flags a dangling previous_event_hash that does not resolve to any event in the set", func() {
+		corrID := "verify-order-dangling"
+		event1 := buildChainEvent(uuid.New(), corrID, "", 1)
+		// event2 claims a previous_event_hash that doesn't belong to any
+		// event actually in the retrieved set.
+		event2 := buildChainEvent(uuid.New(), corrID, strings.Repeat("0", 64), 2)
+
+		response := &VerifyChainResponse{IsValid: true, TamperedEvents: []TamperedEvent{}}
+		Expect(verifyEventChain(response, []*repository.AuditEvent{event2, event1}, nil)).To(Succeed())
+
+		Expect(response.IsValid).To(BeFalse())
+		Expect(tamperedEventIDs(response)).To(ContainElement(event2.EventID.String()))
+	})
+
+	It("UT-DS-2318-104: flags a fork (two events pointing at the same previous_event_hash) distinctly from a hash mismatch", func() {
+		corrID := "verify-order-fork"
+		event1 := buildChainEvent(uuid.New(), corrID, "", 1)
+		event2a := buildChainEvent(uuid.New(), corrID, event1.EventHash, 2)
+		event2b := buildChainEvent(uuid.New(), corrID, event1.EventHash, 3) // forks off event1 too
+
+		response := &VerifyChainResponse{IsValid: true, TamperedEvents: []TamperedEvent{}}
+		Expect(verifyEventChain(response, []*repository.AuditEvent{event1, event2a, event2b}, nil)).To(Succeed())
+
+		Expect(response.IsValid).To(BeFalse())
+		Expect(tamperedMessagesContain(response, "fork")).To(BeTrue(),
+			"a fork must be flagged with a message distinct from a plain hash mismatch (SOC2 CC7.2/FedRAMP AU-9)")
+	})
+
+	It("UT-DS-2318-105: allows exactly one genesis event (empty previous_event_hash) without flagging it", func() {
+		corrID := "verify-order-genesis"
+		event1 := buildChainEvent(uuid.New(), corrID, "", 1)
+		event2 := buildChainEvent(uuid.New(), corrID, event1.EventHash, 2)
+
+		response := &VerifyChainResponse{IsValid: true, TamperedEvents: []TamperedEvent{}}
+		Expect(verifyEventChain(response, []*repository.AuditEvent{event2, event1}, nil)).To(Succeed())
+
+		Expect(response.IsValid).To(BeTrue())
+		Expect(response.VerifiedEvents).To(Equal(2))
+	})
+})
+
+func tamperedEventIDs(response *VerifyChainResponse) []string {
+	ids := make([]string, 0, len(response.TamperedEvents))
+	for _, te := range response.TamperedEvents {
+		ids = append(ids, te.EventID)
+	}
+	return ids
+}
+
+func tamperedMessagesContain(response *VerifyChainResponse, substr string) bool {
+	for _, te := range response.TamperedEvents {
+		if strings.Contains(te.Message, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/shared/assets/migrations/019_audit_events_insert_seq.sql
+++ b/pkg/shared/assets/migrations/019_audit_events_insert_seq.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+-- Migration: 019_audit_events_insert_seq
+-- Issue #2318: hash-chain verification/write-ordering false positives
+-- FedRAMP AU-9: Protection of Audit Information
+-- SOC2 CC7.2 / CC8.1: Monitoring for anomalies; tamper-evident audit trail
+--
+-- getPreviousEventHash (pkg/datastorage/repository/audit_events_hashchain.go)
+-- picks the hash-chain predecessor via
+-- `ORDER BY event_timestamp DESC, event_id DESC LIMIT 1`. event_id is a
+-- client-generated UUID (unrelated to insertion order), so on a same-second
+-- write burst for one correlation_id, the DESC tiebreak can select the wrong
+-- (not-actually-latest) predecessor, silently forking the chain at write
+-- time. insert_seq replaces that ambiguous tiebreak with a true, monotonic
+-- write-order column.
+--
+-- Sequence lives on the parent partitioned table and is shared across all
+-- partitions (a per-partition BIGSERIAL/IDENTITY would create independent
+-- sequences per partition and reintroduce the same ordering ambiguity this
+-- migration exists to close).
+--
+-- No backfill: this migration does not support upgrading an existing
+-- installation in place. Adopting it requires a fresh database. See
+-- DD-AUDIT-009 and the migrations/README.md note on CREATE INDEX vs.
+-- CREATE INDEX CONCURRENTLY inside Goose's transaction envelope.
+CREATE SEQUENCE audit_events_insert_seq;
+
+ALTER TABLE audit_events
+    ADD COLUMN insert_seq BIGINT NOT NULL DEFAULT nextval('audit_events_insert_seq');
+
+ALTER SEQUENCE audit_events_insert_seq OWNED BY audit_events.insert_seq;
+
+COMMENT ON COLUMN audit_events.insert_seq IS
+    'Monotonic write-order tiebreak for hash-chain predecessor lookup and verify-chain ordering (Issue #2318). Shared sequence across all partitions -- do not replace with a per-partition serial/identity column.';
+
+CREATE INDEX idx_audit_events_correlation_insert_seq
+    ON audit_events (correlation_id, insert_seq);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_audit_events_correlation_insert_seq;
+ALTER TABLE audit_events DROP COLUMN IF EXISTS insert_seq;
+DROP SEQUENCE IF EXISTS audit_events_insert_seq;

--- a/test/integration/datastorage/audit_verify_chain_insert_seq_test.go
+++ b/test/integration/datastorage/audit_verify_chain_insert_seq_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/server"
+)
+
+// Issue #2318: POST /api/v1/audit/verify-chain must not report tampering for
+// a genuinely intact hash chain written as a same-timestamp burst. Exercises
+// the real write path (AuditEventsRepository.Create, migration 019's
+// insert_seq) end-to-end through the real HTTP handler against real
+// PostgreSQL, proving the write-path fix (insert_seq-ordered predecessor
+// lookup) and the read-path fix (order-independent verifyEventChain) work
+// together.
+var _ = Describe("POST /api/v1/audit/verify-chain same-timestamp burst [Issue #2318]", func() {
+	var (
+		auditRepo *repository.AuditEventsRepository
+		testID    string
+	)
+
+	BeforeEach(func() {
+		auditRepo = repository.NewAuditEventsRepository(db.DB, logger)
+		testID = generateTestID()
+	})
+
+	AfterEach(func() {
+		_, _ = db.ExecContext(context.Background(),
+			"DELETE FROM audit_events WHERE correlation_id LIKE $1",
+			fmt.Sprintf("%%verify-burst-%s%%", testID))
+	})
+
+	It("IT-DS-2318-002: a same-timestamp write burst verifies as valid with zero tampered events", func() {
+		corrID := fmt.Sprintf("verify-burst-%s", testID)
+		sharedTimestamp := time.Now().UTC().Truncate(time.Second)
+
+		// Deliberately give each event a UUID that sorts in the OPPOSITE
+		// order from its true insertion order, so a false positive here can
+		// only be explained by an ordering defect (event_id tiebreak),
+		// never by coincidence.
+		ids := []uuid.UUID{
+			uuid.MustParse("ffffffff-ffff-ffff-ffff-fffffffffff3"),
+			uuid.MustParse("ffffffff-ffff-ffff-ffff-fffffffffff2"),
+			uuid.MustParse("ffffffff-ffff-ffff-ffff-fffffffffff1"),
+			uuid.MustParse("ffffffff-ffff-ffff-ffff-fffffffffff0"),
+		}
+		for i, id := range ids {
+			event := &repository.AuditEvent{
+				EventID:        id,
+				EventTimestamp: sharedTimestamp,
+				EventType:      "test.verify_burst",
+				Version:        "1.0",
+				EventCategory:  "test",
+				EventAction:    "verify",
+				EventOutcome:   "success",
+				CorrelationID:  corrID,
+				ResourceType:   "test-resource",
+				ResourceID:     fmt.Sprintf("res-%d", i),
+				ActorID:        "test-actor",
+				ActorType:      "service",
+				RetentionDays:  30,
+				EventData:      map[string]interface{}{"index": i},
+			}
+			_, err := auditRepo.Create(context.Background(), event)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		srv := server.NewMinimalAuditHandlersHTTPServer(server.MinimalAuditHandlersHTTPServerDeps{
+			Logger:          logger,
+			DB:              db.DB,
+			AuditEventsRepo: auditRepo,
+		})
+
+		reqBody, err := json.Marshal(map[string]string{"correlation_id": corrID})
+		Expect(err).ToNot(HaveOccurred())
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/verify-chain", bytes.NewReader(reqBody))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		srv.HandleVerifyChain(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		var resp server.VerifyChainResponse
+		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+
+		Expect(resp.IsValid).To(BeTrue(),
+			"a genuinely intact hash chain written in a same-timestamp burst must verify as valid (Issue #2318)")
+		Expect(resp.TotalEvents).To(Equal(4))
+		Expect(resp.VerifiedEvents).To(Equal(4))
+		Expect(resp.TamperedEvents).To(BeEmpty())
+	})
+})

--- a/test/integration/datastorage/audit_write_path_insert_seq_test.go
+++ b/test/integration/datastorage/audit_write_path_insert_seq_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
+)
+
+// Issue #2318 (write path): getPreviousEventHash must pick the true chain
+// tip by insertion order, not by an ordering that depends on event_id (a
+// client-generated UUID unrelated to insertion order). FedRAMP AU-9 / SOC2
+// CC8.1: a wrong predecessor silently forks the hash chain at write time.
+var _ = Describe("Audit write-path hash-chain predecessor ordering [Issue #2318]", func() {
+	var (
+		auditRepo *repository.AuditEventsRepository
+		testID    string
+	)
+
+	BeforeEach(func() {
+		auditRepo = repository.NewAuditEventsRepository(db.DB, logger)
+		testID = generateTestID()
+	})
+
+	AfterEach(func() {
+		_, _ = db.ExecContext(context.Background(),
+			"DELETE FROM audit_events WHERE correlation_id LIKE $1",
+			fmt.Sprintf("%%insert-seq-%s%%", testID))
+	})
+
+	It("IT-DS-2318-001: Create picks the true chain tip by insert order on a same-timestamp write burst", func() {
+		corrID := fmt.Sprintf("insert-seq-%s", testID)
+		sharedTimestamp := time.Now().UTC().Truncate(time.Second)
+
+		// event1 is inserted FIRST (chronologically the older predecessor)
+		// but is deliberately given a UUID that sorts HIGHER than event2's.
+		// The pre-fix query (`ORDER BY event_timestamp DESC, event_id DESC`)
+		// picks the row with the largest event_id among timestamp ties --
+		// so with these IDs it wrongly ranks event1 above event2 regardless
+		// of which was actually written last.
+		event1 := &repository.AuditEvent{
+			EventID:        uuid.MustParse("ffffffff-ffff-ffff-ffff-fffffffffffe"),
+			EventTimestamp: sharedTimestamp,
+			EventType:      "test.insert_seq",
+			Version:        "1.0",
+			EventCategory:  "test",
+			EventAction:    "verify",
+			EventOutcome:   "success",
+			CorrelationID:  corrID,
+			ResourceType:   "test-resource",
+			ResourceID:     "res-1",
+			ActorID:        "test-actor",
+			ActorType:      "service",
+			RetentionDays:  30,
+			EventData:      map[string]interface{}{"index": 1},
+		}
+		created1, err := auditRepo.Create(context.Background(), event1)
+		Expect(err).ToNot(HaveOccurred())
+
+		// event2 is inserted SECOND (the true chain tip after event1) but
+		// has a UUID that sorts LOWER than event1's.
+		event2 := &repository.AuditEvent{
+			EventID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+			EventTimestamp: sharedTimestamp,
+			EventType:      "test.insert_seq",
+			Version:        "1.0",
+			EventCategory:  "test",
+			EventAction:    "verify",
+			EventOutcome:   "success",
+			CorrelationID:  corrID,
+			ResourceType:   "test-resource",
+			ResourceID:     "res-2",
+			ActorID:        "test-actor",
+			ActorType:      "service",
+			RetentionDays:  30,
+			EventData:      map[string]interface{}{"index": 2},
+		}
+		created2, err := auditRepo.Create(context.Background(), event2)
+		Expect(err).ToNot(HaveOccurred())
+
+		// event3 is the probe: its PreviousEventHash must chain to event2
+		// (the actual chain tip), not event1 (the timestamp/event_id-tiebreak
+		// artifact).
+		event3 := &repository.AuditEvent{
+			EventID:        uuid.New(),
+			EventTimestamp: sharedTimestamp,
+			EventType:      "test.insert_seq",
+			Version:        "1.0",
+			EventCategory:  "test",
+			EventAction:    "verify",
+			EventOutcome:   "success",
+			CorrelationID:  corrID,
+			ResourceType:   "test-resource",
+			ResourceID:     "res-3",
+			ActorID:        "test-actor",
+			ActorType:      "service",
+			RetentionDays:  30,
+			EventData:      map[string]interface{}{"index": 3},
+		}
+		created3, err := auditRepo.Create(context.Background(), event3)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(created3.PreviousEventHash).To(Equal(created2.EventHash),
+			"event3 must chain off event2 (the actual chain tip written immediately before it), "+
+				"not event1 -- event_id must never be used to break event_timestamp ties (Issue #2318)")
+		Expect(created3.PreviousEventHash).ToNot(Equal(created1.EventHash),
+			"event3 chaining off event1 would mean the write path picked a stale predecessor "+
+				"during a same-timestamp write burst (Issue #2318 write-path fork)")
+	})
+})


### PR DESCRIPTION
## Summary

Two related audit-trail defects:

- **#2317**: kubernaut-agent hardcoded `actor_type="Service"`/`"User"` instead of ADR-034's lowercase convention, so it's invisible to any downstream query/SIEM correlation matching on lowercase `actor_type`.
- **#2318**: `POST /api/v1/audit/verify-chain` produces false-positive tampering reports, and the write path has a related latent fork defect. Both trace back to the same root cause: `event_id` (a client-generated UUID, unrelated to insertion order) was used to break ties on `event_timestamp` in both the write-time predecessor lookup and the read-time verification ordering. On a same-timestamp write burst, that tiebreak can pick the wrong predecessor.

## Changes

- **#2317**: lowercase the two hardcoded literals in `ds_store.go`/`ds_buffered_store.go`, flip existing test assertions/fixtures, add missing unit coverage for `BufferedDSAuditStore`'s actor defaults.
- **#2318 write path**: migration 019 adds `insert_seq`, a monotonic column backed by one sequence shared across all `audit_events` partitions. `getPreviousEventHash` now orders by `insert_seq DESC` instead of `event_timestamp DESC, event_id DESC`. No backfill — adopting this requires a fresh database (pre-production; v1.5 EOLs at v1.6.0 GA).
- **#2318 read path**: `verifyEventChain` rewritten to check each event against its own stored `previous_event_hash` pointer plus a topology map, instead of assuming the input slice is already in true chain order. Adds dangling-pointer and fork detection (SOC2 CC7.2 / FedRAMP AU-9). `queryVerifyChainEvents` now orders by `insert_seq`.

## Test plan

- [x] Migration 019 validated against a real partitioned Postgres via goose (column/index propagate to all 35 pre-created partitions; `insert_seq DESC` correctly identifies the true last-written row where `event_id DESC` picks the wrong one)
- [x] `IT-DS-2318-001`: reproduces the write-path fork with deliberately-inverted UUIDs against unfixed code (RED), passes after the fix (GREEN)
- [x] `UT-DS-2318-101..105`: scrambled/forked/dangling fixtures fed directly into `verifyEventChain` (RED on 101/104/105 against the old linear walk)
- [x] `IT-DS-2318-002`: end-to-end through the real HTTP handler against a same-timestamp burst
- [x] `UT-KA-2317-001/002`: new coverage for `BufferedDSAuditStore` actor defaults
- [x] `go build ./...`, `golangci-lint run` (0 new issues), full `pkg/datastorage/...` + `internal/kubernautagent/audit/...` + `internal/kubernautagent/mcp/...` unit suites, full `test/integration/datastorage/...` suite (167/167) — all green