### PR TITLE
setup-e2e-fleet-infra: support optional extra worker nodes on the spoke cluster

### DIFF
--- a/hack/setup-fleet-infra/main.go
+++ b/hack/setup-fleet-infra/main.go
@@ -36,6 +36,14 @@ import (
 func main() {
 	clusterName := flag.String("cluster-name", "fleet-e2e", "Kind cluster name for the hub cluster (the spoke cluster is named <cluster-name>-remote)")
 	gatewayTypeFlag := flag.String("gateway-type", string(registry.GatewayKuadrant), "MCP Gateway implementation to deploy: \"kuadrant\" or \"eaigw\"")
+	// Issue #2333: some E2E demo scenarios (pending-taint, pdb-deadlock,
+	// autoscale, node-notready) taint/drain/pressure-test a worker node
+	// distinct from the control plane, which the spoke can't provide by
+	// default (control-plane-only). Only takes effect on first creation --
+	// Kind can't add nodes to an already-running cluster, so requesting
+	// workers against an existing single-node spoke requires deleting it
+	// first (`kind delete cluster --name <cluster-name>-remote`).
+	spokeWorkers := flag.Int("spoke-workers", 0, "number of extra worker nodes to add to the spoke cluster (default 0: control-plane-only, current behavior)")
 	// sigs.k8s.io/controller-runtime/pkg/client/config's own init() unconditionally
 	// registers a "-kubeconfig" flag on flag.CommandLine the moment anything --
 	// direct or transitive -- imports it, which already happened here via the
@@ -66,7 +74,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	if _, _, err := infrastructure.SetupFleetCoreInfrastructureWithGateway(ctx, *clusterName, kubeconfigPath, gatewayType, os.Stdout); err != nil {
+	if _, _, err := infrastructure.SetupFleetCoreInfrastructureWithGateway(ctx, *clusterName, kubeconfigPath, gatewayType, *spokeWorkers, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "\n❌ setup-fleet-infra failed: %v\n", err)
 		os.Exit(1)
 	}

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -334,7 +334,18 @@ func SetupFleetE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPat
 		// caller's own token instead of relying on a cached credential.
 		// Kuadrant itself stays covered by its own standalone FMC E2E lane
 		// (test/e2e/fleetmetadatacache, non-eaigw variant).
-		fleetOpts, rkp, err := provisionFleetCoreInfra(ctx, clusterName, kubeconfigPath, namespace, namespace, registry.GatewayEAIGW, writer)
+		// SpokeWorkers=0 (zero value, left unset): this Ginkgo-suite journey
+		// has no demo scenario needing a worker node distinct from the
+		// control plane (Issue #2333's -spoke-workers flag is exposed via
+		// the CLI entry point, SetupFleetCoreInfrastructureWithGateway,
+		// below -- not this path).
+		fleetOpts, rkp, err := provisionFleetCoreInfra(ctx, FleetCoreInfraOptions{
+			ClusterName:       clusterName,
+			KubeconfigPath:    kubeconfigPath,
+			Namespace:         namespace,
+			KeycloakNamespace: namespace,
+			GatewayType:       registry.GatewayEAIGW,
+		}, writer)
 		remoteKubeconfigPath = rkp
 		return fleetOpts, err
 	}
@@ -402,14 +413,21 @@ func SetupFleetE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPat
 // behavior before gateway-type selection existed). Prefer
 // SetupFleetCoreInfrastructureWithGateway for new callers.
 func SetupFleetCoreInfrastructure(ctx context.Context, clusterName, kubeconfigPath string, writer io.Writer) (fleetOpts *FleetHelmOptions, remoteKubeconfigPath string, err error) {
-	return SetupFleetCoreInfrastructureWithGateway(ctx, clusterName, kubeconfigPath, registry.GatewayKuadrant, writer)
+	return SetupFleetCoreInfrastructureWithGateway(ctx, clusterName, kubeconfigPath, registry.GatewayKuadrant, 0, writer)
 }
 
 // SetupFleetCoreInfrastructureWithGateway is SetupFleetCoreInfrastructure
 // with an explicit gatewayType (registry.GatewayKuadrant or
 // registry.GatewayEAIGW; empty defaults to Kuadrant). See
 // provisionFleetCoreInfra's doc comment for what differs between the two.
-func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, kubeconfigPath string, gatewayType registry.MCPGatewayType, writer io.Writer) (fleetOpts *FleetHelmOptions, remoteKubeconfigPath string, err error) {
+//
+// spokeWorkers appends this many `role: worker` nodes to the spoke cluster
+// at creation time (Issue #2333: some E2E demo scenarios taint/drain/
+// pressure-test a worker node distinct from the control plane, which the
+// spoke can't provide as a control-plane-only cluster). Zero (the
+// long-standing default) leaves the spoke control-plane-only. This is the
+// `hack/setup-fleet-infra -spoke-workers=N` entry point's parameter.
+func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, kubeconfigPath string, gatewayType registry.MCPGatewayType, spokeWorkers int, writer io.Writer) (fleetOpts *FleetHelmOptions, remoteKubeconfigPath string, err error) {
 	if gatewayType == "" {
 		gatewayType = registry.GatewayKuadrant
 	}
@@ -453,7 +471,14 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, k
 	// (Keycloak wouldn't share a namespace with the app it authenticates
 	// for). See idpNamespace's doc comment (keycloak_e2e.go) for why this
 	// is scoped here only, not the shared Ginkgo-suite provisioner closure.
-	fleetOpts, remoteKubeconfigPath, err = provisionFleetCoreInfra(ctx, clusterName, kubeconfigPath, namespace, idpNamespace, gatewayType, writer)
+	fleetOpts, remoteKubeconfigPath, err = provisionFleetCoreInfra(ctx, FleetCoreInfraOptions{
+		ClusterName:       clusterName,
+		KubeconfigPath:    kubeconfigPath,
+		Namespace:         namespace,
+		KeycloakNamespace: idpNamespace,
+		GatewayType:       gatewayType,
+		SpokeWorkers:      spokeWorkers,
+	}, writer)
 	if err != nil {
 		return nil, remoteKubeconfigPath, fmt.Errorf("fleet-core infrastructure provisioning failed: %w", err)
 	}
@@ -630,6 +655,40 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, k
 	return fleetOpts, remoteKubeconfigPath, nil
 }
 
