### PR TITLE
fix(fleet-demo): resolve chicken-and-egg LLM secret, AlertManager DNS/auth, MCP owner-chain resolution, and phase credential fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -963,16 +963,16 @@ test-e2e-fleet: ginkgo ensure-coverage-dirs ## Run fleet E2E tests (multi-cluste
 # fleet MCPServerRegistration/AlertManager label already uses for this same
 # physical cluster.
 .PHONY: setup-fleet-demo-infra
-setup-fleet-demo-infra: ## Create fleet Kind clusters + install Kubernaut, Console-first by default (~15 min). Required: LLM_PROVIDER, LLM_MODEL, LLM_ENDPOINT, and a pre-created llm-credentials-primary Secret
-	@if [ -z "$(LLM_PROVIDER)" ] || [ -z "$(LLM_MODEL)" ] || [ -z "$(LLM_ENDPOINT)" ]; then \
-		echo "❌ LLM_PROVIDER, LLM_MODEL, and LLM_ENDPOINT are all required, e.g.:"; \
+setup-fleet-demo-infra: ## Create fleet Kind clusters + install Kubernaut, Console-first by default (~15 min). Required: LLM_PROVIDER, LLM_MODEL, LLM_ENDPOINT, LLM_CREDENTIALS_FILE
+	@if [ -z "$(LLM_PROVIDER)" ] || [ -z "$(LLM_MODEL)" ] || [ -z "$(LLM_ENDPOINT)" ] || [ -z "$(LLM_CREDENTIALS_FILE)" ]; then \
+		echo "❌ LLM_PROVIDER, LLM_MODEL, LLM_ENDPOINT, and LLM_CREDENTIALS_FILE are all required, e.g.:"; \
 		echo "   make setup-fleet-demo-infra LLM_PROVIDER=openai_compatible LLM_MODEL=gpt-4o \\"; \
-		echo "     LLM_ENDPOINT=https://api.openai.com/v1"; \
+		echo "     LLM_ENDPOINT=https://api.openai.com/v1 LLM_CREDENTIALS_FILE=~/.secrets/llm-api-key.txt"; \
 		echo ""; \
-		echo "You must also create the llm-credentials-primary Secret yourself first:"; \
-		echo "   kubectl create namespace kubernaut-system"; \
-		echo "   kubectl create secret generic llm-credentials-primary \\"; \
-		echo "     --from-literal=api_key=<your-llm-api-key> -n kubernaut-system"; \
+		echo "LLM_CREDENTIALS_FILE is a file holding your raw LLM credential (a plain API"; \
+		echo "key, or a JSON blob for vertex_ai) -- it becomes the llm-credentials-primary"; \
+		echo "Secret's content once the hub cluster exists. Never put credential material"; \
+		echo "directly on the command line."; \
 		exit 1; \
 	fi
 	@echo "════════════════════════════════════════════════════════════════════════"
@@ -983,6 +983,7 @@ setup-fleet-demo-infra: ## Create fleet Kind clusters + install Kubernaut, Conso
 		-llm-provider "$(LLM_PROVIDER)" \
 		-llm-model "$(LLM_MODEL)" \
 		-llm-endpoint "$(LLM_ENDPOINT)" \
+		-llm-credentials-file "$(LLM_CREDENTIALS_FILE)" \
 		$(if $(AUTONOMOUS),-autonomous=$(AUTONOMOUS)) \
 		$(if $(GATEWAY_TYPE),-gateway-type "$(GATEWAY_TYPE)") \
 		$(if $(SPOKE_WORKERS),-spoke-workers "$(SPOKE_WORKERS)") \

