### PR TITLE
fix(remediationrequest,fleet-demo): consistent workflow display separator, enable Console ingress

### DIFF
--- a/api/remediation/v1alpha1/remediationrequest_types.go
+++ b/api/remediation/v1alpha1/remediationrequest_types.go
@@ -897,7 +897,7 @@ type WorkflowSelection struct {
 	Confidence string `json:"confidence,omitempty"`
 
 	// WorkflowDisplayName is the human-readable workflow identifier
-	// (e.g., "GitRevertCommit:git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
+	// (e.g., "GitRevertCommit/git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
 	// +optional
 	WorkflowDisplayName string `json:"workflowDisplayName,omitempty"`
 

--- a/charts/kubernaut/crds/kubernaut.ai_remediationrequests.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_remediationrequests.yaml
@@ -1123,7 +1123,7 @@ spec:
                   workflowDisplayName:
                     description: |-
                       WorkflowDisplayName is the human-readable workflow identifier
-                      (e.g., "GitRevertCommit:git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
+                      (e.g., "GitRevertCommit/git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
                     type: string
                 type: object
             type: object

--- a/charts/kubernaut/files/crds/kubernaut.ai_remediationrequests.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_remediationrequests.yaml
@@ -1123,7 +1123,7 @@ spec:
                   workflowDisplayName:
                     description: |-
                       WorkflowDisplayName is the human-readable workflow identifier
-                      (e.g., "GitRevertCommit:git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
+                      (e.g., "GitRevertCommit/git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
                     type: string
                 type: object
             type: object

--- a/config/crd/bases/kubernaut.ai_remediationrequests.yaml
+++ b/config/crd/bases/kubernaut.ai_remediationrequests.yaml
@@ -1123,7 +1123,7 @@ spec:
                   workflowDisplayName:
                     description: |-
                       WorkflowDisplayName is the human-readable workflow identifier
-                      (e.g., "GitRevertCommit:git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
+                      (e.g., "GitRevertCommit/git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
                     type: string
                 type: object
             type: object

--- a/docs/generated/crds.md
+++ b/docs/generated/crds.md
@@ -1463,7 +1463,7 @@ _Appears in:_
 | `remediationTarget`| _[ResourceIdentifier](#resourceidentifier)_| RemediationTarget identifies the Kubernetes resource the LLM determined should be<br />remediated. Populated from AIAnalysis.Status.RootCauseAnalysis.RemediationTarget.<br />May differ from Spec.TargetResource (e.g., Deployment vs Pod).|
 | `targetDisplay`| _string_| TargetDisplay is the Kubernetes-idiomatic Kind/Name of the RCA target<br />(e.g., "Deployment/web-frontend"). Populated when RemediationTarget is set.|
 | `confidence`| _string_| Confidence is the AI analysis confidence score as a display string<br />(e.g., "0.97"). Populated from AIAnalysis.SelectedWorkflow.Confidence.|
-| `workflowDisplayName`| _string_| WorkflowDisplayName is the human-readable workflow identifier<br />(e.g., "GitRevertCommit:git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.|
+| `workflowDisplayName`| _string_| WorkflowDisplayName is the human-readable workflow identifier<br />(e.g., "GitRevertCommit/git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.|
 | `signalTargetDisplay`| _string_| SignalTargetDisplay is the Kubernetes-idiomatic Kind/Name of the signal target<br />(e.g., "Pod/web-frontend-cdbdbc4f8-6kn6j"). Populated from Spec.TargetResource.|
 
 

--- a/internal/controller/remediationorchestrator/wfe_creation_helper_test.go
+++ b/internal/controller/remediationorchestrator/wfe_creation_helper_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Issue #666: WFE Creation Helper (TP-666-v1 §8.3)", func() {
 		// Issue #1677 Phase 1: WorkflowDisplayName comes directly from
 		// ai.Status.SelectedWorkflow.ActionType/.WorkflowName (set by minimalAI()
 		// to "patch"/"wf-restart") -- no live resolver involved.
-		Expect(updated.Status.EnsureWorkflowSelection().WorkflowDisplayName).To(Equal("patch:wf-restart"))
+		Expect(updated.Status.EnsureWorkflowSelection().WorkflowDisplayName).To(Equal("patch/wf-restart"))
 	})
 
 	It("UT-WEC-005: increments ChildCRDCreationsTotal metric", func() {

--- a/internal/controller/remediationorchestrator/workflow_name_resolution_test.go
+++ b/internal/controller/remediationorchestrator/workflow_name_resolution_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Issue #1677 Phase 1: Workflow Name Resolution from AIAnalysis 
 		actionType   = "RestartPod"
 	)
 
-	It("UT-RO-643-001: should set WorkflowDisplayName as ActionType:WorkflowName from AIAnalysis.Status.SelectedWorkflow, with no DataStorage call", func() {
+	It("UT-RO-643-001: should set WorkflowDisplayName as ActionType/WorkflowName from AIAnalysis.Status.SelectedWorkflow, with no DataStorage call", func() {
 		ctx := context.Background()
 		scheme := setupScheme()
 
@@ -96,8 +96,8 @@ var _ = Describe("Issue #1677 Phase 1: Workflow Name Resolution from AIAnalysis 
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(updatedRR.Status.EnsureWorkflowSelection().WorkflowDisplayName).To(
-			Equal(actionType+":"+workflowName),
-			"WorkflowDisplayName should be ActionType:WorkflowName sourced from AIAnalysis.Status.SelectedWorkflow")
+			Equal(actionType+"/"+workflowName),
+			"WorkflowDisplayName should be ActionType/WorkflowName sourced from AIAnalysis.Status.SelectedWorkflow")
 		Expect(updatedRR.Status.EnsureWorkflowSelection().WorkflowDisplayName).NotTo(
 			ContainSubstring(workflowUUID),
 			"WorkflowDisplayName should NOT contain the raw UUID")
@@ -142,6 +142,6 @@ var _ = Describe("Issue #1677 Phase 1: Workflow Name Resolution from AIAnalysis 
 		err = fakeClient.Get(ctx, client.ObjectKey{Name: "test-rr-643b", Namespace: defaultFixture}, &updatedRR)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(updatedRR.Status.EnsureWorkflowSelection().WorkflowDisplayName).To(Equal("RestartPod:" + workflowUUID))
+		Expect(updatedRR.Status.EnsureWorkflowSelection().WorkflowDisplayName).To(Equal("RestartPod/" + workflowUUID))
 	})
 })

--- a/pkg/remediationrequest/display.go
+++ b/pkg/remediationrequest/display.go
@@ -30,9 +30,10 @@ func FormatResourceDisplay(kind, name string) string {
 	return kind + "/" + name
 }
 
-// FormatWorkflowDisplay produces an ActionType:WorkflowID string
-// for human-readable workflow identification. Returns empty string if
-// workflowID is empty.
+// FormatWorkflowDisplay produces an ActionType/WorkflowID string
+// for human-readable workflow identification, consistent with the
+// Kind/Name convention used by FormatResourceDisplay. Returns empty
+// string if workflowID is empty.
 func FormatWorkflowDisplay(actionType, workflowID string) string {
 	if workflowID == "" {
 		return ""
@@ -40,7 +41,7 @@ func FormatWorkflowDisplay(actionType, workflowID string) string {
 	if actionType == "" {
 		return workflowID
 	}
-	return actionType + ":" + workflowID
+	return actionType + "/" + workflowID
 }
 
 // FormatConfidence formats a float64 confidence score as a 2-decimal string.

--- a/pkg/remediationrequest/display_test.go
+++ b/pkg/remediationrequest/display_test.go
@@ -69,9 +69,9 @@ var _ = Describe("Issue #635: Display Helpers for RR kubectl Columns", func() {
 	// ========================================
 
 	Describe("FormatWorkflowDisplay", func() {
-		It("UT-RO-635-003: should produce ActionType:WorkflowID for standard workflow", func() {
+		It("UT-RO-635-003: should produce ActionType/WorkflowID for standard workflow", func() {
 			result := remediationrequest.FormatWorkflowDisplay("GitRevertCommit", "git-revert-v2")
-			Expect(result).To(Equal("GitRevertCommit:git-revert-v2"))
+			Expect(result).To(Equal("GitRevertCommit/git-revert-v2"))
 		})
 
 		It("UT-RO-635-004a: should return just WorkflowID when ActionType is empty", func() {
@@ -91,7 +91,7 @@ var _ = Describe("Issue #635: Display Helpers for RR kubectl Columns", func() {
 
 		It("should handle RestartPod action type", func() {
 			result := remediationrequest.FormatWorkflowDisplay("RestartPod", "restart-pod-v1")
-			Expect(result).To(Equal("RestartPod:restart-pod-v1"))
+			Expect(result).To(Equal("RestartPod/restart-pod-v1"))
 		})
 	})
 
@@ -136,13 +136,13 @@ var _ = Describe("Issue #635: Display Helpers for RR kubectl Columns", func() {
 				WorkflowSelection: &remediationv1.WorkflowSelection{
 					TargetDisplay:       "Deployment/web-frontend",
 					Confidence:          "0.97",
-					WorkflowDisplayName: "GitRevertCommit:git-revert-v2",
+					WorkflowDisplayName: "GitRevertCommit/git-revert-v2",
 					SignalTargetDisplay: "Pod/web-frontend-cdbdbc4f8-6kn6j",
 				},
 			}
 			Expect(status.WorkflowSelection.TargetDisplay).To(Equal("Deployment/web-frontend"))
 			Expect(status.WorkflowSelection.Confidence).To(Equal("0.97"))
-			Expect(status.WorkflowSelection.WorkflowDisplayName).To(Equal("GitRevertCommit:git-revert-v2"))
+			Expect(status.WorkflowSelection.WorkflowDisplayName).To(Equal("GitRevertCommit/git-revert-v2"))
 			Expect(status.WorkflowSelection.SignalTargetDisplay).To(Equal("Pod/web-frontend-cdbdbc4f8-6kn6j"))
 		})
 	})

--- a/pkg/shared/assets/crds/kubernaut.ai_remediationrequests.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_remediationrequests.yaml
@@ -1123,7 +1123,7 @@ spec:
                   workflowDisplayName:
                     description: |-
                       WorkflowDisplayName is the human-readable workflow identifier
-                      (e.g., "GitRevertCommit:git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
+                      (e.g., "GitRevertCommit/git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
                     type: string
                 type: object
             type: object

--- a/test/infrastructure/fleet_demo_helm.go
+++ b/test/infrastructure/fleet_demo_helm.go
@@ -183,6 +183,13 @@ func buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace string, fleetOp
 		// SetupFleetCoreInfrastructureWithGateway already provisions.
 		"--set", "console.enabled=true",
 		"--set", "console.auth.secretName=" + fleetDemoConsoleOAuthSecretName,
+		// console.ingress.enabled defaults to false (opt-in, same as
+		// gateway.ingress.enabled/apifrontend.ingress.enabled --
+		// charts/kubernaut/templates/console/ingress.yaml) -- without this,
+		// every other console.ingress.* --set below was silently a no-op:
+		// no Ingress resource ever rendered, so kubernaut-console.local
+		// never resolved to anything through Traefik (issue #2351).
+		"--set", "console.ingress.enabled=true",
 		"--set", "console.ingress.className=traefik",
 		"--set", "console.ingress.host=" + fleetDemoConsoleHost,
 		"--set", fmt.Sprintf("console.ingress.port=%d", fleetDemoConsolePort),


### PR DESCRIPTION
## Summary

Two independent fixes, consolidated into one PR:

- **`WorkflowDisplayName` separator (#2348)**: `FormatWorkflowDisplay` now joins `ActionType`/`WorkflowName` with `/` instead of `:`, matching the `Kind/Name` convention `FormatResourceDisplay` already uses for the TARGET/RCA TARGET/SIGNAL TARGET columns. `kubectl get rr` now uses one consistent separator across every composite column instead of mixing `:` and `/`.

  Before: `RollbackDeployment:crashloop-rollback-v1`
  After: `RollbackDeployment/crashloop-rollback-v1`

- **Fleet demo Console was never actually reachable (#2351)**: `fleet_demo_helm.go`'s Helm install set `console.ingress.className`/`host`/`port` but never `console.ingress.enabled`, which the chart's `Ingress` template gates on (default `false`, opt-in — same pattern as `gateway.ingress.enabled`/`apifrontend.ingress.enabled`). Every other `console.ingress.*` value was silently a no-op: no `Ingress` was ever rendered, so `kubernaut-console.local` never resolved through Traefik on any fleet demo run using this tooling. Found live while getting ready to switch a fleet demo scenario over to Console.

## Changes

- `pkg/remediationrequest/display.go`: `FormatWorkflowDisplay` separator change, plus its doc comment
- `api/remediation/v1alpha1/remediationrequest_types.go`: `WorkflowDisplayName` doc comment example updated
- Regenerated CRD manifests (`config/crd/bases`, Helm chart CRDs, embedded assets) and `docs/generated/crds.md` via `make manifests sync-embed generate-crd-docs`
- Test assertions updated in `pkg/remediationrequest/display_test.go`, `internal/controller/remediationorchestrator/workflow_name_resolution_test.go`, and `wfe_creation_helper_test.go`
- `test/infrastructure/fleet_demo_helm.go`: added the missing `--set console.ingress.enabled=true`

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/remediationrequest/... ./internal/controller/remediationorchestrator/... ./test/infrastructure/...` — all passing
- [x] `golangci-lint run` on touched packages — 0 issues
- [x] `FormatWorkflowDisplay` and its production caller (`persistWFERefAndDisplay`) both at 100% statement/branch coverage
- [x] Verified live on a Kind hub+spoke cluster: rendered `templates/console/ingress.yaml` with `console.ingress.enabled=true` and applied it directly, confirmed `kubectl get ingress -n kubernaut-system` now shows the `console` Ingress bound to `kubernaut-console.local` via the `traefik` class, and Console's own oauth2-proxy redirect (`https://kubernaut-console.local:8843/oauth2/callback`) now resolves instead of 404ing

Closes #2348
Closes #2351