+// FleetCoreInfraOptions configures provisionFleetCoreInfra. Introduced by
+// Issue #2333 (SpokeWorkers) to keep the function signature under the
+// project's 8-parameter anti-pattern threshold -- see AGENTS.md's Go
+// Anti-Pattern Checklist ("Function/method with 8+ parameters" ->
+// "Use Options pattern or config struct").
+type FleetCoreInfraOptions struct {
+	ClusterName    string
+	KubeconfigPath string
+
+	// Namespace must already exist (both callers create it via
+	// CreateTestNamespace before invoking provisionFleetCoreInfra).
+	Namespace string
+
+	// KeycloakNamespace is Namespace (kubernautSystem) for the "fleet"/
+	// "fullpipeline" Ginkgo suites' provisioner closure -- unchanged
+	// behavior -- and idpNamespace ("idp") for the demo-only entry point
+	// (SetupFleetCoreInfrastructure). See idpNamespace's doc comment
+	// (keycloak_e2e.go) for why this is scoped to the demo path only.
+	KeycloakNamespace string
+
+	// GatewayType selects registry.GatewayKuadrant or registry.GatewayEAIGW
+	// (empty defaults to Kuadrant, matching DeployFleetGatewayInfra's own
+	// zero-value handling) -- see KubeMCPServerAuthConfig.GatewayType's doc
+	// comment for what differs between the two at the edge routing/OAuth
+	// validation layer.
+	GatewayType registry.MCPGatewayType
+
+	// SpokeWorkers appends this many `role: worker` nodes to the remote/
+	// spoke cluster at creation time (Issue #2333); see
+	// SetupRemoteClusterForFMC's doc comment for the full rationale and the
+	// recreate-required caveat.
+	SpokeWorkers int
+}
+
 // provisionFleetCoreInfra deploys Keycloak (IdP), the genuinely separate
 // remote Kind cluster (DD-TEST-013), and the Kuadrant MCP Gateway +
 // kube-mcp-server -- the full fleet-core infrastructure sequence shared by:
@@ -643,16 +702,17 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, k
 //     `helm install` with real LLM credentials and Rego policies
 //     (`make setup-e2e-fleet-infra`).
 //
-// namespace must already exist (both callers create it via
-// CreateTestNamespace before invoking this). gatewayType selects
-// registry.GatewayKuadrant or registry.GatewayEAIGW (empty defaults to
-// Kuadrant, matching DeployFleetGatewayInfra's own zero-value handling) --
-// see KubeMCPServerAuthConfig.GatewayType's doc comment for what differs
-// between the two at the edge routing/OAuth validation layer. Returns the
-// FleetHelmOptions (MCP Gateway endpoint/type, OAuth2 token URL/secret/
-// scopes) needed to render a fleet-enabled `helm install`, and the remote
-// cluster's kubeconfig path.
-func provisionFleetCoreInfra(ctx context.Context, clusterName, kubeconfigPath, namespace, keycloakNamespace string, gatewayType registry.MCPGatewayType, writer io.Writer) (*FleetHelmOptions, string, error) {
+// Returns the FleetHelmOptions (MCP Gateway endpoint/type, OAuth2 token
+// URL/secret/scopes) needed to render a fleet-enabled `helm install`, and
+// the remote cluster's kubeconfig path. See FleetCoreInfraOptions' field
+// docs for individual parameter semantics.
+func provisionFleetCoreInfra(ctx context.Context, opts FleetCoreInfraOptions, writer io.Writer) (*FleetHelmOptions, string, error) {
+	clusterName := opts.ClusterName
+	kubeconfigPath := opts.KubeconfigPath
+	namespace := opts.Namespace
+	keycloakNamespace := opts.KeycloakNamespace
+	gatewayType := opts.GatewayType
+	spokeWorkers := opts.SpokeWorkers
 	var remoteKubeconfigPath string
 
 	// Backward-compatible default (all existing callers pre-dating this
@@ -767,7 +827,16 @@ func provisionFleetCoreInfra(ctx context.Context, clusterName, kubeconfigPath, n
 		StsScopes:        []string{"k8s-api-audience"},
 		CAFilePath:       "/etc/tls-ca/ca.crt",
 	}
-	remoteBridge, remoteErr := SetupRemoteClusterForFMC(ctx, clusterName, kubeconfigPath, remoteClusterName, remoteKubeconfigPath, oidcCfg.IssuerURL, keycloakHostPortFleet, sharedAuthConfig, writer)
+	remoteBridge, remoteErr := SetupRemoteClusterForFMC(ctx, RemoteClusterFMCConfig{
+		PrimaryClusterName:    clusterName,
+		PrimaryKubeconfigPath: kubeconfigPath,
+		RemoteClusterName:     remoteClusterName,
+		RemoteKubeconfigPath:  remoteKubeconfigPath,
+		KeycloakIssuerURL:     oidcCfg.IssuerURL,
+		KeycloakNodePort:      keycloakHostPortFleet,
+		AuthConfig:            sharedAuthConfig,
+		ExtraWorkerNodes:      spokeWorkers,
+	}, writer)
 	if remoteErr != nil {
 		return nil, "", fmt.Errorf("remote cluster provisioning failed: %w", remoteErr)
 	}

--- a/test/infrastructure/fleetmetadatacache_e2e.go
+++ b/test/infrastructure/fleetmetadatacache_e2e.go
@@ -205,7 +205,20 @@ func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 		StsScopes:        []string{"k8s-api-audience"},
 		CAFilePath:       "/etc/tls-ca/ca.crt",
 	}
-	remoteBridge, remoteErr := SetupRemoteClusterForFMC(ctx, clusterName, kubeconfigPath, remoteClusterName, remoteKubeconfigPath, oidcCfg.IssuerURL, keycloakHostPortFMC, remoteKubeMCPAuthConfig, writer)
+	// ExtraWorkerNodes=0: this standalone FMC E2E lane only exercises the
+	// "prod-east" cross-cluster bridge (DD-TEST-013) and has no demo
+	// scenario needing a worker node distinct from the control plane --
+	// unlike the "fleet" suite's spoke (see SetupRemoteClusterForFMC call
+	// in fleet_e2e.go), which threads Issue #2333's spokeWorkers through.
+	remoteBridge, remoteErr := SetupRemoteClusterForFMC(ctx, RemoteClusterFMCConfig{
+		PrimaryClusterName:    clusterName,
+		PrimaryKubeconfigPath: kubeconfigPath,
+		RemoteClusterName:     remoteClusterName,
+		RemoteKubeconfigPath:  remoteKubeconfigPath,
+		KeycloakIssuerURL:     oidcCfg.IssuerURL,
+		KeycloakNodePort:      keycloakHostPortFMC,
+		AuthConfig:            remoteKubeMCPAuthConfig,
+	}, writer)
 	if remoteErr != nil {
 		return "", "", fmt.Errorf("remote cluster provisioning failed: %w", remoteErr)
 	}

--- a/test/infrastructure/fleetmetadatacache_remote_cluster.go
+++ b/test/infrastructure/fleetmetadatacache_remote_cluster.go
@@ -54,6 +54,48 @@ const remoteBridgeServiceName = "kube-mcp-server-remote"
 // actually runs in).
 const remoteMCPServerNamespace = "mcp-system"
 
+// RemoteClusterFMCConfig configures SetupRemoteClusterForFMC. Introduced by
+// Issue #2333 (ExtraWorkerNodes) to keep the function signature under the
+// project's 8-parameter anti-pattern threshold -- see AGENTS.md's Go
+// Anti-Pattern Checklist ("Function/method with 8+ parameters" ->
+// "Use Options pattern or config struct").
+type RemoteClusterFMCConfig struct {
+	// PrimaryClusterName/PrimaryKubeconfigPath identify the already-running
+	// primary cluster this remote cluster bridges to (Keycloak must already
+	// be reachable there).
+	PrimaryClusterName    string
+	PrimaryKubeconfigPath string
+
+	// RemoteClusterName/RemoteKubeconfigPath identify the remote cluster
+	// this function creates.
+	RemoteClusterName    string
+	RemoteKubeconfigPath string
+
+	// KeycloakIssuerURL/KeycloakNodePort locate the primary cluster's
+	// Keycloak, bridged into the remote cluster for its API server's OIDC
+	// patch.
+	KeycloakIssuerURL string
+	KeycloakNodePort  int
+
+	// AuthConfig must be the same passthrough+STS config used for the
+	// primary cluster's kube-mcp-server -- this function deploys an
+	// identical kube-mcp-server into the remote cluster so both perform the
+	// same RFC 8693 exchange against the same bridged Keycloak.
+	AuthConfig KubeMCPServerAuthConfig
+
+	// ExtraWorkerNodes appends this many `role: worker` nodes to the remote
+	// cluster's Kind config at creation time (Issue #2333: E2E demo
+	// scenarios that taint/drain/pressure-test a worker node distinct from
+	// the control plane need one on the spoke). Zero preserves the existing
+	// control-plane-only topology. Since Kind fixes node count at creation,
+	// requesting workers on an already-running single-node spoke requires
+	// tearing it down and recreating (re-running this function's whole
+	// bootstrap sequence) rather than a live add -- this field only takes
+	// effect on first creation/recreation, mirroring
+	// KindClusterOptions.ExtraWorkerNodes.
+	ExtraWorkerNodes int
+}
+
 // SetupRemoteClusterForFMC provisions a second, independent Kind cluster
 // and wires it into the FMC E2E lane's cross-cluster bridge (DD-TEST-013,
 // validated in Spike S19): a genuinely separate Kubernetes control plane
@@ -63,16 +105,21 @@ const remoteMCPServerNamespace = "mcp-system"
 // Must be called AFTER Keycloak is deployed and reachable in the primary
 // cluster (Keycloak must already be running for the remote cluster's own
 // API server OIDC patch to succeed) and AFTER the primary cluster's node
-// exists (its bridge IP is discovered here). authConfig must be the same
-// passthrough+STS config used for the primary cluster's kube-mcp-server --
-// this function deploys an identical kube-mcp-server into the remote
-// cluster so both perform the same RFC 8693 exchange against the same
-// bridged Keycloak.
+// exists (its bridge IP is discovered here). See RemoteClusterFMCConfig's
+// field docs for individual parameter semantics.
 //
 // Returns a RemoteClusterBridgeConfig for the caller to set on
 // KubeMCPServerAuthConfig.RemoteBridge before calling DeployFleetCoreInfra
 // for the primary cluster.
-func SetupRemoteClusterForFMC(ctx context.Context, primaryClusterName, primaryKubeconfigPath, remoteClusterName, remoteKubeconfigPath string, keycloakIssuerURL string, keycloakNodePort int, authConfig KubeMCPServerAuthConfig, writer io.Writer) (*RemoteClusterBridgeConfig, error) {
+func SetupRemoteClusterForFMC(ctx context.Context, cfg RemoteClusterFMCConfig, writer io.Writer) (*RemoteClusterBridgeConfig, error) {
+	primaryClusterName := cfg.PrimaryClusterName
+	primaryKubeconfigPath := cfg.PrimaryKubeconfigPath
+	remoteClusterName := cfg.RemoteClusterName
+	remoteKubeconfigPath := cfg.RemoteKubeconfigPath
+	keycloakIssuerURL := cfg.KeycloakIssuerURL
+	keycloakNodePort := cfg.KeycloakNodePort
+	authConfig := cfg.AuthConfig
+
 	_, _ = fmt.Fprintln(writer, "\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	_, _ = fmt.Fprintln(writer, "🌍 Provisioning remote cluster for cross-cluster isolation (DD-TEST-013)...")
 	_, _ = fmt.Fprintln(writer, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -84,6 +131,7 @@ func SetupRemoteClusterForFMC(ctx context.Context, primaryClusterName, primaryKu
 		WaitTimeout:             "5m",
 		UsePodman:               true,
 		ProjectRootAsWorkingDir: true,
+		ExtraWorkerNodes:        cfg.ExtraWorkerNodes,
 	}
 	if err := CreateKindClusterWithConfig(ctx, opts, writer); err != nil {
 		return nil, fmt.Errorf("remote cluster creation failed: %w", err)

--- a/test/infrastructure/kind_cluster_helpers.go
+++ b/test/infrastructure/kind_cluster_helpers.go
@@ -45,6 +45,12 @@ const (
 
 var kindVersionPattern = regexp.MustCompile(`kind v(\d+)\.(\d+)\.(\d+)`)
 
+// kindNodeImagePattern extracts a Kind node's image reference (e.g.
+// "kindest/node:v1.36.1@sha256:...") from the first "image:" line in a Kind
+// Cluster config, so generated worker nodes stay pinned to the same K8s
+// version as the existing control-plane node (appendWorkerNodesToKindConfig).
+var kindNodeImagePattern = regexp.MustCompile(`(?m)^\s*image:\s*(\S+)`)
+
 // checkKindVersionOutput parses `kind version` output (format: "kind v0.32.0
 // go1.26.4 linux/amd64") and returns an error if the installed CLI is older
 // than the minimum required version. Pure function (no I/O) so it is
@@ -83,6 +89,39 @@ func validateKindVersion(ctx context.Context, writer io.Writer) error {
 	}
 	_, _ = fmt.Fprintf(writer, "  ✅ Kind version validated: %s", versionStr)
 	return nil
+}
+
+// appendWorkerNodesToKindConfig returns kindConfigYAML with workerCount
+// additional `role: worker` node entries appended to its `nodes:` list, each
+// pinned to the same node image as the existing control-plane node (Issue
+// #2333: E2E demo scenarios that taint/drain/pressure-test a worker node
+// distinct from the control plane need one on the spoke cluster). Kind
+// requires this at cluster-creation time -- it cannot add nodes to an
+// already-running cluster -- so callers must only invoke this when actually
+// creating (not reusing) a cluster.
+//
+// workerCount=0 is a no-op passthrough (returns kindConfigYAML unchanged),
+// so callers with no worker nodes requested incur no behavior change.
+func appendWorkerNodesToKindConfig(kindConfigYAML string, workerCount int) (string, error) {
+	if workerCount == 0 {
+		return kindConfigYAML, nil
+	}
+
+	match := kindNodeImagePattern.FindStringSubmatch(kindConfigYAML)
+	if match == nil {
+		return "", fmt.Errorf("no node image found in kind config to pin worker nodes to")
+	}
+	image := match[1]
+
+	var b strings.Builder
+	b.WriteString(kindConfigYAML)
+	if !strings.HasSuffix(kindConfigYAML, "\n") {
+		b.WriteString("\n")
+	}
+	for i := 0; i < workerCount; i++ {
+		b.WriteString(fmt.Sprintf("- role: worker\n  image: %s\n", image))
+	}
+	return b.String(), nil
 }
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -494,6 +533,16 @@ type KindClusterOptions struct {
 
 	// ProjectRootAsWorkingDir sets working directory to project root (for ./coverdata resolution)
 	ProjectRootAsWorkingDir bool
+
+	// ExtraWorkerNodes appends this many `role: worker` node entries to the
+	// Kind config's `nodes:` list at creation time, pinned to the same node
+	// image as the config's existing control-plane node (Issue #2333: some
+	// E2E demo scenarios taint/drain/pressure-test a worker node distinct
+	// from the control plane). Zero (default) preserves the config's
+	// existing node topology unchanged. Kind can't add nodes to an
+	// already-running cluster, so this has no effect when ReuseExisting
+	// short-circuits cluster creation below.
+	ExtraWorkerNodes int
 }
 
 // CreateKindClusterWithConfig creates a Kind cluster with the specified configuration
@@ -580,6 +629,35 @@ func CreateKindClusterWithConfig(ctx context.Context, opts KindClusterOptions, w
 
 	_, _ = fmt.Fprintf(writer, "  📋 Using Kind config: %s\n", absoluteConfigPath)
 
+	// 3b. Append extra worker nodes if requested (Issue #2333). Only rewrite
+	// the config into a temp file when actually needed -- every existing
+	// caller (ExtraWorkerNodes=0) keeps passing absoluteConfigPath straight
+	// through, unchanged.
+	kindConfigPath := absoluteConfigPath
+	if opts.ExtraWorkerNodes > 0 {
+		configBytes, readErr := os.ReadFile(absoluteConfigPath)
+		if readErr != nil {
+			return fmt.Errorf("failed to read kind config %s: %w", absoluteConfigPath, readErr)
+		}
+		configWithWorkers, appendErr := appendWorkerNodesToKindConfig(string(configBytes), opts.ExtraWorkerNodes)
+		if appendErr != nil {
+			return fmt.Errorf("failed to append %d worker node(s) to kind config: %w", opts.ExtraWorkerNodes, appendErr)
+		}
+		tmpConfig, tmpErr := os.CreateTemp("", fmt.Sprintf("kind-%s-*.yaml", opts.ClusterName))
+		if tmpErr != nil {
+			return fmt.Errorf("failed to create temp config with worker nodes: %w", tmpErr)
+		}
+		defer func() { _ = os.Remove(tmpConfig.Name()) }()
+		if _, writeErr := tmpConfig.WriteString(configWithWorkers); writeErr != nil {
+			return fmt.Errorf("failed to write temp config with worker nodes: %w", writeErr)
+		}
+		if closeErr := tmpConfig.Close(); closeErr != nil {
+			return fmt.Errorf("failed to close temp config with worker nodes: %w", closeErr)
+		}
+		kindConfigPath = tmpConfig.Name()
+		_, _ = fmt.Fprintf(writer, "  ➕ Added %d extra worker node(s) to spoke config\n", opts.ExtraWorkerNodes)
+	}
+
 	// 4. Ensure kubeconfig directory exists
 	kubeconfigDir := filepath.Dir(opts.KubeconfigPath)
 	if err := os.MkdirAll(kubeconfigDir, 0755); err != nil {
@@ -601,7 +679,7 @@ func CreateKindClusterWithConfig(ctx context.Context, opts KindClusterOptions, w
 		var captured strings.Builder
 		cmd := exec.CommandContext(ctx, "kind", "create", "cluster",
 			"--name", opts.ClusterName,
-			"--config", absoluteConfigPath,
+			"--config", kindConfigPath,
 			"--kubeconfig", opts.KubeconfigPath,
 			"--wait", waitTimeout)
 

--- a/test/infrastructure/kind_cluster_helpers_test.go
+++ b/test/infrastructure/kind_cluster_helpers_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package infrastructure
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -52,6 +54,53 @@ var _ = Describe("checkKindVersionOutput", func() {
 		Entry("UT-INFRA-KIND-007: rejects empty output",
 			"", true),
 	)
+})
+
+// Issue #2333: some E2E demo scenarios (pending-taint, pdb-deadlock,
+// autoscale, node-notready) taint/drain/pressure-test a worker node distinct
+// from the control plane. The fleet spoke cluster (kind-fleetmetadatacache-
+// remote-config.yaml) is control-plane-only, so these scenarios can't run
+// against it as-is. appendWorkerNodesToKindConfig appends N `role: worker`
+// node entries to a Kind config's `nodes:` list, pinned to the same node
+// image as the existing control-plane node, so those scenarios have a
+// worker node to target.
+var _ = Describe("appendWorkerNodesToKindConfig", func() {
+	const sampleConfig = `kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.36.1@sha256:deadbeef
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+`
+
+	It("UT-INFRA-KIND-008: appends N worker entries pinned to the control-plane's image", func() {
+		result, err := appendWorkerNodesToKindConfig(sampleConfig, 2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Count(result, "- role: worker")).To(Equal(2))
+		Expect(strings.Count(result, "image: kindest/node:v1.36.1@sha256:deadbeef")).To(Equal(3), "control-plane + 2 workers should share the same pinned image")
+	})
+
+	It("UT-INFRA-KIND-009: workerCount=0 is a no-op passthrough", func() {
+		result, err := appendWorkerNodesToKindConfig(sampleConfig, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(sampleConfig))
+	})
+
+	It("UT-INFRA-KIND-010: errors when no image line exists to pin workers to", func() {
+		const noImageConfig = "kind: Cluster\napiVersion: kind.x-k8s.io/v1alpha4\nnodes:\n- role: control-plane\n"
+		_, err := appendWorkerNodesToKindConfig(noImageConfig, 1)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no node image found"))
+	})
+
+	It("UT-INFRA-KIND-011: preserves a config with no trailing newline", func() {
+		noTrailingNewline := strings.TrimSuffix(sampleConfig, "\n")
+		result, err := appendWorkerNodesToKindConfig(noTrailingNewline, 1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(ContainSubstring(noTrailingNewline + "\n- role: worker"))
+	})
 })
 
 // Issue #2327/#2326 helios08 fleet E2E triage: an earlier version of


### PR DESCRIPTION
Closes #2333.

Adds `-spoke-workers=N` to `hack/setup-fleet-infra` (default 0, current
control-plane-only behavior unchanged). Threaded through
`SetupFleetCoreInfrastructureWithGateway` → `provisionFleetCoreInfra` →
`SetupRemoteClusterForFMC` → `KindClusterOptions`, which now appends N
`role: worker` node entries to the spoke's Kind config at creation time.

`provisionFleetCoreInfra` and `SetupRemoteClusterForFMC` were refactored to
options structs (`FleetCoreInfraOptions`, `RemoteClusterFMCConfig`) — both
were at or approaching the project's 8-parameter limit before adding this
field.

Since Kind fixes node count at cluster creation, requesting workers on an
existing single-node spoke means tearing it down and recreating rather than
a live add.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./test/infrastructure/...`
- [x] New unit tests for `appendWorkerNodesToKindConfig` (UT-INFRA-KIND-008..011): append workers, no-op for zero workers, missing-image error, no-trailing-newline config