--- a/README.md
+++ b/README.md
@@ -99,14 +99,13 @@ See the interactive version with per-phase detail: [How It Works](https://jordig
 
 ---
 
-## Roadmap
+## Try It Out
 
-### v1.6 — Fleet Operations (release candidate)
-
-- **Fleet operations** — Multi-cluster remediation orchestration through a pluggable scope-checking adapter: Red Hat ACM/OCM for ACM shops, or a control-plane-free mode backed by the built-in Fleet Metadata Cache (FMC) for GitOps and standalone clusters — with Rancher and Clusterpedia adapters architected for other vendor fleet platforms ([#54](https://github.com/jordigilh/kubernaut/issues/54))
-- **ServiceNow incident triage** (v1.6.1) — Consume ServiceNow incidents as signals through the API Frontend, enabling Kubernaut to investigate and remediate ITSM tickets alongside Kubernetes alerts ([#1338](https://github.com/jordigilh/kubernaut/issues/1338))
-
-**[Full roadmap](docs/roadmap/ROADMAP.md)** — for released features, see the [CHANGELOG](CHANGELOG.md).
+Don't have a cluster yet? Follow the
+[Fleet Demo Quick Start](docs/operations/deployment/FLEET_DEMO_QUICKSTART.md) to spin up
+a self-contained hub+spoke Kind environment, install Kubernaut, and run a real
+fault-injection demo scenario yourself. All you need is an LLM provider API key, ~16 GB
+of memory, 4 CPU cores, and ~50 GB of disk space.
 
 ---
 
@@ -131,16 +130,6 @@ independent and can be combined on the same install:
 | Autonomous | Alert-driven (Prometheus/AlertManager → Gateway) | [Autonomous Mode Setup Guide](docs/operations/deployment/AUTONOMOUS_MODE_SETUP_GUIDE.md) |
 | Interactive | Chat-driven (Console/APIFrontend, human-in-the-loop) | [Interactive Mode Setup Guide](docs/operations/deployment/INTERACTIVE_MODE_SETUP_GUIDE.md) |
 | Fleet | Multi-cluster (hub + spoke, layers onto either mode above) | [Fleet Setup Guide](docs/operations/deployment/FLEET_SETUP_GUIDE.md) |
-
----
-
-## Try It Out
-
-Don't have a cluster yet? Follow the
-[Fleet Demo Quick Start](docs/operations/deployment/FLEET_DEMO_QUICKSTART.md) to spin up
-a self-contained hub+spoke Kind environment, install Kubernaut, and run a real
-fault-injection demo scenario yourself. All you need is an LLM provider API key, ~16 GB
-of memory, 4 CPU cores, and ~50 GB of disk space.
 
 ---
 
@@ -198,18 +187,14 @@ Security posture is tracked continuously via [OpenSSF Scorecard](https://scoreca
 
 ---
 
-## Development
+## Roadmap
 
-```bash
-make build-all                    # Build all services
-make test-tier-unit               # Run unit tests (all services)
-make test-integration-apifrontend # Run integration tests for a service
-make test-e2e-apifrontend         # Run E2E tests for a service (Kind cluster)
-make test-all-gateway             # Run all test tiers for a service
-make lint                         # Run golangci-lint across the monorepo
-```
+### v1.6 — Fleet Operations (release candidate)
 
-We use **Ginkgo/Gomega BDD** for testing and follow a strict TDD workflow with a defense-in-depth testing pyramid (unit, integration, E2E). See the [Developer Guide](docs/DEVELOPER_GUIDE.md) for environment setup, build targets, and test commands.
+- **Fleet operations** — Multi-cluster remediation orchestration through a pluggable scope-checking adapter: Red Hat ACM/OCM for ACM shops, or a control-plane-free mode backed by the built-in Fleet Metadata Cache (FMC) for GitOps and standalone clusters — with Rancher and Clusterpedia adapters architected for other vendor fleet platforms ([#54](https://github.com/jordigilh/kubernaut/issues/54))
+- **ServiceNow incident triage** (v1.6.1) — Consume ServiceNow incidents as signals through the API Frontend, enabling Kubernaut to investigate and remediate ITSM tickets alongside Kubernetes alerts ([#1338](https://github.com/jordigilh/kubernaut/issues/1338))
+
+**[Full roadmap](docs/roadmap/ROADMAP.md)** — for released features, see the [CHANGELOG](CHANGELOG.md).
 
 ---
 

--- a/charts/kubernaut/.helm-coverage-allowlist.yaml
+++ b/charts/kubernaut/.helm-coverage-allowlist.yaml
@@ -31,6 +31,9 @@
 - authwebhook.nodeSelector
 - authwebhook.pdb.enabled
 - authwebhook.replicas
+- console.image.pullPolicy
+- console.image.repository
+- console.image.tag
 - console.ingress.className
 - console.nodeSelector
 - console.oauth2Proxy.image

--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -131,6 +131,10 @@ console:
     auth:
         secretName: ""
     enabled: false
+    image:
+        pullPolicy: IfNotPresent
+        repository: quay.io/kubernaut-ai/kubernaut-console
+        tag: 1.1.0
     ingress:
         annotations: {}
         className: ""
@@ -227,7 +231,7 @@ fleetmetadatacache:
     image:
         pullPolicy: IfNotPresent
         repository: quay.io/kubernaut-ai/fleetmetadatacache
-        tag: v1.6.0
+        tag: 1.6.0
     keyTTL: 45s
     namespace: ""
     oauth2:

--- a/charts/kubernaut/templates/console/console.yaml
+++ b/charts/kubernaut/templates/console/console.yaml
@@ -87,6 +87,21 @@ Issue #1984 Phase C: console.enabled=true's dependency on apifrontend.enabled,
 console.auth.secretName, an OIDC issuer, and console.ingress.host all moved
 from fail() guards here to values.schema.json if/then blocks (BR-PLATFORM-010).
 */}}
+{{- /*
+console.image (found 2026-09-02): kubernaut-console publishes its own
+release tags on quay.io/kubernaut-ai/kubernaut-console, decoupled from this
+chart's appVersion/global.image.tag train (confirmed: no 1.6.0 or 1.6.0-rcN
+tag has ever existed for it, only its own 1.0.0/1.1.0/1.5.x series) -- the
+previous `kubernaut.image` (service="kubernaut-console", appVersion=.Chart.
+AppVersion) render always resolved a tag that was never actually published.
+Mirrors fleetmetadatacache's existing direct image.repository/image.tag
+schema block (the one per-service override in this chart the template
+actually reads -- apifrontend also declares an `image:` schema block, but
+its own template still calls kubernaut.image unconditionally and never
+consumes it, a separate pre-existing gap out of scope here) rather than
+apifrontend's dead pattern.
+*/}}
+{{- $cv := include "kubernaut.mergedValues" (dict "root" $ "service" "console") | fromYaml }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -233,8 +248,8 @@ spec:
           volumeMounts:
             {{- include "kubernaut.tlsCaVolumeMount" . | nindent 12 }}
         - name: console
-          image: {{ include "kubernaut.image" (dict "service" "kubernaut-console" "root" $ "appVersion" .Chart.AppVersion) }}
-          imagePullPolicy: {{ include "kubernaut.imagePullPolicy" $ }}
+          image: "{{ $cv.image.repository }}:{{ $cv.image.tag }}"
+          imagePullPolicy: {{ $cv.image.pullPolicy }}
           ports:
             - name: static
               containerPort: 8080

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -2812,7 +2812,8 @@
             },
             "tag": {
               "type": "string",
-              "default": "v1.6.0"
+              "default": "1.6.0",
+              "description": "No 'v' prefix: quay.io/kubernaut-ai/fleetmetadatacache tags follow the same 1.6.0/1.6.0-rcN convention as the rest of the chart's images (fixed 2026-09-02 -- the prior 'v1.6.0' default never matched a published tag)."
             },
             "pullPolicy": {
               "type": "string",
@@ -3431,6 +3432,25 @@
               "type": "string",
               "default": "",
               "description": "Pre-created Secret with keys: client-id, client-secret, cookie-secret. Required when console.enabled=true."
+            }
+          }
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "kubernaut-console (2026-09-02): publishes its own quay.io/kubernaut-ai/kubernaut-console release tags, decoupled from this chart's appVersion/global.image.tag train -- no 1.6.0 or 1.6.0-rcN tag has ever existed for it.",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "default": "quay.io/kubernaut-ai/kubernaut-console"
+            },
+            "tag": {
+              "type": "string",
+              "default": "1.1.0"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "default": "IfNotPresent"
             }
           }
         },

--- a/cmd/kubernautagent/datastorage.go
+++ b/cmd/kubernautagent/datastorage.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -37,6 +38,7 @@ import (
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/tools/custom"
 	k8stools "github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/k8s"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/sanitization"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/summarizer"
@@ -158,6 +160,18 @@ func buildEnricher(cfg *kaconfig.Config, ds *dsClients, infra *k8sInfra, auditSt
 		e.WithLabelDetector(enrichment.NewLabelDetector(infra.dynClient, infra.mapper, logger.WithName("label-detector")))
 		logger.Info("label detector enabled (ADR-056)")
 	}
+	// Issue #2343: without this, Investigate()'s automatic pre-fetch
+	// enrichment step always resolved owner-chain/spec-hash against the hub
+	// (ds.k8sAdapter) even for a fleet-target investigation, unlike the
+	// get_namespaced_resource_context/get_cluster_resource_context tools
+	// (issue #2306), which already resolve per-call from ctx via
+	// custom.ResolveK8sClient. This installs the exact same routing one
+	// call site earlier, so both paths agree on which cluster they're
+	// looking at.
+	k8sResolverLogger := logger.WithName("enricher-k8s-resolver")
+	e.WithK8sResolver(func(ctx context.Context) enrichment.K8sClient {
+		return custom.ResolveK8sClient(ctx, ds.k8sAdapter, k8sResolverLogger)
+	})
 	e.WithRetryConfig(enrichment.RetryConfig{
 		MaxRetries:  cfg.AI.Enrichment.MaxRetries,
 		BaseBackoff: cfg.AI.Enrichment.BaseBackoff,

--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -621,11 +621,30 @@ func reloadSinglePhaseClient(
 	// #1726: a phase override's own apiKeyFile (distinct from the base
 	// profile's) must be resolved into APIKey here — EffectivePhaseConfig
 	// only produces the correct APIKeyFile, it does not read it.
-	// ResolveAPIKey no-ops when APIKeyFile is empty (inherited from base).
+	// An apiKeyFile that IS set but fails to resolve must reject this
+	// phase's client outright (IT-KA-1726-005, SI-10) — never fall back
+	// silently, so this early-return stays unconditional.
 	if err := merged.ResolveAPIKey(); err != nil {
 		logger.Error(err, "reload: failed to resolve phase LLM api key file",
 			"phase", phaseName, "apiKeyFile", merged.APIKeyFile)
 		return
+	}
+	// Issue #2341: a phase with no apiKeyFile override at all -- the common
+	// case, since Helm only renders one when the phase's
+	// credentialsSecretName differs from the base's
+	// (charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml) --
+	// and whose base runtime config never carried a resolved APIKey either
+	// (the base profile's own APIKey resolution at line ~431 is local to
+	// that call site, never written back into the shared LLMRuntimeConfig)
+	// left merged.APIKey empty here for file-based providers like vertex_ai.
+	// The client then fell through to plain GCP ADC lookup, which fails
+	// inside the pod (no metadata server, no GOOGLE_APPLICATION_CREDENTIALS).
+	// Guarding on APIKeyFile == "" keeps this fallback from ever firing for
+	// the reject-on-unreadable-file case above -- it only applies when there
+	// was no apiKeyFile to begin with.
+	if merged.APIKey == "" && merged.APIKeyFile == "" {
+		const credDir = "/etc/kubernaut-agent/credentials" // pre-commit:allow-sensitive (mount path)
+		merged.APIKey = credentials.ResolveCredentialsFile(merged.Provider, credDir, logger)
 	}
 
 	phaseClient, err := buildLLMClientFromConfig(context.Background(), merged)

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -145,6 +145,9 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 |-----------|------|--------------|---------|----------|
 | `auth.secretName` | string | Pre-created Secret with keys: client-id, client-secret, cookie-secret. Required when console.enabled=true. | `""` | No |
 | `enabled` | boolean |  | `false` | No |
+| `image.pullPolicy` | string |  | `"IfNotPresent"` | No |
+| `image.repository` | string |  | `"quay.io/kubernaut-ai/kubernaut-console"` | No |
+| `image.tag` | string |  | `"1.1.0"` | No |
 | `ingress.annotations` | object |  | `{}` | No |
 | `ingress.className` | string |  | `""` | No |
 | `ingress.enabled` | boolean |  | `false` | No |
@@ -261,7 +264,7 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `enabled` | boolean | DD-PLATFORM-006 Decision Area 10: when unset, the effective value is derived from global.fleet.enabled + global.fleet.backend (true whenever the fleet backend resolves to "fleetmetadatacache"); set explicitly to override. An explicit false that contradicts a derived-true fails the render. | `false` | No |
 | `image.pullPolicy` | string |  | `"IfNotPresent"` | No |
 | `image.repository` | string |  | `"quay.io/kubernaut-ai/fleetmetadatacache"` | No |
-| `image.tag` | string |  | `"v1.6.0"` | No |
+| `image.tag` | string | No 'v' prefix: quay.io/kubernaut-ai/fleetmetadatacache tags follow the same 1.6.0/1.6.0-rcN convention as the rest of the chart's images (fixed 2026-09-02 -- the prior 'v1.6.0' default never matched a published tag). | `"1.6.0"` | No |
 | `keyTTL` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"45s"` | No |
 | `namespace` | string | Namespace where the MCP Gateway manages its MCPServerRegistration (kuadrant) or Backend (eaigw) CRs. #2298 RCA: previously defaulted to "kubernaut-system" (FMC's own namespace), which silently scoped the ClusterRegistry watch away from wherever the MCP Gateway actually runs -- there is no safe default (a cluster can run more than one MCP Gateway). This (or its global.fleet.mcpGatewayNamespace fallback) must be set, or the FMC pod fails fast at startup: pkg/fleet/fmc/config.Validate() enforces this at the Go level (covers every deployment path, including the kubernaut-operator, which renders this ConfigMap independently of this chart). | `""` | No |
 | `nodeSelector` | map[string]object | Kubernetes node selector | `` | No |

--- a/docs/operations/deployment/FLEET_DEMO_QUICKSTART.md
+++ b/docs/operations/deployment/FLEET_DEMO_QUICKSTART.md
@@ -21,15 +21,14 @@ the Kind automation below? Use the Helm chart's own
 podman as the container runtime — `export KIND_EXPERIMENTAL_PROVIDER=podman`), and an
 API key from an LLM provider.
 
-The LLM credential is the only thing you provide by hand — everything else (Secrets,
-Rego policies, RBAC) is generated for you.
+The LLM credential is the only thing you provide by hand, and even that is just a file
+path — everything else (Secrets, Rego policies, RBAC) is generated for you.
 
-**1. Create the namespace and your LLM credentials Secret:**
+**1. Put your LLM credential in a file.** A plain API key for most providers, or a
+service-account/ADC JSON blob for `vertex_ai`:
 
 ```bash
-kubectl create namespace kubernaut-system
-kubectl create secret generic llm-credentials-primary \
-  --from-literal=api_key=<your-llm-api-key> -n kubernaut-system
+echo -n "<your-llm-api-key>" > /tmp/llm-credentials
 ```
 
 **2. Run the setup:**
@@ -38,13 +37,17 @@ kubectl create secret generic llm-credentials-primary \
 make setup-fleet-demo-infra \
   LLM_PROVIDER=openai_compatible \
   LLM_MODEL=gpt-4o \
-  LLM_ENDPOINT=https://api.openai.com/v1
+  LLM_ENDPOINT=https://api.openai.com/v1 \
+  LLM_CREDENTIALS_FILE=/tmp/llm-credentials
 ```
 
 This creates the hub + spoke Kind clusters, Keycloak, MCP Gateway, kube-mcp-server,
-Traefik, and fleet-wide monitoring, then runs `helm install charts/kubernaut` itself —
-remaining Secrets, default Rego policies, and RBAC included — and finishes by printing
-a Console URL, a login, and a suggested `/etc/hosts` line (~15 min total).
+and fleet-wide monitoring; once the hub cluster exists, it writes
+`LLM_CREDENTIALS_FILE`'s contents into the `llm-credentials-primary` Secret (there's no
+way to do this before the cluster exists to hold it); then it runs
+`helm install charts/kubernaut` itself — remaining Secrets, default Rego policies, and
+RBAC included — and finishes by printing a Console URL, a login, and a suggested
+`/etc/hosts` line (~15 min total).
 
 Gateway (autonomous, alert-driven remediation) starts **disabled**. Alerts still fire
 in Prometheus, but nothing auto-remediates until you ask Console to investigate — so

--- a/hack/setup-fleet-infra/main.go
+++ b/hack/setup-fleet-infra/main.go
@@ -18,11 +18,13 @@
 // -gateway-type=kuadrant if you specifically need it.
 //
 // Use this (`make setup-fleet-demo-infra`) for a one-shot, ready-to-browse
-// fleet + Kubernaut stack. You must create the LLM credentials Secret
-// yourself first (`kubectl create secret generic llm-credentials-primary
-// --from-literal=api_key=... -n kubernaut-system`, README "Try It Out") --
-// this tool never reads or handles that credential material. Everything
-// else (PostgreSQL/Valkey/console-oauth Secrets, a catch-all
+// fleet + Kubernaut stack. Pass -llm-credentials-file pointing at a file
+// holding your LLM provider credentials (a plain API key, or a JSON blob
+// for vertex_ai) -- the tool writes it into the llm-credentials-primary
+// Secret itself once the hub cluster exists (2026-09-01: previously the
+// docs asked you to pre-create this Secret before running setup at all,
+// which can't work since the cluster meant to hold it doesn't exist yet).
+// Everything else (PostgreSQL/Valkey/console-oauth Secrets, a catch-all
 // classification policy and an "always require approval" gate for
 // SignalProcessing/AIAnalysis Rego) is generated automatically unless you
 // pass -sp-policy-file/-aa-policy-file to override.
@@ -65,6 +67,7 @@ func main() {
 	llmProvider := flag.String("llm-provider", "", "required: global.llmProfiles.primary.provider (e.g. openai_compatible)")
 	llmModel := flag.String("llm-model", "", "required: global.llmProfiles.primary.model")
 	llmEndpoint := flag.String("llm-endpoint", "", "required: global.llmProfiles.primary.endpoint")
+	llmCredentialsFile := flag.String("llm-credentials-file", "", "required: path to a file holding your LLM provider credentials (a plain API key, or a JSON blob for vertex_ai service-account/ADC credentials) -- written verbatim into the llm-credentials-primary Secret once the hub cluster exists, replacing the mock placeholder")
 	spPolicyFile := flag.String("sp-policy-file", "", "optional: SignalProcessing Rego policy file (default: a built-in catch-all demo policy)")
 	aaPolicyFile := flag.String("aa-policy-file", "", "optional: AIAnalysis Rego policy file (default: a built-in policy that always requires human approval)")
 	// sigs.k8s.io/controller-runtime/pkg/client/config's own init() unconditionally
@@ -108,9 +111,17 @@ func main() {
 		fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 		os.Exit(1)
 	}
+	if *llmCredentialsFile == "" {
+		fmt.Fprintln(os.Stderr, "❌ missing required flag: -llm-credentials-file")
+		os.Exit(1)
+	}
 
 	ctx := context.Background()
-	fleetOpts, remoteKubeconfigPath, err := infrastructure.SetupFleetCoreInfrastructureWithGateway(ctx, *clusterName, *remoteClusterName, kubeconfigPath, gatewayType, *spokeWorkers, os.Stdout)
+	fleetOpts, remoteKubeconfigPath, err := infrastructure.SetupFleetCoreInfrastructureWithGateway(ctx, *clusterName, *remoteClusterName, kubeconfigPath, infrastructure.FleetCoreDemoOptions{
+		GatewayType:        gatewayType,
+		SpokeWorkers:       *spokeWorkers,
+		LLMCredentialsFile: *llmCredentialsFile,
+	}, os.Stdout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n❌ setup-fleet-infra failed: %v\n", err)
 		os.Exit(1)

--- a/internal/kubernautagent/enrichment/enricher.go
+++ b/internal/kubernautagent/enrichment/enricher.go
@@ -191,6 +191,7 @@ type Enricher struct {
 	logger        logr.Logger
 	labelDetector *LabelDetector
 	retryConfig   RetryConfig
+	k8sResolver   func(ctx context.Context) K8sClient
 }
 
 // NewEnricher creates an enricher with the given clients.
@@ -215,13 +216,42 @@ func (e *Enricher) WithRetryConfig(cfg RetryConfig) *Enricher {
 	return e
 }
 
+// WithK8sResolver installs a per-call override for the K8sClient used by
+// owner-chain and spec-hash resolution (Issue #2343). When resolver returns
+// non-nil, its result is used instead of the K8sClient passed to
+// NewEnricher; effectiveK8s falls back to that hub client otherwise -- so a
+// hub-local investigation (no resolver installed, or resolver returns nil)
+// is byte-identical to pre-#2343 behavior. Production wiring
+// (cmd/kubernautagent/datastorage.go's buildEnricher) installs a resolver
+// backed by custom.ResolveK8sClient, mirroring the same ctx-based fleet
+// overlay routing the get_namespaced_resource_context/get_cluster_resource_context
+// tools already use (issue #2306) -- this closes the one remaining call
+// site (the automatic pre-fetch enrichment step) that bypassed it.
+func (e *Enricher) WithK8sResolver(resolver func(ctx context.Context) K8sClient) *Enricher {
+	e.k8sResolver = resolver
+	return e
+}
+
+// effectiveK8s returns the K8sClient to use for this call: the resolver's
+// result when one is installed and returns non-nil, otherwise the hub
+// client passed to NewEnricher.
+func (e *Enricher) effectiveK8s(ctx context.Context) K8sClient {
+	if e.k8sResolver != nil {
+		if k8s := e.k8sResolver(ctx); k8s != nil {
+			return k8s
+		}
+	}
+	return e.k8s
+}
+
 // resolveOwnerChainWithRetry calls GetOwnerChain with optional retry logic.
 // With MaxRetries=0 (default): single call, best-effort.
 // With MaxRetries>0: all errors are retried with exponential backoff,
 // matching HAPI v1.2.1 EnrichmentService._retry (except Exception → retry).
 // The caller sets HardFail on EnrichmentResult when this returns a non-nil error.
 func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, namespace, apiVersion string) ([]OwnerChainEntry, error) {
-	chain, err := e.k8s.GetOwnerChain(ctx, kind, name, namespace, apiVersion)
+	k8s := e.effectiveK8s(ctx)
+	chain, err := k8s.GetOwnerChain(ctx, kind, name, namespace, apiVersion)
 	if err == nil {
 		return chain, nil
 	}
@@ -253,7 +283,7 @@ func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, n
 		case <-time.After(wait):
 		}
 
-		chain, err = e.k8s.GetOwnerChain(ctx, kind, name, namespace, apiVersion)
+		chain, err = k8s.GetOwnerChain(ctx, kind, name, namespace, apiVersion)
 		if err == nil {
 			return chain, nil
 		}
@@ -351,7 +381,7 @@ func (e *Enricher) resolveSpecHash(ctx context.Context, kind, name, namespace, a
 	if specHash != "" {
 		return specHash, nil
 	}
-	computed, err := e.k8s.GetSpecHash(ctx, kind, name, namespace, apiVersion)
+	computed, err := e.effectiveK8s(ctx).GetSpecHash(ctx, kind, name, namespace, apiVersion)
 	if err != nil {
 		if isForbiddenError(err) {
 			return "", fmt.Errorf("%w: GetSpecHash %s/%s in %s: %w", ErrRBACForbidden, kind, name, namespace, err)

--- a/internal/kubernautagent/enrichment/fleet_k8s_resolver_test.go
+++ b/internal/kubernautagent/enrichment/fleet_k8s_resolver_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enrichment_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+)
+
+// Issue #2343: Investigator.Investigate()'s pre-fetch enrichment step
+// (resolveSpecHash/resolveOwnerChainWithRetry) always used the K8sClient
+// passed to NewEnricher, ignoring any fleet-target routing carried on ctx --
+// unlike the get_namespaced_resource_context/get_cluster_resource_context
+// tools (issue #2306), which already resolve per-call from ctx via
+// resolveK8sClient. WithK8sResolver closes that gap by letting a caller
+// install a per-call override; production wiring (buildEnricher in
+// cmd/kubernautagent/datastorage.go) supplies a closure backed by
+// custom.ResolveK8sClient -- proven end to end by the IT in
+// test/integration/kubernautagent/investigator/fleet_enrichment_prefetch_it_test.go.
+var _ = Describe("Enricher.WithK8sResolver — #2343", func() {
+
+	var (
+		logger     = logr.Discard()
+		auditStore *recordingAuditStore
+		hub        *fakeK8sClient
+		overlay    *fakeK8sClient
+	)
+
+	BeforeEach(func() {
+		auditStore = &recordingAuditStore{}
+		hub = &fakeK8sClient{
+			ownerChain: []enrichment.OwnerChainEntry{{Kind: "Deployment", Name: "hub-should-not-appear", Namespace: "production"}},
+			specHash:   "sha256:hub-hash",
+		}
+		overlay = &fakeK8sClient{
+			ownerChain: []enrichment.OwnerChainEntry{{Kind: "Deployment", Name: "remote-target", Namespace: "demo-checkout"}},
+			specHash:   "sha256:overlay-hash",
+		}
+	})
+
+	Describe("UT-KA-2343-001: a resolved override client is used for owner-chain and spec-hash instead of the hub client", func() {
+		It("routes GetOwnerChain/GetSpecHash through the resolver's returned client, never the hub client passed to NewEnricher", func() {
+			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+			e := enrichment.NewEnricher(hub, ds, auditStore, logger).WithK8sResolver(func(_ context.Context) enrichment.K8sClient {
+				return overlay
+			})
+
+			result, err := e.Enrich(context.Background(), enrichment.EnrichRequest{
+				Kind: "Deployment", Name: "remote-target", Namespace: "demo-checkout",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.OwnerChain).To(HaveLen(1))
+			Expect(result.OwnerChain[0].Name).To(Equal("remote-target"),
+				"UT-KA-2343-001: owner chain must come from the resolver's overlay client, not the hub client")
+			Expect(ds.capturedSpecHash).To(Equal("sha256:overlay-hash"),
+				"UT-KA-2343-001: specHash must be auto-computed via the resolver's overlay client, not the hub client")
+		})
+	})
+
+	Describe("UT-KA-2343-002: no resolver installed falls back to the hub client (zero regression)", func() {
+		It("uses the hub client passed to NewEnricher when WithK8sResolver is never called", func() {
+			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+			e := enrichment.NewEnricher(hub, ds, auditStore, logger)
+
+			result, err := e.Enrich(context.Background(), enrichment.EnrichRequest{
+				Kind: "Deployment", Name: "hub-should-not-appear", Namespace: "production",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.OwnerChain).To(HaveLen(1))
+			Expect(result.OwnerChain[0].Name).To(Equal("hub-should-not-appear"))
+			Expect(ds.capturedSpecHash).To(Equal("sha256:hub-hash"))
+		})
+	})
+})

--- a/internal/kubernautagent/tools/custom/fleet_resource_context.go
+++ b/internal/kubernautagent/tools/custom/fleet_resource_context.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,6 +81,9 @@ func (r *overlayClientReader) Get(ctx context.Context, key client.ObjectKey, obj
 
 	text, err := r.getTool.Execute(ctx, argsJSON)
 	if err != nil {
+		if notFound := asRemoteNotFound(err, gvk, key.Name); notFound != nil {
+			err = notFound
+		}
 		return fmt.Errorf("overlayClientReader.Get: %s/%s in %q: %w", gvk.Kind, key.Name, key.Namespace, err)
 	}
 	fetched, err := mcpclient.ParseUnstructuredResponse(text)
@@ -86,6 +91,32 @@ func (r *overlayClientReader) Get(ctx context.Context, key client.ObjectKey, obj
 		return fmt.Errorf("overlayClientReader.Get: parse response for %s/%s: %w", gvk.Kind, key.Name, err)
 	}
 	return mcpclient.PopulateObject(fetched, obj)
+}
+
+// asRemoteNotFound recognizes the Kubernetes API's standard NotFound message
+// shape (apierrors.NewNotFound's `"<resource>[.<group>] %q not found"`) inside
+// a fleet overlay tool's error text and converts it to a typed
+// *apierrors.StatusError, or returns nil when the text doesn't match.
+//
+// The MCP protocol only carries tool errors as plain text (BridgeTool.Execute
+// renders a remote result.IsError as a formatted string, bridge_tool.go), so
+// a remote cluster's real apierrors.NewNotFound -- raised by kube-mcp-server's
+// own client-go call -- arrives here as a string, not a *apierrors.StatusError.
+// That loses the type enrichment.IsNotFoundError needs to honor the HardFail /
+// TargetResourceDeleted contract (issue #1039): every legitimately-absent
+// remote resource was misclassified as a hard failure, triggering
+// rca_incomplete for any fleet-target investigation whose target doesn't
+// exist (issue #2344, caught by E2E-FLEET-004 once #2343 first routed real
+// investigations through this path instead of the hub-only client).
+//
+// Scoped to the exact requested name (`%q not found`), not a blind "not
+// found" substring match, so an unrelated error that happens to mention a
+// different name isn't misclassified.
+func asRemoteNotFound(err error, gvk schema.GroupVersionKind, name string) error {
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("%q not found", name)) {
+		return nil
+	}
+	return apierrors.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: strings.ToLower(gvk.Kind)}, name)
 }
 
 // List is intentionally not supported: overlayClientReader only backs

--- a/internal/kubernautagent/tools/custom/fleet_resource_context_test.go
+++ b/internal/kubernautagent/tools/custom/fleet_resource_context_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -113,6 +114,47 @@ var _ = Describe("UT-KA-FLEET-031: overlayClientReader (BR-INTEGRATION-1489)", f
 		err := reader.Get(context.Background(), client.ObjectKey{Name: "p"}, obj)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("remote tool call failed"))
+	})
+
+	// UT-KA-FLEET-033 (issue #2344): the MCP protocol only carries tool
+	// errors as plain text (bridge_tool.go's BridgeTool.Execute renders
+	// result.IsError as a formatted string), so a remote cluster's real
+	// apierrors.NewNotFound arrives here as text, not a typed
+	// *apierrors.StatusError. Get must recognize the k8s-standard
+	// "<resource> \"<name>\" not found" message shape and re-wrap it as a
+	// typed NotFound so enrichment.IsNotFoundError (and the HardFail /
+	// TargetResourceDeleted contract, issue #1039) works identically to the
+	// hub-local K8sAdapter path. Without this, every legitimately-absent
+	// remote resource was misclassified as a hard failure.
+	It("returns a typed apierrors NotFound when the remote tool reports a k8s-style not-found (issue #2344)", func() {
+		getTool := &fakeGetTool{
+			err: fmt.Errorf("remote tool %q (cluster %q) returned error: failed to get resource: pods %q not found",
+				"remote-cluster__resources_get", "remote-cluster", "memory-eater"),
+		}
+		reader := custom.NewOverlayClientReader(getTool)
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Pod"})
+		err := reader.Get(context.Background(), client.ObjectKey{Namespace: "kubernaut-system", Name: "memory-eater"}, obj)
+
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+			"UT-KA-FLEET-033: remote not-found text must be classified as a typed apierrors NotFound")
+	})
+
+	It("does not misclassify an unrelated error mentioning a different resource as not-found (issue #2344)", func() {
+		getTool := &fakeGetTool{
+			err: fmt.Errorf(`remote tool "remote-cluster__resources_get" (cluster "remote-cluster") returned error: connection refused`),
+		}
+		reader := custom.NewOverlayClientReader(getTool)
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Pod"})
+		err := reader.Get(context.Background(), client.ObjectKey{Namespace: "kubernaut-system", Name: "memory-eater"}, obj)
+
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsNotFound(err)).To(BeFalse(),
+			"UT-KA-FLEET-033: a non-not-found error must not be misclassified")
 	})
 
 	It("returns a clear not-supported error for List", func() {

--- a/internal/kubernautagent/tools/custom/resource_context.go
+++ b/internal/kubernautagent/tools/custom/resource_context.go
@@ -65,8 +65,8 @@ type clusterResponse struct {
 	RemediationHistory *enrichment.RemediationHistoryResult `json:"remediation_history"`
 }
 
-// resolveK8sClient picks the effective enrichment.K8sClient for one Execute
-// call (issue #2306): the hub-bound client for a hub-local investigation (no
+// ResolveK8sClient picks the effective enrichment.K8sClient for one call
+// (issue #2306): the hub-bound client for a hub-local investigation (no
 // fleet overlay in ctx) — zero regression, byte-identical to before this fix
 // — a new overlay-backed K8sClient wrapping the fleet overlay's resources_get
 // tool for a fleet-target investigation whose overlay publishes it, or a
@@ -75,7 +75,13 @@ type clusterResponse struct {
 // deliberately does NOT fall back to hub, which would silently resolve
 // owner-chain/spec-hash against the wrong cluster — the exact AC-6 defect
 // this issue closes for the k8s-tool suppression half.
-func resolveK8sClient(ctx context.Context, hub enrichment.K8sClient, logger logr.Logger) enrichment.K8sClient {
+//
+// Exported (issue #2343) so cmd/kubernautagent's buildEnricher can install
+// the exact same routing as an Enricher.WithK8sResolver closure — the
+// get_namespaced_resource_context/get_cluster_resource_context tools below
+// and the Investigator's own pre-fetch enrichment step now share one
+// resolution path instead of the tools being the only caller.
+func ResolveK8sClient(ctx context.Context, hub enrichment.K8sClient, logger logr.Logger) enrichment.K8sClient {
 	overlay, hasOverlay := investigator.FleetOverlayFromContext(ctx)
 	if !hasOverlay {
 		return hub
@@ -152,7 +158,7 @@ func (t *namespacedResourceContextTool) Execute(ctx context.Context, args json.R
 		return "", fmt.Errorf("parsing args: %w", err)
 	}
 
-	k8sClient := resolveK8sClient(ctx, t.k8s, t.logger)
+	k8sClient := ResolveK8sClient(ctx, t.k8s, t.logger)
 
 	chain, chainErr := k8sClient.GetOwnerChain(ctx, params.Kind, params.Name, params.Namespace, "")
 	if chainErr != nil {
@@ -222,7 +228,7 @@ func (t *clusterResourceContextTool) Execute(ctx context.Context, args json.RawM
 		return "", fmt.Errorf("parsing args: %w", err)
 	}
 
-	k8sClient := resolveK8sClient(ctx, t.k8s, t.logger)
+	k8sClient := ResolveK8sClient(ctx, t.k8s, t.logger)
 
 	specHash := computeSpecHash(ctx, t.logger, k8sClient, params.Kind, params.Name, "", "get_cluster_resource_context")
 	clusterID, _ := audit.ClusterIDFromContext(ctx)

--- a/pkg/fleet/mcpclient/client.go
+++ b/pkg/fleet/mcpclient/client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -342,7 +343,19 @@ func (c *Client) getResource(ctx context.Context, kind, apiVersion, namespace, n
 	}
 
 	if result.IsError {
-		return nil, fmt.Errorf("call %s returned error: %s", toolName, ExtractText(result))
+		errText := ExtractText(result)
+		// Issue #2349: a NotFound must arrive typed so callers relying on
+		// apierrors.IsNotFound/client.IgnoreNotFound (e.g. JobExecutor.Cleanup's
+		// ownership-check Get, pkg/workflowexecution/executor/job.go) actually
+		// match it instead of hard-failing forever on a resource that
+		// legitimately never existed.
+		gv, gvErr := schema.ParseGroupVersion(apiVersion)
+		if gvErr == nil {
+			if nf := asRemoteNotFound(errText, gv.WithKind(kind), name); nf != nil {
+				return nil, nf
+			}
+		}
+		return nil, fmt.Errorf("call %s returned error: %s", toolName, errText)
 	}
 
 	if m := extractStructuredGet(result); m != nil {

--- a/pkg/fleet/mcpclient/client_test.go
+++ b/pkg/fleet/mcpclient/client_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -123,6 +124,27 @@ var _ = Describe("ResourceClient (BR-FLEET-002, Phase 0)", func() {
 
 			err = c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "nginx"}, obj)
 			Expect(err).To(HaveOccurred())
+		})
+
+		// UT-FLEET-MCP-NOTFOUND-004 (issue #2349): Get must recognize a
+		// remote resources_get's plain-text "not found" message shape and
+		// return a typed apierrors.NotFound, so callers relying on
+		// apierrors.IsNotFound/client.IgnoreNotFound (e.g.
+		// JobExecutor.Cleanup's ownership-check Get) actually match it.
+		It("UT-FLEET-MCP-NOTFOUND-004: Get returns a typed apierrors.NotFound for a k8s-style remote not-found", func() {
+			gw = mockgw.NewMockGateway(mockgw.WithMultiCluster("prod-east"))
+
+			c, err := mcpclient.New(ctx, gw.URL(), mcpclient.WithClusterID("prod-east"))
+			Expect(err).ToNot(HaveOccurred())
+			defer c.Close()
+
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"})
+
+			err = c.Get(ctx, client.ObjectKey{Namespace: "kubernaut-workflows", Name: mockgw.NotFoundSentinelName}, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+				"remote not-found text must be classified as a typed apierrors NotFound")
 		})
 
 		It("UT-FLEET-P0-007: returns error when GVK Kind is not set", func() {

--- a/pkg/fleet/mcpclient/notfound.go
+++ b/pkg/fleet/mcpclient/notfound.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpclient
+
+import (
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// asRemoteNotFound recognizes the Kubernetes API's standard NotFound message
+// shape (apierrors.NewNotFound's `"<resource>[.<group>] %q not found"`)
+// inside a remote MCP tool's error text and converts it to a typed
+// *apierrors.StatusError, or returns nil when the text doesn't match.
+//
+// The MCP protocol only carries tool errors as plain text (result.IsError
+// renders as a formatted string, not a Go error type), so the remote
+// kube-mcp-server's own apierrors.NewNotFound arrives here as a string.
+// Every caller relying on apierrors.IsNotFound / client.IgnoreNotFound
+// against a resource fetched through this client -- e.g.
+// JobExecutor.Cleanup's ownership-check Get and idempotent-delete Delete
+// (pkg/workflowexecution/executor/job.go) -- silently never matched,
+// permanently blocking WorkflowExecution's cleanup finalizer whenever the
+// target Job never existed (issue #2349).
+//
+// This mirrors the identical, independently-discovered fix already applied
+// to kubernaut-agent's own overlay client
+// (internal/kubernautagent/tools/custom/fleet_resource_context.go, issue
+// #2344) -- this is the foundational occurrence: that fix only covered
+// kubernaut-agent's investigator tools, not this shared client used by
+// every other fleet consumer (Gateway, WorkflowExecution, SignalProcessing,
+// EffectivenessMonitor, RemediationOrchestrator, APIFrontend).
+//
+// Scoped to the exact requested name (`%q not found`), not a blind "not
+// found" substring match, so an unrelated error mentioning a different name
+// isn't misclassified.
+func asRemoteNotFound(errText string, gvk schema.GroupVersionKind, name string) error {
+	if !strings.Contains(errText, fmt.Sprintf("%q not found", name)) {
+		return nil
+	}
+	return apierrors.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: strings.ToLower(gvk.Kind)}, name)
+}

--- a/pkg/fleet/mcpclient/notfound_test.go
+++ b/pkg/fleet/mcpclient/notfound_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpclient
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// UT-FLEET-MCP-NOTFOUND: asRemoteNotFound (issue #2349, foundational
+// occurrence of #2344's fix).
+var _ = Describe("asRemoteNotFound", func() {
+	gvk := schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+
+	It("UT-FLEET-MCP-NOTFOUND-001: recognizes the k8s-standard not-found message shape", func() {
+		errText := fmt.Sprintf(`call remote-cluster__resources_get returned error: failed to get resource: jobs.batch %q not found`, "wfe-618ac7d3b8940927")
+
+		err := asRemoteNotFound(errText, gvk, "wfe-618ac7d3b8940927")
+
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("UT-FLEET-MCP-NOTFOUND-002: does not misclassify an unrelated error mentioning a different name", func() {
+		errText := `call remote-cluster__resources_get returned error: connection refused`
+
+		err := asRemoteNotFound(errText, gvk, "wfe-618ac7d3b8940927")
+
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("UT-FLEET-MCP-NOTFOUND-003: does not misclassify a not-found for a different resource name", func() {
+		errText := fmt.Sprintf(`failed to get resource: jobs.batch %q not found`, "some-other-job")
+
+		err := asRemoteNotFound(errText, gvk, "wfe-618ac7d3b8940927")
+
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/pkg/fleet/mcpclient/reader_factory.go
+++ b/pkg/fleet/mcpclient/reader_factory.go
@@ -112,7 +112,7 @@ func (f *mcpReaderFactory) ReaderFor(ctx context.Context, clusterID string) (cli
 			opts = append(opts, WithToolPrefix(prefix))
 		}
 	} else {
-		prefix, err := DiscoverToolPrefix(ctx, session, clusterID)
+		prefix, err := f.discoverToolPrefixWithReconnect(ctx, session, clusterID)
 		if err != nil {
 			return nil, fmt.Errorf("resolve tool prefix for cluster %q: %w", clusterID, err)
 		}
@@ -126,4 +126,35 @@ func (f *mcpReaderFactory) ReaderFor(ctx context.Context, clusterID string) (cli
 		return NewFromSessionProvider(f.sessionProvider, clusterID, opts...), nil
 	}
 	return NewFromSession(session, clusterID, opts...), nil
+}
+
+// discoverToolPrefixWithReconnect calls DiscoverToolPrefix against session,
+// and on a retryable session error invokes f.reconnect once and retries
+// against the freshly-resolved session. Mirrors providerDiscoverer's
+// retryWithReconnect (discovery.go) so this call site follows the same
+// self-healing semantics as ListClusters/ToolsForCluster instead of the
+// pre-#2317 "permanently nil resolver" failure mode one level deeper.
+//
+// Without this, a session that dies mid-lifetime (gateway itself stays
+// healthy) fails ReaderFor -- and therefore remote owner-chain resolution --
+// forever, until the pod restarts. Observed live on the Fleet E2E hub as
+// repeated "standalone SSE stream: exceeded 5 retries without progress"
+// errors reusing the same dead session ID (issue #2340, a gap #2317 missed:
+// this call site invoked DiscoverToolPrefix directly on the raw session,
+// bypassing the reconnect callback already available on the struct).
+func (f *mcpReaderFactory) discoverToolPrefixWithReconnect(ctx context.Context, session *mcp.ClientSession, clusterID string) (string, error) {
+	prefix, err := DiscoverToolPrefix(ctx, session, clusterID)
+	if err == nil || f.reconnect == nil || !isRetryableSessionError(err) {
+		return prefix, err
+	}
+
+	if reconnErr := f.reconnect(ctx); reconnErr != nil {
+		return "", fmt.Errorf("reconnect failed: %w (original: %w)", reconnErr, err)
+	}
+
+	session, resolveErr := ResolveSession(f.session, f.sessionProvider)
+	if resolveErr != nil {
+		return "", resolveErr
+	}
+	return DiscoverToolPrefix(ctx, session, clusterID)
 }

--- a/pkg/fleet/mcpclient/reader_factory.go
+++ b/pkg/fleet/mcpclient/reader_factory.go
@@ -143,16 +143,44 @@ func (f *mcpReaderFactory) ReaderFor(ctx context.Context, clusterID string) (cli
 // this call site invoked DiscoverToolPrefix directly on the raw session,
 // bypassing the reconnect callback already available on the struct).
 func (f *mcpReaderFactory) discoverToolPrefixWithReconnect(ctx context.Context, session *mcp.ClientSession, clusterID string) (string, error) {
+	return discoverToolPrefixWithReconnectImpl(ctx, session, f.session, f.sessionProvider, clusterID, f.reconnect)
+}
+
+// DiscoverToolPrefixWithReconnect resolves the current session from static/
+// provider (via ResolveSession) and calls DiscoverToolPrefix against it, and
+// on a retryable session error invokes reconnect once (when non-nil) and
+// retries against the freshly re-resolved session.
+//
+// Exported (issue #2346) so every fleet-aware consumer that calls
+// DiscoverToolPrefix directly shares one self-healing implementation instead
+// of independently reintroducing the pre-#2340 "no reconnect on a dead
+// session" gap at a new call site -- as workflowexecution's
+// mcpClientFactory.ClientFor (pkg/workflowexecution/executor/client_factory.go)
+// had done, the third such occurrence after #2317 and #2340.
+func DiscoverToolPrefixWithReconnect(ctx context.Context, static *mcp.ClientSession, provider SessionProvider, clusterID string, reconnect func(context.Context) error) (string, error) {
+	session, err := ResolveSession(static, provider)
+	if err != nil {
+		return "", err
+	}
+	return discoverToolPrefixWithReconnectImpl(ctx, session, static, provider, clusterID, reconnect)
+}
+
+// discoverToolPrefixWithReconnectImpl is the shared retry body: try once
+// against the already-resolved session, and on a retryable error, reconnect
+// and re-resolve before retrying once more. Split out so mcpReaderFactory
+// (which already has a resolved session in hand for other uses in ReaderFor)
+// doesn't pay a redundant ResolveSession call.
+func discoverToolPrefixWithReconnectImpl(ctx context.Context, session, static *mcp.ClientSession, provider SessionProvider, clusterID string, reconnect func(context.Context) error) (string, error) {
 	prefix, err := DiscoverToolPrefix(ctx, session, clusterID)
-	if err == nil || f.reconnect == nil || !isRetryableSessionError(err) {
+	if err == nil || reconnect == nil || !isRetryableSessionError(err) {
 		return prefix, err
 	}
 
-	if reconnErr := f.reconnect(ctx); reconnErr != nil {
+	if reconnErr := reconnect(ctx); reconnErr != nil {
 		return "", fmt.Errorf("reconnect failed: %w (original: %w)", reconnErr, err)
 	}
 
-	session, resolveErr := ResolveSession(f.session, f.sessionProvider)
+	session, resolveErr := ResolveSession(static, provider)
 	if resolveErr != nil {
 		return "", resolveErr
 	}

--- a/pkg/fleet/mcpclient/reader_factory_test.go
+++ b/pkg/fleet/mcpclient/reader_factory_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpclient_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
+	mockgw "github.com/jordigilh/kubernaut/test/services/mock-mcp-gateway/testutil"
+)
+
+// Mid-lifetime session death for the tool-prefix discovery path used by
+// mcpReaderFactory.ReaderFor (issue #2340, a gap #2317 missed).
+//
+// #2317 added reconnect-on-retryable-error to providerDiscoverer's
+// ListClusters/ToolsForCluster (discovery.go) and to Client.callTool itself,
+// but mcpReaderFactory.ReaderFor's own tool-prefix lookup -- the
+// DiscoverToolPrefix(ctx, session, clusterID) call taken when no
+// registry.ToolPrefixResolver is configured, which is exactly how
+// cmd/gateway/main.go wires NewMCPReaderFactoryWithProvider today -- calls
+// DiscoverToolPrefix directly on the raw resolved session, bypassing the
+// same self-healing retry even though f.reconnect is available on the
+// struct. Observed live on the Fleet E2E hub: Gateway's Prometheus adapter
+// permanently failed remote owner-chain resolution for "remote-cluster"
+// with "list tools from MCP Gateway: connection closed: ... standalone SSE
+// stream: exceeded 5 retries without progress" after the underlying session
+// died mid-lifetime, even though the MCP Gateway and kube-mcp-server both
+// stayed healthy throughout.
+var _ = Describe("mcpReaderFactory.ReaderFor reconnect-on-failure (issue #2317 gap)", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("UT-READERFACTORY-RECONN-001: ReaderFor recovers via reconnect after the underlying session dies mid-lifetime", func() {
+		gw := mockgw.NewMockGateway(mockgw.WithMultiCluster("prod-east"))
+		defer gw.Close()
+
+		cfg := mcpclient.DefaultResilienceConfig()
+		cfg.MaxElapsedTime = 5 * time.Second
+		rc, err := mcpclient.NewResilient(ctx, gw.URL(), cfg, logr.Discard())
+		Expect(err).ToNot(HaveOccurred())
+		defer func() { _ = rc.Close() }()
+
+		factory := mcpclient.NewMCPReaderFactoryWithProvider(nil, rc.SessionProvider(), rc.Reconnect)
+
+		// Simulate the session dying from a protocol-level error while the
+		// MCP Gateway itself stays healthy -- exactly the observed
+		// production scenario (gateway healthy, client session dead).
+		Expect(rc.Session().Close()).ToNot(HaveOccurred())
+
+		reader, err := factory.ReaderFor(ctx, "prod-east")
+		Expect(err).ToNot(HaveOccurred(),
+			"ReaderFor must recover by reconnecting once the session is dead, not fail forever")
+		Expect(reader).ToNot(BeNil())
+
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "PodList"})
+		Expect(reader.List(ctx, list, client.InNamespace("default"))).To(Succeed(),
+			"the reader returned after reconnect must actually be usable")
+	})
+
+	It("UT-READERFACTORY-RECONN-002: without a reconnect callback, a dead session fails ReaderFor every time", func() {
+		gw := mockgw.NewMockGateway(mockgw.WithMultiCluster("prod-west"))
+		defer gw.Close()
+
+		cfg := mcpclient.DefaultResilienceConfig()
+		cfg.MaxElapsedTime = 5 * time.Second
+		rc, err := mcpclient.NewResilient(ctx, gw.URL(), cfg, logr.Discard())
+		Expect(err).ToNot(HaveOccurred())
+		defer func() { _ = rc.Close() }()
+
+		factory := mcpclient.NewMCPReaderFactoryWithProvider(nil, rc.SessionProvider(), nil)
+
+		Expect(rc.Session().Close()).ToNot(HaveOccurred())
+
+		_, err = factory.ReaderFor(ctx, "prod-west")
+		Expect(err).To(HaveOccurred(), "without a reconnect callback there is no way to repair a dead session")
+	})
+})

--- a/pkg/fleet/mcpclient/writer.go
+++ b/pkg/fleet/mcpclient/writer.go
@@ -165,7 +165,15 @@ func (w *WriterClient) Delete(ctx context.Context, obj client.Object, _ ...clien
 		return err
 	}
 	if result.IsError {
-		return fmt.Errorf("call %s returned error: %s", toolName, ExtractText(result))
+		errText := ExtractText(result)
+		// Issue #2349: a NotFound must arrive typed so an idempotent delete
+		// (client.IgnoreNotFound) of an already-gone remote resource -- e.g.
+		// JobExecutor.Cleanup, pkg/workflowexecution/executor/job.go -- is
+		// actually recognized as such instead of hard-failing.
+		if nf := asRemoteNotFound(errText, gvk, obj.GetName()); nf != nil {
+			return nf
+		}
+		return fmt.Errorf("call %s returned error: %s", toolName, errText)
 	}
 	return nil
 }

--- a/pkg/fleet/mcpclient/writer_test.go
+++ b/pkg/fleet/mcpclient/writer_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -289,6 +290,34 @@ var _ = Describe("WriterClient (BR-FLEET-054)", func() {
 			}
 			Expect(found).To(BeTrue(),
 				"WriterClient.Delete must call {clusterID}__resources_delete")
+		})
+
+		// UT-FLEET-MCP-NOTFOUND-005 (issue #2349): an idempotent delete of an
+		// already-gone remote resource must surface as a typed
+		// apierrors.NotFound so client.IgnoreNotFound (e.g.
+		// JobExecutor.Cleanup, pkg/workflowexecution/executor/job.go)
+		// actually recognizes it instead of hard-failing forever.
+		It("UT-FLEET-MCP-NOTFOUND-005: Delete returns a typed apierrors.NotFound for a k8s-style remote not-found", func() {
+			gw = mockgw.NewMockGateway(mockgw.WithMultiCluster("prod-west"))
+
+			parentClient, err := mcpclient.New(ctx, gw.URL())
+			Expect(err).ToNot(HaveOccurred())
+			defer parentClient.Close()
+
+			writer := mcpclient.NewWriterFromSession(parentClient.Session(), "prod-west")
+
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      mockgw.NotFoundSentinelName,
+					Namespace: "kubernaut-workflows",
+				},
+			}
+			job.SetGroupVersionKind(batchv1.SchemeGroupVersion.WithKind("Job"))
+
+			err = writer.Delete(ctx, job)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+				"remote not-found text must be classified as a typed apierrors NotFound")
 		})
 	})
 

--- a/pkg/workflowexecution/executor/client_factory.go
+++ b/pkg/workflowexecution/executor/client_factory.go
@@ -152,7 +152,14 @@ func (f *mcpClientFactory) ClientFor(ctx context.Context, clusterID string) (Exe
 			opts = append(opts, mcpclient.WithToolPrefix(prefix))
 		}
 	} else {
-		prefix, err := mcpclient.DiscoverToolPrefix(ctx, session, clusterID)
+		// Issue #2346 (a third instance of #2340's gap): must go through the
+		// reconnect-and-retry wrapper, not call DiscoverToolPrefix directly
+		// on session -- session here can already be a stale snapshot (from
+		// ResolveSession above) if the underlying MCP session died between
+		// this ClientFor call and the previous one, since ClientFor is
+		// invoked fresh on every JobExecutor.Create/GetStatus rather than
+		// cached.
+		prefix, err := mcpclient.DiscoverToolPrefixWithReconnect(ctx, f.session, f.sessionProvider, clusterID, f.reconnect)
 		if err != nil {
 			return nil, fmt.Errorf("resolve tool prefix for cluster %q: %w", clusterID, err)
 		}

--- a/pkg/workflowexecution/executor/client_factory_test.go
+++ b/pkg/workflowexecution/executor/client_factory_test.go
@@ -158,5 +158,37 @@ var _ = Describe("UT-WE-054-CF: ClientFactory", func() {
 			Expect(err).ToNot(HaveOccurred(),
 				"Get must recover by reconnecting once the session is dead, not fail forever")
 		})
+
+		// UT-WE-054-CF-007 above only kills the session *after* ClientFor has
+		// already returned a client -- it never exercises ClientFor's own
+		// internal DiscoverToolPrefix call against an already-dead session.
+		// Issue #2346 (a third instance of #2340's gap): ClientFor is called
+		// fresh on every JobExecutor.Create/GetStatus (not cached), so a
+		// session that dies *before* ClientFor runs -- e.g. between the
+		// AIAnalysis phase and the WorkflowExecution phase -- hit this
+		// exact, previously-uncovered path in production.
+		It("UT-WE-054-CF-008: ClientFor itself recovers via reconnect when the session is already dead before the call (issue #2346)", func() {
+			gw := mockgw.NewMockGateway(mockgw.WithMultiCluster("remote-cluster"))
+			defer gw.Close()
+
+			cfg := mcpclient.DefaultResilienceConfig()
+			cfg.MaxElapsedTime = 5 * time.Second
+			rc, err := mcpclient.NewResilient(ctx, gw.URL(), cfg, logr.Discard())
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _ = rc.Close() }()
+
+			localClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			factory := executor.NewMCPClientFactoryWithProvider(localClient, rc.SessionProvider(), rc.Reconnect)
+
+			// Kill the session BEFORE calling ClientFor -- simulates the
+			// production scenario where the gateway stays healthy but the
+			// client's session died in between two ClientFor calls.
+			Expect(rc.Session().Close()).ToNot(HaveOccurred())
+
+			execClient, err := factory.ClientFor(ctx, "remote-cluster")
+			Expect(err).ToNot(HaveOccurred(),
+				"ClientFor must recover by reconnecting once the session is already dead, not fail forever")
+			Expect(execClient).ToNot(BeNil())
+		})
 	})
 })

--- a/test/infrastructure/effectivenessmonitor_e2e.go
+++ b/test/infrastructure/effectivenessmonitor_e2e.go
@@ -292,7 +292,7 @@ func SetupEMInfrastructure(ctx context.Context, clusterName, kubeconfigPath stri
 
 	// Deploy AlertManager (real instance for alert resolution)
 	// EM suite does not deploy Gateway; pass empty token (webhook targets gateway-service which may not exist)
-	if err := DeployAlertManager(ctx, namespace, kubeconfigPath, "", writer); err != nil {
+	if err := DeployAlertManager(ctx, namespace, namespace, kubeconfigPath, "", writer); err != nil {
 		return fmt.Errorf("failed to deploy AlertManager: %w", err)
 	}
 

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -19,6 +19,7 @@ package infrastructure
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -87,6 +88,14 @@ const (
 	gatewayLabelKuadrant = "Kuadrant MCP Gateway"
 	gatewayLabelEAIGW    = "Envoy AI Gateway (EAIGW)"
 
+	// fleetAlertManagerGatewaySA: ServiceAccount minted so the fleet demo's
+	// hub AlertManager can authenticate its gateway-webhook POSTs (Gateway's
+	// BR-GATEWAY-036/037 auth middleware rejects unauthenticated requests
+	// with 401 -- demo team report, 2026-09-02). Distinct name from
+	// fullpipeline_e2e.go's "fullpipeline-gateway-sa" so both suites' RBAC
+	// bindings can coexist if ever run against the same cluster.
+	fleetAlertManagerGatewaySA = "fleet-alertmanager-gateway-sa"
+
 	// KubeMCPServerAuthModeKubeconfig makes kube-mcp-server ignore any
 	// caller-forwarded Authorization header and always use its own
 	// ServiceAccount (ADR-068 Decision #9, "no token delegation"). This is
@@ -124,6 +133,22 @@ type KubeMCPServerAuthConfig struct {
 	RequireOAuth     bool
 	AuthorizationURL string
 	OAuthAudience    string
+	// KeycloakNamespace is the namespace Keycloak's own Service actually
+	// lives in -- namespace (kubernautSystem) for the "fleet"/"fullpipeline"
+	// Ginkgo suites, idpNamespace ("idp") for the demo-only entry point
+	// (SetupFleetCoreInfrastructureWithGateway). Empty falls back to
+	// whichever namespace the caller passes to deployEnvoyAIGatewayRegistrations/
+	// deployKuadrantRegistrations, preserving every existing caller's
+	// behavior unchanged. Deliberately separate from AuthorizationURL
+	// (already keycloakNamespace-aware via oidcCfg.IssuerURL): the
+	// "keycloak-jwks" EAIGW Backend needs Keycloak's bare hostname for DNS
+	// resolution, not the full issuer URL AuthorizationURL carries -- found
+	// 2026-09-02 when the demo path's Backend hardcoded namespace (kubernaut-system)
+	// instead of idpNamespace, so Envoy's JWKS fetch permanently 503'd
+	// ("Jwks async fetching... failed", never converging regardless of
+	// timeout) even though AuthorizationURL/the token URL were already
+	// correct.
+	KeycloakNamespace string
 	// StsClientID/StsClientSecret/StsAudience drive the RFC 8693 token
 	// exchange. Deliberately NOT setting token_exchange_strategy: Spike S18
 	// found the pluggable "keycloak-v1" exchanger never sets
@@ -389,6 +414,51 @@ func SetupFleetE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPat
 	return builtImages, seededUUIDs, afRemediateNS, remoteKubeconfigPath, nil
 }
 
+// buildLLMCredentialsSecretManifest renders the llm-credentials-primary
+// Secret manifest with the given file's raw bytes under BOTH key names the
+// chart's kubernaut.llm.credFile helper can ask for: "api_key" (every
+// provider except vertex_ai) and "credentials.json" (vertex_ai only --
+// confirmed via _helpers.tpl's kubernaut.llm.credFile). This function runs
+// before the LLM provider is known to the infra-provisioning step (that's
+// FleetDemoHelmOptions.LLMProvider, resolved later, in the separate
+// `helm install` step), so it populates both rather than plumbing the
+// provider string through this far earlier in the flow.
+//
+// Base64-encoded via the manifest's `data:` field (not `stringData:`)
+// deliberately: vertex_ai credential material is a JSON blob that may
+// contain characters (quotes, newlines) that don't round-trip safely
+// through a YAML block scalar. Pure function (no exec/cluster access) for
+// unit testing, mirroring buildFleetDemoHelmSecretsManifest.
+func buildLLMCredentialsSecretManifest(namespace string, credentials []byte) string {
+	encoded := base64.StdEncoding.EncodeToString(credentials)
+	return fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+type: Opaque
+data:
+  api_key: %s
+  credentials.json: %s
+`, fleetDemoLLMSecretName, namespace, encoded, encoded)
+}
+
+// applyRealLLMCredentialsSecret reads llmCredentialsFile and overwrites the
+// mock llm-credentials-primary placeholder createFullPipelineHelmSecrets
+// just created with its raw bytes -- see FleetCoreDemoOptions.
+// LLMCredentialsFile's doc comment for why this exists.
+func applyRealLLMCredentialsSecret(ctx context.Context, namespace, kubeconfigPath, llmCredentialsFile string, writer io.Writer) error {
+	credentials, err := os.ReadFile(llmCredentialsFile)
+	if err != nil {
+		return fmt.Errorf("failed to read -llm-credentials-file %q: %w", llmCredentialsFile, err)
+	}
+	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, buildLLMCredentialsSecretManifest(namespace, credentials)); err != nil {
+		return fmt.Errorf("failed to apply real %s Secret: %w", fleetDemoLLMSecretName, err)
+	}
+	_, _ = fmt.Fprintf(writer, "  ✅ %s replaced with your real credentials (%s)\n", fleetDemoLLMSecretName, llmCredentialsFile)
+	return nil
+}
+
 // SetupFleetCoreInfrastructure creates the hub+spoke Kind cluster pair and
 // deploys ONLY the fleet-core infrastructure (Keycloak IdP, Kuadrant MCP
 // Gateway, kube-mcp-server, the genuinely separate remote/spoke cluster,
@@ -413,28 +483,56 @@ func SetupFleetE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPat
 // behavior before gateway-type selection existed). Prefer
 // SetupFleetCoreInfrastructureWithGateway for new callers.
 func SetupFleetCoreInfrastructure(ctx context.Context, clusterName, kubeconfigPath string, writer io.Writer) (fleetOpts *FleetHelmOptions, remoteKubeconfigPath string, err error) {
-	return SetupFleetCoreInfrastructureWithGateway(ctx, clusterName, "", kubeconfigPath, registry.GatewayKuadrant, 0, writer)
+	return SetupFleetCoreInfrastructureWithGateway(ctx, clusterName, "", kubeconfigPath, FleetCoreDemoOptions{GatewayType: registry.GatewayKuadrant}, writer)
+}
+
+// FleetCoreDemoOptions configures SetupFleetCoreInfrastructureWithGateway's
+// optional knobs. Options-pattern struct (AGENTS.md 8-parameter limit) --
+// GatewayType/SpokeWorkers/LLMCredentialsFile as three more positional
+// params would push the function to 8.
+type FleetCoreDemoOptions struct {
+	// GatewayType selects registry.GatewayKuadrant or registry.GatewayEAIGW;
+	// empty defaults to Kuadrant. See provisionFleetCoreInfra's doc comment
+	// for what differs between the two.
+	GatewayType registry.MCPGatewayType
+	// SpokeWorkers appends this many `role: worker` nodes to the spoke
+	// cluster at creation time (Issue #2333: some E2E demo scenarios taint/
+	// drain/pressure-test a worker node distinct from the control plane,
+	// which the spoke can't provide as a control-plane-only cluster). Zero
+	// (the long-standing default) leaves the spoke control-plane-only.
+	// This is the `hack/setup-fleet-infra -spoke-workers=N` entry point's
+	// parameter.
+	SpokeWorkers int
+	// LLMCredentialsFile, when non-empty, overwrites the mock
+	// llm-credentials-primary placeholder createFullPipelineHelmSecrets
+	// creates with this file's raw bytes, right after the hub cluster and
+	// namespace exist. Closes a chicken-and-egg gap (found 2026-09-01,
+	// FLEET_DEMO_QUICKSTART.md): the docs previously told users to
+	// pre-create this Secret before running setup at all, i.e. before the
+	// cluster meant to hold it existed. Empty (the default, and every
+	// existing Ginkgo-suite caller) leaves the long-standing
+	// mock-llm-e2e-key placeholder untouched -- this is the
+	// `hack/setup-fleet-infra -llm-credentials-file` entry point's
+	// parameter, deliberately a file path rather than a literal string:
+	// vertex_ai's credential material is a multi-KB service-account/ADC
+	// JSON blob, not a short token, and a file also keeps the secret out of
+	// argv/shell history.
+	LLMCredentialsFile string
 }
 
 // SetupFleetCoreInfrastructureWithGateway is SetupFleetCoreInfrastructure
-// with an explicit gatewayType (registry.GatewayKuadrant or
-// registry.GatewayEAIGW; empty defaults to Kuadrant). See
-// provisionFleetCoreInfra's doc comment for what differs between the two.
+// with explicit options beyond cluster/kubeconfig identity -- see
+// FleetCoreDemoOptions's field docs for GatewayType/SpokeWorkers/
+// LLMCredentialsFile.
 //
 // remoteClusterName names the remote/spoke Kind cluster explicitly; empty
 // falls back to clusterName+"-remote" (see FleetCoreInfraOptions.
 // RemoteClusterName's doc comment).
-//
-// spokeWorkers appends this many `role: worker` nodes to the spoke cluster
-// at creation time (Issue #2333: some E2E demo scenarios taint/drain/
-// pressure-test a worker node distinct from the control plane, which the
-// spoke can't provide as a control-plane-only cluster). Zero (the
-// long-standing default) leaves the spoke control-plane-only. This is the
-// `hack/setup-fleet-infra -spoke-workers=N` entry point's parameter.
-func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, remoteClusterName, kubeconfigPath string, gatewayType registry.MCPGatewayType, spokeWorkers int, writer io.Writer) (fleetOpts *FleetHelmOptions, remoteKubeconfigPath string, err error) {
+func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, remoteClusterName, kubeconfigPath string, opts FleetCoreDemoOptions, writer io.Writer) (fleetOpts *FleetHelmOptions, remoteKubeconfigPath string, err error) {
 	if remoteClusterName == "" {
 		remoteClusterName = clusterName + "-remote"
 	}
+	gatewayType := opts.GatewayType
 	if gatewayType == "" {
 		gatewayType = registry.GatewayKuadrant
 	}
@@ -471,6 +569,11 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, r
 	if err := createFullPipelineHelmSecrets(ctx, namespace, kubeconfigPath, writer); err != nil {
 		return nil, "", fmt.Errorf("failed to create Helm chart prerequisite secrets: %w", err)
 	}
+	if opts.LLMCredentialsFile != "" {
+		if err := applyRealLLMCredentialsSecret(ctx, namespace, kubeconfigPath, opts.LLMCredentialsFile, writer); err != nil {
+			return nil, "", err
+		}
+	}
 
 	_, _ = fmt.Fprintln(writer, "\n🌐 Provisioning fleet-core infrastructure (IdP + MCP Gateway + spoke cluster)...")
 	// keycloakNamespace=idpNamespace ("idp"), NOT namespace: this demo-only
@@ -485,7 +588,7 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, r
 		Namespace:         namespace,
 		KeycloakNamespace: idpNamespace,
 		GatewayType:       gatewayType,
-		SpokeWorkers:      spokeWorkers,
+		SpokeWorkers:      opts.SpokeWorkers,
 	}, writer)
 	if err != nil {
 		return nil, remoteKubeconfigPath, fmt.Errorf("fleet-core infrastructure provisioning failed: %w", err)
@@ -542,14 +645,39 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, r
 	// per cluster). Both clusters' Prometheus instances point their
 	// `alerting:` sink at it: the hub's via in-cluster Service DNS, the
 	// spoke's via the hub's node-bridge IP:NodePort (no in-cluster route
-	// from spoke to a hub Service). gatewayToken="" -- no AlertManager->
-	// Gateway webhook forwarding wired up front (same as kubernautagent.go's
-	// Phase 5.7 and effectivenessmonitor_e2e.go, both of which also pass "");
-	// AlertManager's default "gateway-webhook" receiver still resolves
-	// correctly (gateway-service is in kubernaut-system, unaffected by
-	// which namespace AlertManager itself lives in).
+	// from spoke to a hub Service).
+	//
+	// gatewayNamespace=namespace (kubernaut-system), NOT monitoringNamespace:
+	// AlertManager itself lives in "monitoring" here, but Gateway's Service
+	// is in "kubernaut-system" -- passing monitoringNamespace for both
+	// previously produced an unresolvable
+	// gateway-service.monitoring.svc.cluster.local webhook URL (demo team
+	// report, 2026-09-02: AlertManager logs showed "dial tcp: lookup
+	// gateway-service.monitoring.svc.cluster.local ... no such host").
+	//
+	// gatewayToken: a real Bearer token is required here (unlike
+	// kubernautagent.go's Phase 5.7 and effectivenessmonitor_e2e.go, which
+	// pass "" because their suites don't exercise the AlertManager->Gateway
+	// webhook hop at all). Fleet's Gateway has BR-GATEWAY-036/037 auth
+	// middleware enabled and unconditionally rejects unauthenticated
+	// webhook POSTs with 401 (demo team report, 2026-09-02, round 2:
+	// "missing_auth_header" on every request, confirmed in Gateway's own
+	// security_event audit log) -- passing "" here left the earlier DNS fix
+	// necessary but not sufficient. Reuses the same
+	// CreateE2EServiceAccountWithGatewayAccess/GetServiceAccountToken pair
+	// InstallFullPipelineHelmChart already relies on for this exact hop
+	// (fullpipeline_e2e.go), under a fleet-specific ServiceAccount name so
+	// the two suites' RBAC bindings don't collide if ever run against the
+	// same cluster.
+	if err := CreateE2EServiceAccountWithGatewayAccess(ctx, namespace, kubeconfigPath, fleetAlertManagerGatewaySA, writer); err != nil {
+		return nil, remoteKubeconfigPath, fmt.Errorf("fleet AlertManager Gateway ServiceAccount setup failed: %w", err)
+	}
+	fleetGatewayToken, err := GetServiceAccountToken(ctx, namespace, fleetAlertManagerGatewaySA, kubeconfigPath)
+	if err != nil {
+		return nil, remoteKubeconfigPath, fmt.Errorf("failed to mint fleet AlertManager Gateway token: %w", err)
+	}
 	_, _ = fmt.Fprintln(writer, "\n📊 Installing fleet-wide monitoring (Prometheus+Thanos per cluster, hub AlertManager)...")
-	if err := DeployAlertManager(ctx, monitoringNamespace, kubeconfigPath, "", writer); err != nil {
+	if err := DeployAlertManager(ctx, monitoringNamespace, namespace, kubeconfigPath, fleetGatewayToken, writer); err != nil {
 		return nil, remoteKubeconfigPath, fmt.Errorf("alertmanager install failed: %w", err)
 	}
 
@@ -637,9 +765,11 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, r
 	_, _ = fmt.Fprintln(writer, "      external_labels to fired alert instances (thanos-io/thanos#7327), so AF's")
 	_, _ = fmt.Fprintln(writer, "      cluster_id filter will silently drop any alert missing it. See")
 	_, _ = fmt.Fprintln(writer, "      DeployDemoAlertingRules's doc comment (thanos_e2e.go) for details.")
-	_, _ = fmt.Fprintln(writer, "\n  ⚠️  llm-credentials-primary currently holds a MOCK key --")
-	_, _ = fmt.Fprintln(writer, "      kubectl apply your real LLM credentials Secret before")
-	_, _ = fmt.Fprintln(writer, "      `helm install` if you're not using Mock LLM.")
+	if opts.LLMCredentialsFile == "" {
+		_, _ = fmt.Fprintln(writer, "\n  ⚠️  llm-credentials-primary currently holds a MOCK key --")
+		_, _ = fmt.Fprintln(writer, "      kubectl apply your real LLM credentials Secret before")
+		_, _ = fmt.Fprintln(writer, "      `helm install` if you're not using Mock LLM.")
+	}
 	_, _ = fmt.Fprintf(writer, "\n  Keycloak (IdP) lives in its own %q namespace, not %s (production parity).\n", idpNamespace, namespace)
 	_, _ = fmt.Fprintln(writer, "  For AF/Console browser login (reuses the same Keycloak, no DEX):")
 	_, _ = fmt.Fprintln(writer, "    apifrontend.config.auth.issuerURL=https://keycloak:8443/realms/kubernaut-fleet")
@@ -838,16 +968,17 @@ func provisionFleetCoreInfra(ctx context.Context, opts FleetCoreInfraOptions, wr
 	}
 	remoteKubeconfigPath = filepath.Join(filepath.Dir(kubeconfigPath), remoteClusterName+"-config")
 	sharedAuthConfig := KubeMCPServerAuthConfig{
-		Mode:             KubeMCPServerAuthModePassthrough,
-		GatewayType:      gatewayType,
-		RequireOAuth:     true,
-		AuthorizationURL: oidcCfg.IssuerURL,
-		OAuthAudience:    "kube-mcp-server",
-		StsClientID:      "kube-mcp-server",
-		StsClientSecret:  "e2e-kube-mcp-server-secret",
-		StsAudience:      "k8s-api",
-		StsScopes:        []string{"k8s-api-audience"},
-		CAFilePath:       "/etc/tls-ca/ca.crt",
+		Mode:              KubeMCPServerAuthModePassthrough,
+		GatewayType:       gatewayType,
+		RequireOAuth:      true,
+		AuthorizationURL:  oidcCfg.IssuerURL,
+		KeycloakNamespace: keycloakNamespace,
+		OAuthAudience:     "kube-mcp-server",
+		StsClientID:       "kube-mcp-server",
+		StsClientSecret:   "e2e-kube-mcp-server-secret",
+		StsAudience:       "k8s-api",
+		StsScopes:         []string{"k8s-api-audience"},
+		CAFilePath:        "/etc/tls-ca/ca.crt",
 	}
 	remoteBridge, remoteErr := SetupRemoteClusterForFMC(ctx, RemoteClusterFMCConfig{
 		PrimaryClusterName:    clusterName,
@@ -1592,7 +1723,11 @@ func deployEnvoyAIGatewayRegistrations(ctx context.Context, namespace, kubeconfi
 	_, _ = fmt.Fprintln(writer, "    Creating Backends + MCPRoute (with OAuth SecurityPolicy)...")
 
 	kubeMCPHostname := fmt.Sprintf("kube-mcp-server.%s.svc.cluster.local", namespace)
-	keycloakHostname := fmt.Sprintf("keycloak.%s.svc.cluster.local", namespace)
+	keycloakNamespace := authConfig.KeycloakNamespace
+	if keycloakNamespace == "" {
+		keycloakNamespace = namespace
+	}
+	keycloakHostname := fmt.Sprintf("keycloak.%s.svc.cluster.local", keycloakNamespace)
 	jwksURI := authConfig.AuthorizationURL + "/protocol/openid-connect/certs"
 
 	// prod-east's Backend targets a genuinely separate Kind cluster's

--- a/test/infrastructure/fleet_e2e_credentials_test.go
+++ b/test/infrastructure/fleet_e2e_credentials_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	"encoding/base64"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Issue found 2026-09-01 (FLEET_DEMO_QUICKSTART.md): the docs told users to
+// pre-create the llm-credentials-primary Secret before running
+// `setup-fleet-demo-infra` at all -- impossible, since the cluster meant to
+// hold it doesn't exist yet at that point. SetupFleetCoreInfrastructureWithGateway
+// always creates a mock placeholder regardless (createFullPipelineHelmSecrets),
+// so the "actionable error if missing" InstallFleetDemoHelmChart's
+// checkSecretExists promised was actually unreachable. buildLLMCredentialsSecretManifest
+// is the pure builder behind the fix: -llm-credentials-file overwrites that
+// placeholder with real content once the cluster exists, closing the gap in
+// one command instead of two.
+var _ = Describe("buildLLMCredentialsSecretManifest", func() {
+	It("UT-INFRA-FLEETDEMO-023: base64-encodes the credentials into both data.api_key and data[credentials.json]", func() {
+		manifest := buildLLMCredentialsSecretManifest("kubernaut-system", []byte(`{"type":"authorized_user"}`))
+		encoded := base64.StdEncoding.EncodeToString([]byte(`{"type":"authorized_user"}`))
+		Expect(manifest).To(ContainSubstring("name: llm-credentials-primary"))
+		Expect(manifest).To(ContainSubstring("namespace: kubernaut-system"))
+		Expect(manifest).To(ContainSubstring("data:"))
+		Expect(manifest).To(ContainSubstring("api_key: " + encoded))
+		Expect(manifest).To(ContainSubstring("credentials.json: " + encoded))
+	})
+
+	It("UT-INFRA-FLEETDEMO-024: scopes the Secret to the namespace passed in", func() {
+		manifest := buildLLMCredentialsSecretManifest("some-other-namespace", []byte("a-plain-api-key"))
+		Expect(manifest).To(ContainSubstring("namespace: some-other-namespace"))
+		Expect(manifest).NotTo(ContainSubstring("namespace: kubernaut-system"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-025: round-trips credential bytes containing YAML-unsafe characters (quotes, newlines)", func() {
+		tricky := []byte("{\n  \"private_key\": \"-----BEGIN KEY-----\\nabc\\n-----END KEY-----\"\n}\n")
+		manifest := buildLLMCredentialsSecretManifest("kubernaut-system", tricky)
+		Expect(manifest).To(ContainSubstring("api_key: " + base64.StdEncoding.EncodeToString(tricky)))
+	})
+})
+
+// Issue found 2026-09-02 (demo team report): the fleet demo's AlertManager
+// runs in a dedicated "monitoring" namespace (DD-EM-005's fleet-wide
+// platform-monitoring instance), but Gateway's Service lives in
+// "kubernaut-system". DeployAlertManager previously took a single namespace
+// argument and used it for BOTH AlertManager's own manifest AND the
+// gateway-webhook receiver's URL, so the fleet caller's monitoringNamespace
+// leaked into the webhook URL too -- producing an unresolvable
+// gateway-service.monitoring.svc.cluster.local address. AlertManager's own
+// logs confirmed it: "dial tcp: lookup gateway-service.monitoring.svc.
+// cluster.local ... no such host". buildAlertManagerManifest now takes
+// gatewayNamespace separately; these tests prove the webhook URL tracks it,
+// independent of namespace.
+var _ = Describe("buildAlertManagerManifest", func() {
+	It("UT-INFRA-FLEETDEMO-026: gateway-webhook URL uses gatewayNamespace, not namespace, when they differ", func() {
+		manifest := buildAlertManagerManifest("monitoring", "kubernaut-system", "")
+		Expect(manifest).To(ContainSubstring("http://gateway-service.kubernaut-system.svc.cluster.local:8080/api/v1/signals/prometheus"))
+		Expect(manifest).NotTo(ContainSubstring("gateway-service.monitoring.svc.cluster.local"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-027: AlertManager's own ConfigMap/Deployment/Service still use namespace, not gatewayNamespace", func() {
+		manifest := buildAlertManagerManifest("monitoring", "kubernaut-system", "")
+		Expect(manifest).To(ContainSubstring("name: alertmanager-config\n  namespace: monitoring"))
+		Expect(manifest).To(ContainSubstring("name: alertmanager\n  namespace: monitoring"))
+		Expect(manifest).To(ContainSubstring("name: alertmanager-svc\n  namespace: monitoring"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-028: single-cluster callers passing the same value for both still resolve correctly", func() {
+		manifest := buildAlertManagerManifest("kubernaut-system", "kubernaut-system", "")
+		Expect(manifest).To(ContainSubstring("http://gateway-service.kubernaut-system.svc.cluster.local:8080/api/v1/signals/prometheus"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-029: BR-GATEWAY-036/037 bearer token is still added to the webhook's http_config when provided", func() {
+		manifest := buildAlertManagerManifest("kubernaut-system", "kubernaut-system", "test-token")
+		Expect(manifest).To(ContainSubstring("bearer_token: 'test-token'"))
+	})
+})

--- a/test/infrastructure/fullpipeline_e2e.go
+++ b/test/infrastructure/fullpipeline_e2e.go
@@ -547,7 +547,7 @@ func SetupFullPipelineInfrastructure(ctx context.Context, clusterName, kubeconfi
 		allResults <- waveResult{"Prometheus", nil}
 	}()
 	go func() {
-		if err := DeployAlertManager(ctx, namespace, kubeconfigPath, gatewayToken, writer); err != nil {
+		if err := DeployAlertManager(ctx, namespace, namespace, kubeconfigPath, gatewayToken, writer); err != nil {
 			allResults <- waveResult{"AlertManager", err}
 			return
 		}

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -276,7 +276,7 @@ func SetupKubernautAgentInfrastructure(ctx context.Context, clusterName, kubecon
 	if err := DeployPrometheus(ctx, namespace, kubeconfigPath, writer); err != nil {
 		return fmt.Errorf("failed to deploy Prometheus: %w", err)
 	}
-	if err := DeployAlertManager(ctx, namespace, kubeconfigPath, "", writer); err != nil {
+	if err := DeployAlertManager(ctx, namespace, namespace, kubeconfigPath, "", writer); err != nil {
 		return fmt.Errorf("failed to deploy AlertManager: %w", err)
 	}
 

--- a/test/infrastructure/prometheus_alertmanager_e2e.go
+++ b/test/infrastructure/prometheus_alertmanager_e2e.go
@@ -498,7 +498,19 @@ spec:
 //
 // Parameters:
 //   - ctx: Context for cancellation
-//   - namespace: Target namespace (e.g., "kubernaut-system")
+//   - namespace: Namespace AlertManager itself is deployed into (e.g.,
+//     "kubernaut-system", or "monitoring" for the fleet demo's dedicated
+//     platform-monitoring namespace).
+//   - gatewayNamespace: Namespace the "gateway-webhook" receiver's URL
+//     targets (Gateway's own Service namespace). Equal to namespace for
+//     every single-cluster caller (Gateway and AlertManager share one
+//     namespace there); MUST be passed separately in fleet mode, where
+//     AlertManager lives in "monitoring" but Gateway lives in
+//     "kubernaut-system" -- passing namespace for both there previously
+//     produced an unresolvable gateway-service.monitoring.svc.cluster.local
+//     webhook URL (demo team report, 2026-09-02: AlertManager logs showed
+//     "dial tcp: lookup gateway-service.monitoring.svc.cluster.local ...
+//     no such host", confirming the bug empirically).
 //   - kubeconfigPath: Path to kubeconfig for kubectl commands
 //   - gatewayToken: Bearer token for Gateway signal endpoints (BR-GATEWAY-036/037). If empty, no auth is added.
 //   - writer: Output writer for progress logging
@@ -506,9 +518,32 @@ spec:
 // Routing: every alert is forwarded to Gateway's real webhook EXCEPT one
 // carrying label SkipGatewayRouteLabelKey=SkipGatewayRouteLabelValue, which
 // AlertManager instead routes to a null receiver (see route config below).
-func DeployAlertManager(ctx context.Context, namespace, kubeconfigPath, gatewayToken string, writer io.Writer) error {
+func DeployAlertManager(ctx context.Context, namespace, gatewayNamespace, kubeconfigPath, gatewayToken string, writer io.Writer) error {
 	_, _ = fmt.Fprintf(writer, "  🔔 Deploying AlertManager in namespace %s...\n", namespace)
 
+	manifest := buildAlertManagerManifest(namespace, gatewayNamespace, gatewayToken)
+
+	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
+	cmd.Stdin = bytes.NewBufferString(manifest)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	if err := cmd.Run(); err != nil {
+		dumpNodePortAllocations(ctx, kubeconfigPath, writer)
+		return fmt.Errorf("failed to deploy AlertManager: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(writer, "  ✅ AlertManager deployed (NodePort %d)\n", AlertManagerNodePort)
+	return nil
+}
+
+// buildAlertManagerManifest is the pure manifest-building half of
+// DeployAlertManager, split out for unit testing (2026-09-02, demo team
+// report): asserting on the rendered YAML string directly, without a shell
+// out to kubectl, is how UT-ALERTMGR-001 proves the gateway-webhook URL
+// uses gatewayNamespace and not namespace even when they differ (the fleet
+// case this bug was found in). See DeployAlertManager's doc comment for the
+// namespace/gatewayNamespace distinction.
+func buildAlertManagerManifest(namespace, gatewayNamespace, gatewayToken string) string {
 	// BR-GATEWAY-036/037: http_config with bearer_token for authenticated Gateway webhooks
 	webhookAuthYaml := ""
 	if gatewayToken != "" {
@@ -517,7 +552,7 @@ func DeployAlertManager(ctx context.Context, namespace, kubeconfigPath, gatewayT
           bearer_token: '` + strings.ReplaceAll(gatewayToken, "'", "''") + `'`
 	}
 
-	manifest := fmt.Sprintf(`---
+	return fmt.Sprintf(`---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -549,7 +584,7 @@ data:
     receivers:
     - name: gateway-webhook
       webhook_configs:
-      - url: 'http://gateway-service.%[1]s.svc.cluster.local:8080/api/v1/signals/prometheus'
+      - url: 'http://gateway-service.%[4]s.svc.cluster.local:8080/api/v1/signals/prometheus'
         send_resolved: false`+webhookAuthYaml+`
     - name: null-receiver
 ---
@@ -623,19 +658,7 @@ spec:
     targetPort: 9093
     nodePort: %[3]d
     protocol: TCP
-`, namespace, AlertManagerImage, AlertManagerNodePort)
-
-	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
-	cmd.Stdin = bytes.NewBufferString(manifest)
-	cmd.Stdout = writer
-	cmd.Stderr = writer
-	if err := cmd.Run(); err != nil {
-		dumpNodePortAllocations(ctx, kubeconfigPath, writer)
-		return fmt.Errorf("failed to deploy AlertManager: %w", err)
-	}
-
-	_, _ = fmt.Fprintf(writer, "  ✅ AlertManager deployed (NodePort %d)\n", AlertManagerNodePort)
-	return nil
+`, namespace, AlertManagerImage, AlertManagerNodePort, gatewayNamespace)
 }
 
 // dumpNodePortAllocations lists every Service (all namespaces) with its

--- a/test/infrastructure/serviceaccount.go
+++ b/test/infrastructure/serviceaccount.go
@@ -37,6 +37,20 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// e2eTokenExpirationSeconds bounds every TokenRequest minted by this file for
+// E2E/demo infrastructure setup. These tokens are baked once into a static
+// file/ConfigMap/Secret (e.g. AlertManager's webhook bearer_token, a
+// container-mounted kubeconfig) with no refresh mechanism of their own --
+// unlike an in-cluster pod's projected-volume ServiceAccount token, which
+// kubelet auto-rotates transparently. The previous value (3600, the
+// TokenRequest API's own default when the field is omitted) reliably expired
+// mid-session: any fleet demo running longer than an hour broke on its own,
+// independent of the host-suspend/MCP-session issue that surfaced it
+// (issue #2347). Confirmed empirically this accepts up to at least 90 days
+// on a kind cluster (`kubectl create token --duration=2160h`); a demo/E2E
+// process is not expected to outlive this.
+const e2eTokenExpirationSeconds = 90 * 24 * 3600 // 90 days
+
 // CreateE2EServiceAccountWithDataStorageAccess creates a ServiceAccount for E2E tests
 // with RBAC permissions to access DataStorage via middleware-based SAR validation.
 //
@@ -326,8 +340,7 @@ func GetServiceAccountToken(ctx context.Context, namespace, saName, kubeconfigPa
 	// Authority: https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/
 	treq := &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{
-			// Request long-lived token for E2E tests (default is 1 hour)
-			ExpirationSeconds: func() *int64 { exp := int64(3600); return &exp }(),
+			ExpirationSeconds: func() *int64 { exp := int64(e2eTokenExpirationSeconds); return &exp }(),
 		},
 	}
 
@@ -1046,7 +1059,7 @@ func CreateIntegrationServiceAccountWithDataStorageAccess(
 	_, _ = fmt.Fprintf(writer, "🎫 Requesting DataStorage service token...\n")
 	datastorageTokenRequest := &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{
-			ExpirationSeconds: int64Ptr(3600), // 1 hour
+			ExpirationSeconds: int64Ptr(e2eTokenExpirationSeconds),
 		},
 	}
 
@@ -1087,7 +1100,7 @@ func CreateIntegrationServiceAccountWithDataStorageAccess(
 	_, _ = fmt.Fprintf(writer, "🎫 Requesting client ServiceAccount token...\n")
 	tokenRequest := &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{
-			ExpirationSeconds: int64Ptr(3600), // 1 hour
+			ExpirationSeconds: int64Ptr(e2eTokenExpirationSeconds),
 		},
 	}
 
@@ -1372,7 +1385,7 @@ func CreateServiceAccountForHTTPService(
 	_, _ = fmt.Fprintf(writer, "🎫 Requesting ServiceAccount token for %s\n", saName)
 	tokenRequest := &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{
-			ExpirationSeconds: int64Ptr(3600), // 1 hour
+			ExpirationSeconds: int64Ptr(e2eTokenExpirationSeconds),
 		},
 	}
 	tokenResp, err := clientset.CoreV1().ServiceAccounts(namespace).CreateToken(

--- a/test/integration/kubernautagent/investigator/fleet_enrichment_prefetch_it_test.go
+++ b/test/integration/kubernautagent/investigator/fleet_enrichment_prefetch_it_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/tools/custom"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// Issue #2343: Investigate()'s automatic pre-fetch enrichment step
+// (resolveEnrichmentCached -> Enricher.Enrich) always resolved owner-chain/
+// spec-hash against the hub K8sClient, even for a fleet-target investigation
+// -- unlike get_namespaced_resource_context/get_cluster_resource_context
+// (issue #2306, proven by fleet_resource_context_it_test.go), which already
+// resolve per-call from ctx via custom.ResolveK8sClient. Every existing fleet
+// IT in this package built its Enricher with a bare k8sFixtureClient and
+// never installed a K8sResolver, so the exact call path that was broken
+// (Enricher.k8s inside the pre-fetch, not the LLM-callable tools) was never
+// exercised with a fixture that could reveal "wrong cluster" -- these two
+// specs close that coverage gap by wiring the Enricher exactly as
+// cmd/kubernautagent/datastorage.go's buildEnricher does in production.
+var _ = Describe("Fleet-aware enrichment pre-fetch (BR-INTEGRATION-1489, Issue #2343)", Label("fleet", "integration"), func() {
+
+	var (
+		invLogger  logr.Logger
+		auditStore *capturingAuditStore
+	)
+
+	BeforeEach(func() {
+		invLogger = logr.Discard()
+		auditStore = newCapturingAuditStore(suiteAuditStore)
+	})
+
+	// minimalInvestigationResponses is the shortest response sequence that
+	// completes Investigate() without exercising any tool calls that would
+	// themselves route through the fleet overlay -- isolating this spec to
+	// the automatic pre-fetch enrichment step alone (mirrors
+	// fleet_prescoping_test.go's IT-KA-FLEET-013 minimal sequence).
+	minimalInvestigationResponses := func() []llm.ChatResponse {
+		return []llm.ChatResponse{
+			{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
+			{
+				Message:   llm.Message{Role: "assistant", Content: ""},
+				ToolCalls: []llm.ToolCall{{ID: "tc_wf1", Name: "list_available_actions", Arguments: `{}`}},
+			},
+			{
+				Message: llm.Message{Role: "assistant", Content: ""},
+				ToolCalls: []llm.ToolCall{
+					{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled"},"reasoning":"none"}`},
+				},
+			},
+		}
+	}
+
+	Describe("IT-KA-FLEET-036 [AC-6]: pre-fetch enrichment resolves against the fleet overlay, never the hub K8sClient", func() {
+		It("emits an enrichment.completed audit event whose root owner is the overlay's resource, not the hub's", func() {
+			// Hub-bound K8sClient: fixed, unrelated owner chain. If the
+			// pre-fetch enrichment step ever used this for a fleet-target
+			// investigation, its sentinel name would leak into the audit
+			// event asserted on below.
+			hubK8s := &k8sFixtureClient{ownerChain: []enrichment.OwnerChainEntry{
+				{Kind: "Deployment", Name: "hub-should-not-appear", Namespace: "production"},
+			}}
+
+			overlayGetTool := &fakeTool{name: "resources_get", result: `{"apiVersion":"apps/v1","kind":"Deployment",` +
+				`"metadata":{"name":"remote-target","namespace":"remote-ns"}}`}
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{"resources_get": overlayGetTool}}
+
+			mockClient := &mockLLMClient{responses: minimalInvestigationResponses()}
+
+			// WithK8sResolver installed exactly as buildEnricher wires it in
+			// production (cmd/kubernautagent/datastorage.go): per-call
+			// routing through custom.ResolveK8sClient, not a fixed client.
+			enricher := enrichment.NewEnricher(hubK8s, suiteDSAdapter, auditStore, invLogger).
+				WithK8sResolver(func(ctx context.Context) enrichment.K8sClient {
+					return custom.ResolveK8sClient(ctx, hubK8s, invLogger)
+				})
+			builder, berr := prompt.NewBuilder()
+			Expect(berr).ToNot(HaveOccurred())
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: registry.New(),
+				FleetOverlayResolver: spy,
+			})
+
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "remote-target", Namespace: "remote-ns", ResourceKind: "Deployment", ResourceName: "remote-target",
+				ClusterID: "remote-east", RemediationID: "rem-2343-036",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			completedEvents := filterEvents(auditStore.events, audit.EventTypeEnrichmentCompleted)
+			Expect(completedEvents).NotTo(BeEmpty(), "IT-KA-FLEET-036: an enrichment.completed audit event must be emitted")
+			ev := completedEvents[0]
+			Expect(ev.Data["root_owner_name"]).To(Equal("remote-target"),
+				"IT-KA-FLEET-036: pre-fetch enrichment must resolve the owner chain against the target "+
+					"cluster's own resources_get tool, not fall through to the hub")
+			Expect(ev.Data["root_owner_name"]).NotTo(Equal("hub-should-not-appear"),
+				"IT-KA-FLEET-036: the hub-bound K8sClient must never be consulted for a fleet-target "+
+					"investigation's pre-fetch enrichment (AC-6)")
+		})
+
+		It("still resolves against the hub K8sClient for a hub-local investigation (zero regression)", func() {
+			hubK8s := &k8sFixtureClient{ownerChain: []enrichment.OwnerChainEntry{
+				{Kind: "Deployment", Name: "hub-local-target", Namespace: "production"},
+			}}
+			mockClient := &mockLLMClient{responses: minimalInvestigationResponses()}
+
+			enricher := enrichment.NewEnricher(hubK8s, suiteDSAdapter, auditStore, invLogger).
+				WithK8sResolver(func(ctx context.Context) enrichment.K8sClient {
+					return custom.ResolveK8sClient(ctx, hubK8s, invLogger)
+				})
+			builder, berr := prompt.NewBuilder()
+			Expect(berr).ToNot(HaveOccurred())
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: registry.New(),
+			})
+
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "hub-local-target", Namespace: "production", ResourceKind: "Deployment", ResourceName: "hub-local-target",
+				RemediationID: "rem-2343-036b",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			completedEvents := filterEvents(auditStore.events, audit.EventTypeEnrichmentCompleted)
+			Expect(completedEvents).NotTo(BeEmpty())
+			ev := completedEvents[0]
+			Expect(ev.Data["root_owner_name"]).To(Equal("hub-local-target"),
+				"a hub-local investigation (no ClusterID, no overlay) must still resolve via the hub K8sClient")
+		})
+	})
+})

--- a/test/services/mock-mcp-gateway/testutil/server.go
+++ b/test/services/mock-mcp-gateway/testutil/server.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -35,6 +36,24 @@ import (
 type ToolCall struct {
 	ToolName  string
 	Arguments json.RawMessage
+}
+
+// NotFoundSentinelName: requesting a resource with this name from
+// resources_get/resources_delete simulates the plain-text-rendered
+// apierrors.NewNotFound a real kube-mcp-server would return for a resource
+// that genuinely doesn't exist (issue #2349) -- the MCP protocol only
+// carries tool errors as text, so callers must recognize this shape and
+// re-wrap it as a typed error themselves.
+const NotFoundSentinelName = "__notfound_sentinel__"
+
+// groupSuffix returns ".<group>" for a non-core apiVersion (e.g. "batch/v1"
+// -> ".batch"), or "" for a core apiVersion (e.g. "v1"), matching
+// apierrors.NewNotFound's own GroupResource.String() rendering.
+func groupSuffix(apiVersion string) string {
+	if idx := strings.Index(apiVersion, "/"); idx > 0 {
+		return "." + strings.ToLower(apiVersion[:idx])
+	}
+	return ""
 }
 
 // Option configures a MockGateway.
@@ -273,6 +292,20 @@ func (gw *MockGateway) registerClusterToolsWithPrefix(cluster, prefix string, cf
 			}, nil
 		}
 
+		// NotFoundSentinelName: simulates the k8s-standard NotFound message
+		// shape a real kube-mcp-server would render as plain text (issue
+		// #2349) -- lets callers test their own error-typing/reconnect
+		// behavior against a "resource genuinely doesn't exist" response
+		// without needing per-test mock reconfiguration.
+		if args.Name == NotFoundSentinelName {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+					"failed to get resource: %s%s %q not found",
+					strings.ToLower(args.Kind), groupSuffix(args.APIVersion), args.Name)}},
+				IsError: true,
+			}, nil
+		}
+
 		obj := map[string]any{
 			"apiVersion": args.APIVersion,
 			"kind":       args.Kind,
@@ -330,12 +363,23 @@ func (gw *MockGateway) registerClusterToolsWithPrefix(cluster, prefix string, cf
 		var args struct {
 			Kind       string `json:"kind"`
 			APIVersion string `json:"apiVersion"`
+			Name       string `json:"name"`
 		}
 		_ = json.Unmarshal(req.Params.Arguments, &args)
 
 		if args.APIVersion == "" {
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: `{"error":"apiVersion is required"}`}},
+				IsError: true,
+			}, nil
+		}
+
+		// See NotFoundSentinelName above (issue #2349).
+		if args.Name == NotFoundSentinelName {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+					"failed to delete resource: %s%s %q not found",
+					strings.ToLower(args.Kind), groupSuffix(args.APIVersion), args.Name)}},
 				IsError: true,
 			}, nil
 		}


### PR DESCRIPTION
## Summary

Seven fixes found and verified live while getting the fleet demo running end-to-end on a fresh Kind hub+spoke cluster:

- **Chicken-and-egg LLM secret / AlertManager DNS+auth / image tag drift**: `setup-fleet-infra` now takes a `-llm-credentials-file` flag so the LLM secret can be created after the cluster exists instead of requiring it up front. AlertManager's webhook URL was hardcoded to its own namespace instead of Gateway's, and its webhook POSTs carried no Bearer token — both fixed, with a dedicated ServiceAccount for AlertManager to authenticate against Gateway. Also fixes `fleetmetadatacache`/`console` image tag defaults drifting from the rest of the chart.
- **Gateway MCP owner-chain resolution (#2340)**: `mcpReaderFactory.ReaderFor` called `DiscoverToolPrefix` directly on the raw MCP session with no reconnect logic. When the session died mid-lifetime (the Go SDK's optional standalone SSE stream failing repeatedly against `kube-mcp-server`, which doesn't implement it), every subsequent remote owner-chain/tool-prefix resolution failed permanently until pod restart. Added the same reconnect-and-retry wrapper already used elsewhere in this client. This is shared code (`pkg/fleet/mcpclient/reader_factory.go`) used by Gateway, SignalProcessing, EffectivenessMonitor, APIFrontend, and RemediationOrchestrator alike — confirmed live that SignalProcessing hit the identical "exceeded 5 retries without progress" failure (environment classification falling back to `Unknown`) until rebuilt with this fix.
- **kubernaut-agent phase credential fallback (#2341)**: phase model overrides that share the base profile's `credentialsSecretName` (the common case) render with no `apiKeyFile` in Helm, and the hot-reload path never fell back to the mounted credentials directory the way the base profile does — so `vertex_ai` phase clients fell through to a plain GCP ADC lookup and failed to build inside the pod. Added the same fallback, guarded to keep the existing #1726 contract (an `apiKeyFile` that's set but unreadable must still hard-fail).
- **kubernaut-agent enrichment pre-fetch is fleet-blind (#2343)**: `Investigator.Investigate()`'s automatic pre-fetch enrichment (owner-chain, spec-hash) always queried the hub cluster regardless of `RemediationRequest.Spec.ClusterID`, incorrectly concluding `TargetResourceDeleted = true` for healthy remote targets and short-circuiting workflow matching. Fixed by reusing the existing fleet-aware `overlayK8sClient` (built for #2306's LLM tools) one level earlier, via a new `Enricher.WithK8sResolver` hook wired in `buildEnricher()`. `LabelDetector` has the identical root cause but needs `List` support the overlay doesn't have yet — split out as a separate follow-up, #2345.
- **Fleet overlay NotFound errors misclassified as HardFail (#2344)**: a regression surfaced by #2343 routing real investigations through the overlay client for the first time — the MCP protocol only carries tool errors as plain text, so a remote cluster's real `apierrors.NewNotFound` arrived as a string, not a typed error, and `enrichment.IsNotFoundError` couldn't recognize it. Every legitimately-absent remote resource was hard-failing the investigation (`rca_incomplete`) instead of being handled as `TargetResourceDeleted`. Fixed by recognizing the k8s-standard "not found" message shape and re-wrapping it as a typed `apierrors.StatusError`.
- **WorkflowExecution had the same reconnect gap as #2340 (#2346)**: `mcpClientFactory.ClientFor` is called fresh on every `JobExecutor.Create`/`GetStatus` (not cached), so a session that died between two calls hit this exact bug in a third, independent call site — `DiscoverToolPrefix` called directly with no reconnect wrapper. Extracted the reconnect-and-retry logic from `reader_factory.go` into a shared `DiscoverToolPrefixWithReconnect` helper and switched this call site to use it.
- **Shared mcpclient Client.Get/WriterClient.Delete also lose typed NotFound (#2349)**: #2344 only fixed kubernaut-agent's own separate overlay client — `pkg/fleet/mcpclient`, the client every other fleet consumer (Gateway, WorkflowExecution, SignalProcessing, EffectivenessMonitor, RemediationOrchestrator, APIFrontend) uses for remote resource access, has the identical gap. Confirmed live: it permanently stuck `WorkflowExecution`'s cleanup finalizer in `Terminating` whenever a Job never existed, because `JobExecutor.Cleanup`'s `client.IgnoreNotFound` guard never matched the untyped error. Fixed the same way, at the shared client level this time.

Also bumped `test/infrastructure/serviceaccount.go`'s `TokenRequest` expiration for every E2E/demo-infra ServiceAccount token (AlertManager's Gateway auth token included) from a static 1 hour to 90 days (#2347) — found while auditing every long-lived credential/session in the platform for resilience to a host-suspend event, which is what surfaced #2346 in the first place. A 1-hour token with no renewal broke any demo session running past an hour, independent of host suspend.

## Test plan

- `go build ./...` passes
- `cmd/kubernautagent` full Ginkgo suite passes (129/129), including the #1726 apiKeyFile regression suite (no regression from the phase credential fallback change)
- `pkg/fleet/mcpclient` suite passes, including new `UT-READERFACTORY-RECONN-001/002` (reconnect-on-dead-session), `UT-FLEET-MCP-NOTFOUND-001/002/003` (helper), and `UT-FLEET-MCP-NOTFOUND-004/005` (end-to-end `Get`/`Delete` wiring against a mock gateway)
- `pkg/workflowexecution/executor` suite passes, including new `UT-WE-054-CF-008` (`ClientFor` recovers via reconnect when the session is already dead before the call)
- `internal/kubernautagent/enrichment` and `internal/kubernautagent/tools/custom` suites pass, including new `UT-KA-2343-001/002` (Enricher resolver routing) and `UT-KA-FLEET-033` (remote NotFound typing)
- New `test/integration/kubernautagent/investigator/fleet_enrichment_prefetch_it_test.go` (`IT-KA-FLEET-036`) proves the enrichment-completed audit event reflects the overlay fixture for a fleet-target investigation, and the hub fixture for a hub-local one (zero regression)
- New `test/infrastructure/fleet_e2e_credentials_test.go` covers the LLM credentials secret manifest (dual `api_key`/`credentials.json` keys) and the AlertManager manifest's gateway-namespace webhook URL
- Verified live end-to-end on a Kind hub+spoke cluster, rebuilding and redeploying every affected service with these fixes as each one was found: confirmed AlertManager → Gateway auth succeeds, remote owner-chain resolution and SignalProcessing's environment classification no longer error or fall back to degraded mode, `WorkflowExecution`'s cleanup finalizer no longer sticks in `Terminating`, and a full `KubePodCrashLooping` alert on the remote cluster reaches `RemediationRequest` phase `Completed` / outcome `Remediated` (0.95 confidence RCA, correct rollback workflow selected, target deployment verified healthy) with zero errors across Gateway, SignalProcessing, AIAnalysis, WorkflowExecution, and EffectivenessMonitor logs for the full run

Closes #2340
Closes #2341
Closes #2343
Closes #2344
Closes #2346
Closes #2347
Closes #2349
