### PR TITLE
fix(fleet-demo): set apifrontend.config.auth.audience so Console's access check passes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -984,13 +984,14 @@ setup-fleet-demo-infra: ## Create fleet Kind clusters + install Kubernaut, Conso
 		-llm-model "$(LLM_MODEL)" \
 		-llm-endpoint "$(LLM_ENDPOINT)" \
 		-llm-credentials-file "$(LLM_CREDENTIALS_FILE)" \
-		$(if $(AUTONOMOUS),-autonomous=$(AUTONOMOUS)) \
-		$(if $(GATEWAY_TYPE),-gateway-type "$(GATEWAY_TYPE)") \
-		$(if $(SPOKE_WORKERS),-spoke-workers "$(SPOKE_WORKERS)") \
-		$(if $(SP_POLICY_FILE),-sp-policy-file "$(SP_POLICY_FILE)") \
-		$(if $(AA_POLICY_FILE),-aa-policy-file "$(AA_POLICY_FILE)") \
-		$(if $(CLUSTER_NAME),-cluster-name "$(CLUSTER_NAME)") \
-		$(if $(REMOTE_CLUSTER_NAME),-remote-cluster-name "$(REMOTE_CLUSTER_NAME)")
+		$(if $(IMAGE_TAG),-image-tag "$(IMAGE_TAG)" \ )
+		$(if $(AUTONOMOUS),-autonomous=$(AUTONOMOUS) \ )
+		$(if $(GATEWAY_TYPE),-gateway-type "$(GATEWAY_TYPE)" \ )
+		$(if $(SPOKE_WORKERS),-spoke-workers "$(SPOKE_WORKERS)" \ )
+		$(if $(SP_POLICY_FILE),-sp-policy-file "$(SP_POLICY_FILE)" \ )
+		$(if $(AA_POLICY_FILE),-aa-policy-file "$(AA_POLICY_FILE)" \ )
+		$(if $(CLUSTER_NAME),-cluster-name "$(CLUSTER_NAME)" \ )
+		$(if $(REMOTE_CLUSTER_NAME),-remote-cluster-name "$(REMOTE_CLUSTER_NAME)" \ )
 
 .PHONY: bind-fleet-af-rbac
 bind-fleet-af-rbac: ## Bind AF's kubernaut-tool-<persona>/console-access ClusterRoles to Keycloak's "sre" group (run AFTER helm install)

--- a/Makefile
+++ b/Makefile
@@ -963,11 +963,13 @@ test-e2e-fleet: ginkgo ensure-coverage-dirs ## Run fleet E2E tests (multi-cluste
 # fleet MCPServerRegistration/AlertManager label already uses for this same
 # physical cluster.
 .PHONY: setup-fleet-demo-infra
-setup-fleet-demo-infra: ## Create fleet Kind clusters + install Kubernaut, Console-first by default (~15 min). Required: LLM_PROVIDER, LLM_MODEL, LLM_ENDPOINT, LLM_CREDENTIALS_FILE
-	@if [ -z "$(LLM_PROVIDER)" ] || [ -z "$(LLM_MODEL)" ] || [ -z "$(LLM_ENDPOINT)" ] || [ -z "$(LLM_CREDENTIALS_FILE)" ]; then \
-		echo "❌ LLM_PROVIDER, LLM_MODEL, LLM_ENDPOINT, and LLM_CREDENTIALS_FILE are all required, e.g.:"; \
+setup-fleet-demo-infra: ## Create fleet Kind clusters + install Kubernaut, Console-first by default (~15 min). Required: LLM_PROVIDER, LLM_MODEL, LLM_CREDENTIALS_FILE (+ LLM_ENDPOINT except with LLM_PROVIDER=vertex_ai, + VERTEX_PROJECT/VERTEX_LOCATION with LLM_PROVIDER=vertex_ai)
+	@if [ -z "$(LLM_PROVIDER)" ] || [ -z "$(LLM_MODEL)" ] || [ -z "$(LLM_CREDENTIALS_FILE)" ] || { [ -z "$(LLM_ENDPOINT)" ] && [ "$(LLM_PROVIDER)" != "vertex_ai" ]; }; then \
+		echo "❌ LLM_PROVIDER, LLM_MODEL, and LLM_CREDENTIALS_FILE are always required; LLM_ENDPOINT is required except with LLM_PROVIDER=vertex_ai, e.g.:"; \
 		echo "   make setup-fleet-demo-infra LLM_PROVIDER=openai_compatible LLM_MODEL=gpt-4o \\"; \
 		echo "     LLM_ENDPOINT=https://api.openai.com/v1 LLM_CREDENTIALS_FILE=~/.secrets/llm-api-key.txt"; \
+		echo "   make setup-fleet-demo-infra LLM_PROVIDER=vertex_ai LLM_MODEL=claude-haiku-4-5@20251001 \\"; \
+		echo "     LLM_CREDENTIALS_FILE=~/.config/gcloud/key.json VERTEX_PROJECT=my-project VERTEX_LOCATION=us-central1"; \
 		echo ""; \
 		echo "LLM_CREDENTIALS_FILE is a file holding your raw LLM credential (a plain API"; \
 		echo "key, or a JSON blob for vertex_ai) -- it becomes the llm-credentials-primary"; \
@@ -985,6 +987,8 @@ setup-fleet-demo-infra: ## Create fleet Kind clusters + install Kubernaut, Conso
 		-llm-endpoint "$(LLM_ENDPOINT)" \
 		-llm-credentials-file "$(LLM_CREDENTIALS_FILE)" \
 		$(if $(IMAGE_TAG),-image-tag "$(IMAGE_TAG)" \ )
+		$(if $(VERTEX_PROJECT),-vertex-project "$(VERTEX_PROJECT)" \ )
+		$(if $(VERTEX_LOCATION),-vertex-location "$(VERTEX_LOCATION)" \ )
 		$(if $(AUTONOMOUS),-autonomous=$(AUTONOMOUS) \ )
 		$(if $(GATEWAY_TYPE),-gateway-type "$(GATEWAY_TYPE)" \ )
 		$(if $(SPOKE_WORKERS),-spoke-workers "$(SPOKE_WORKERS)" \ )

--- a/charts/kubernaut/Chart.yaml
+++ b/charts/kubernaut/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubernaut
 description: Kubernaut - Autonomous Kubernetes Remediation Platform
 type: application
-version: 1.6.0
-appVersion: "1.6.0"
+version: 1.6.0-rc9
+appVersion: "1.6.0-rc9"
 home: https://github.com/jordigilh/kubernaut
 sources:
   - https://github.com/jordigilh/kubernaut

--- a/charts/kubernaut/README.md
+++ b/charts/kubernaut/README.md
@@ -809,6 +809,28 @@ helm install kubernaut oci://quay.io/myorg/charts/kubernaut \
 
 See the [Disconnected Install Guide](https://jordigilh.github.io/kubernaut-docs/operations/disconnected-install/) for image mirroring instructions.
 
+### Overriding the image tag
+
+Every chart-managed service renders its image via the `kubernaut.image` helper as
+`{registry}/{namespace}{separator}{service}:{tag}`, where `tag` is
+`global.image.tag` when set, otherwise the chart's `appVersion`
+(`charts/kubernaut/Chart.yaml`). To pin or test a published tag without changing
+the chart version:
+
+```bash
+helm upgrade kubernaut charts/kubernaut \
+  --namespace kubernaut-system \
+  --set global.image.tag=1.6.0-rc9 \
+  ...
+```
+
+The fleet demo entry point wires this directly: `setup-fleet-demo-infra
+-image-tag 1.6.0-rc9 ...` (equivalently `make setup-fleet-demo-infra
+IMAGE_TAG=1.6.0-rc9 ...`). When the flag is omitted, no `--set` is emitted and
+every service falls back to `.Chart.AppVersion`. Note the `console` container
+itself is versioned independently (`console.image.repository:tag`) and is
+intentionally not part of the `global.image.tag` train.
+
 ## Upgrading
 
 Helm does **not** upgrade CRDs on `helm upgrade`. Apply new CRDs first:

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -199,7 +199,8 @@ spec:
       {{- include "kubernaut.scheduling" (dict "component" .Values.fleetmetadatacache "global" .Values.global) | nindent 6 }}
       containers:
         - name: fleetmetadatacache
-          image: "{{ $v.image.repository }}:{{ $v.image.tag }}"
+          image: {{ include "kubernaut.image" (dict "service" "fleetmetadatacache" "root" $ "appVersion" .Chart.AppVersion) }}
+          # image: "{{ $v.image.repository }}:{{ $v.image.tag }}"
           imagePullPolicy: {{ $v.image.pullPolicy }}
           securityContext:
             {{- include "kubernaut.containerSecurityContext" .Values.fleetmetadatacache | nindent 12 }}

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -200,7 +200,6 @@ spec:
       containers:
         - name: fleetmetadatacache
           image: {{ include "kubernaut.image" (dict "service" "fleetmetadatacache" "root" $ "appVersion" .Chart.AppVersion) }}
-          # image: "{{ $v.image.repository }}:{{ $v.image.tag }}"
           imagePullPolicy: {{ $v.image.pullPolicy }}
           securityContext:
             {{- include "kubernaut.containerSecurityContext" .Values.fleetmetadatacache | nindent 12 }}

--- a/charts/kubernaut/tests/global_image_overrides_test.yaml
+++ b/charts/kubernaut/tests/global_image_overrides_test.yaml
@@ -1,0 +1,136 @@
+suite: global.image registry/tag overrides render into container images
+templates:
+  - templates/apifrontend/apifrontend.yaml
+  - templates/fleetmetadatacache/fleetmetadatacache.yaml
+  - templates/datastorage/datastorage.yaml
+  - templates/gateway/gateway.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  kubernautAgent:
+    llmProfileRef: primary
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+  fleetmetadatacache:
+    enabled: true
+    namespace: "mcp-gateway-system"
+    oauth2:
+      credentialsSecretRef: "fmc-creds"
+  global:
+    llmProfiles:
+      primary:
+        provider: openai
+        model: gpt-4
+        credentialsSecretName: llm-credentials-primary
+    fleet:
+      mcpGatewayEndpoint: "http://mcp.example.com"
+      oauth2:
+        enabled: true
+        tokenURL: "http://oauth.example.com"
+        credentialsSecretRef: "fleet-oauth2-creds"
+  workflowexecution:
+    fleet:
+      oauth2:
+        credentialsSecretRef: we-oauth2-creds
+tests:
+  - it: "default (no global.image.tag): apifrontend image falls back to the chart appVersion, never an empty tag"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^quay\.io/kubernaut-ai/apifrontend:.+$'
+
+  - it: "global.image.tag override wins over the chart appVersion (apifrontend)"
+    set:
+      global:
+        image:
+          tag: test-tag-1.2.3
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: quay.io/kubernaut-ai/apifrontend:test-tag-1.2.3
+
+  - it: "global.image.registry override is honored (apifrontend)"
+    set:
+      global:
+        image:
+          registry: harbor.corp
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^harbor\.corp/kubernaut-ai/apifrontend:.+$'
+
+  - it: "global.image.registry + tag combine (apifrontend)"
+    set:
+      global:
+        image:
+          registry: harbor.corp
+          tag: test-tag-1.2.3
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: harbor.corp/kubernaut-ai/apifrontend:test-tag-1.2.3
+
+  - it: "fleetmetadatacache honors the global.image.tag override (kubernaut.image helper, not a per-service field)"
+    set:
+      global:
+        image:
+          tag: test-tag-1.2.3
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: quay.io/kubernaut-ai/fleetmetadatacache:test-tag-1.2.3
+
+  - it: "datastorage honors the global.image.tag override"
+    set:
+      global:
+        image:
+          tag: test-tag-1.2.3
+    template: templates/datastorage/datastorage.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: quay.io/kubernaut-ai/datastorage:test-tag-1.2.3
+
+  - it: "gateway honors the global.image.tag override"
+    set:
+      global:
+        image:
+          tag: test-tag-1.2.3
+    template: templates/gateway/gateway.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: quay.io/kubernaut-ai/gateway:test-tag-1.2.3

--- a/docs/operations/deployment/FLEET_DEMO_QUICKSTART.md
+++ b/docs/operations/deployment/FLEET_DEMO_QUICKSTART.md
@@ -41,6 +41,24 @@ make setup-fleet-demo-infra \
   LLM_CREDENTIALS_FILE=/tmp/llm-credentials
 ```
 
+For Claude on Vertex AI instead, point the credential file at a GCP
+service-account key JSON and pass the Vertex project/location (required with
+`LLM_PROVIDER=vertex_ai`; the endpoint is the regional host — the Vertex
+endpoint itself is derived from project/location):
+
+```bash
+make setup-fleet-demo-infra \
+  LLM_PROVIDER=vertex_ai \
+  LLM_MODEL=claude-haiku-4-5@20251001 \
+  LLM_CREDENTIALS_FILE=~/.config/gcloud/kubernaut-fleet-demo-vertexai-key.json \
+  VERTEX_PROJECT=<GCP_PROJECT_ID> \
+  VERTEX_LOCATION=us-central1
+```
+
+No `LLM_ENDPOINT`: every Vertex consumer derives the endpoint from
+project/location (or honors the SDK default), so the flag is not required
+with `LLM_PROVIDER=vertex_ai` (issue #2355).
+
 This creates the hub + spoke Kind clusters, Keycloak, MCP Gateway, kube-mcp-server,
 and fleet-wide monitoring; once the hub cluster exists, it writes
 `LLM_CREDENTIALS_FILE`'s contents into the `llm-credentials-primary` Secret (there's no

--- a/hack/setup-fleet-infra/main.go
+++ b/hack/setup-fleet-infra/main.go
@@ -66,11 +66,13 @@ func main() {
 	autonomous := flag.Bool("autonomous", false, "enable Gateway (gateway.enabled=true) so demo alerts auto-remediate; default false is Console-first, so you drive the first investigation yourself")
 	llmProvider := flag.String("llm-provider", "", "required: global.llmProfiles.primary.provider (e.g. openai_compatible)")
 	llmModel := flag.String("llm-model", "", "required: global.llmProfiles.primary.model")
-	llmEndpoint := flag.String("llm-endpoint", "", "required: global.llmProfiles.primary.endpoint")
+	llmEndpoint := flag.String("llm-endpoint", "", "required except with -llm-provider=vertex_ai: global.llmProfiles.primary.endpoint (omit it for vertex_ai -- the Vertex endpoint is derived from -vertex-project/-vertex-location)")
 	llmCredentialsFile := flag.String("llm-credentials-file", "", "required: path to a file holding your LLM provider credentials (a plain API key, or a JSON blob for vertex_ai service-account/ADC credentials) -- written verbatim into the llm-credentials-primary Secret once the hub cluster exists, replacing the mock placeholder")
 	spPolicyFile := flag.String("sp-policy-file", "", "optional: SignalProcessing Rego policy file (default: a built-in catch-all demo policy)")
 	aaPolicyFile := flag.String("aa-policy-file", "", "optional: AIAnalysis Rego policy file (default: a built-in policy that always requires human approval)")
 	imageTag := flag.String("image-tag", "", "optional: override the container image tag for the fleet demo chart (global.image.tag, e.g. -image-tag 1.6.0-rc9 to test a published image); when empty, the chart's kubernaut.image helper falls back to .Chart.AppVersion")
+	vertexProject := flag.String("vertex-project", "", "required with -llm-provider=vertex_ai: GCP project ID (global.llmProfiles.primary.vertexProject)")
+	vertexLocation := flag.String("vertex-location", "", "required with -llm-provider=vertex_ai: GCP region, e.g. us-central1 (global.llmProfiles.primary.vertexLocation)")
 	// sigs.k8s.io/controller-runtime/pkg/client/config's own init() unconditionally
 	// registers a "-kubeconfig" flag on flag.CommandLine the moment anything --
 	// direct or transitive -- imports it, which already happened here via the
@@ -101,13 +103,15 @@ func main() {
 	}
 
 	demoOpts := infrastructure.FleetDemoHelmOptions{
-		Autonomous:   *autonomous,
-		LLMProvider:  *llmProvider,
-		LLMModel:     *llmModel,
-		LLMEndpoint:  *llmEndpoint,
-		SPPolicyFile: *spPolicyFile,
-		AAPolicyFile: *aaPolicyFile,
-		ImageTag:     *imageTag,
+		Autonomous:     *autonomous,
+		LLMProvider:    *llmProvider,
+		LLMModel:       *llmModel,
+		LLMEndpoint:    *llmEndpoint,
+		SPPolicyFile:   *spPolicyFile,
+		AAPolicyFile:   *aaPolicyFile,
+		ImageTag:       *imageTag,
+		VertexProject:  *vertexProject,
+		VertexLocation: *vertexLocation,
 	}
 	if err := demoOpts.Validate(); err != nil {
 		fmt.Fprintf(os.Stderr, "❌ %v\n", err)

--- a/hack/setup-fleet-infra/main.go
+++ b/hack/setup-fleet-infra/main.go
@@ -70,6 +70,7 @@ func main() {
 	llmCredentialsFile := flag.String("llm-credentials-file", "", "required: path to a file holding your LLM provider credentials (a plain API key, or a JSON blob for vertex_ai service-account/ADC credentials) -- written verbatim into the llm-credentials-primary Secret once the hub cluster exists, replacing the mock placeholder")
 	spPolicyFile := flag.String("sp-policy-file", "", "optional: SignalProcessing Rego policy file (default: a built-in catch-all demo policy)")
 	aaPolicyFile := flag.String("aa-policy-file", "", "optional: AIAnalysis Rego policy file (default: a built-in policy that always requires human approval)")
+	imageTag := flag.String("image-tag", "latest", "Docker image tag for the fleet demo chart (default: latest, which is the current local build; pass a specific tag to test a published image)")
 	// sigs.k8s.io/controller-runtime/pkg/client/config's own init() unconditionally
 	// registers a "-kubeconfig" flag on flag.CommandLine the moment anything --
 	// direct or transitive -- imports it, which already happened here via the
@@ -106,6 +107,7 @@ func main() {
 		LLMEndpoint:  *llmEndpoint,
 		SPPolicyFile: *spPolicyFile,
 		AAPolicyFile: *aaPolicyFile,
+		ImageTag:     *imageTag,
 	}
 	if err := demoOpts.Validate(); err != nil {
 		fmt.Fprintf(os.Stderr, "❌ %v\n", err)

--- a/hack/setup-fleet-infra/main.go
+++ b/hack/setup-fleet-infra/main.go
@@ -70,7 +70,7 @@ func main() {
 	llmCredentialsFile := flag.String("llm-credentials-file", "", "required: path to a file holding your LLM provider credentials (a plain API key, or a JSON blob for vertex_ai service-account/ADC credentials) -- written verbatim into the llm-credentials-primary Secret once the hub cluster exists, replacing the mock placeholder")
 	spPolicyFile := flag.String("sp-policy-file", "", "optional: SignalProcessing Rego policy file (default: a built-in catch-all demo policy)")
 	aaPolicyFile := flag.String("aa-policy-file", "", "optional: AIAnalysis Rego policy file (default: a built-in policy that always requires human approval)")
-	imageTag := flag.String("image-tag", "latest", "Docker image tag for the fleet demo chart (default: latest, which is the current local build; pass a specific tag to test a published image)")
+	imageTag := flag.String("image-tag", "", "optional: override the container image tag for the fleet demo chart (global.image.tag, e.g. -image-tag 1.6.0-rc9 to test a published image); when empty, the chart's kubernaut.image helper falls back to .Chart.AppVersion")
 	// sigs.k8s.io/controller-runtime/pkg/client/config's own init() unconditionally
 	// registers a "-kubeconfig" flag on flag.CommandLine the moment anything --
 	// direct or transitive -- imports it, which already happened here via the

--- a/internal/kubernautagent/session/late_subscribe_replay_1811_test.go
+++ b/internal/kubernautagent/session/late_subscribe_replay_1811_test.go
@@ -137,8 +137,17 @@ var _ = Describe("Late-Subscribe Event Replay — AA/AF Interactive-Upgrade Race
 
 	Describe("UT-KA-1811-003: already-working case (sink active before emission) is unaffected", func() {
 		It("delivers events live with no duplication when Subscribe happens before the goroutine emits", func() {
+			// Gate emission on Subscribe by construction: Launch runs the
+			// worker async, so without this the worker can finish (terminal +
+			// closed channel, no eventChan ever created) before Subscribe runs
+			// and Subscribe correctly returns ErrSessionTerminal -- a load-
+			// dependent flake (CI failure: "session is in terminal state"),
+			// not a product bug. Holding the worker until the sink is
+			// attached is exactly the ordering this spec intends to cover.
+			emitGate := make(chan struct{})
 			pendingID, err := mgr.StartInteractiveSession(context.Background(),
 				func(ctx context.Context) (*katypes.InvestigationResult, error) {
+					<-emitGate
 					session.EmitEvent(ctx, session.InvestigationEvent{Type: session.EventTypeReasoningDelta, Turn: 0})
 					return &katypes.InvestigationResult{RCASummary: "ok"}, nil
 				},
@@ -150,6 +159,7 @@ var _ = Describe("Late-Subscribe Event Replay — AA/AF Interactive-Upgrade Race
 
 			eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
 			Expect(subErr).NotTo(HaveOccurred())
+			close(emitGate)
 
 			var received []session.InvestigationEvent
 			for evt := range eventCh {

--- a/test/e2e/fullpipeline/14_crashloop_real_fix_test.go
+++ b/test/e2e/fullpipeline/14_crashloop_real_fix_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,8 +63,18 @@ var _ = Describe("E2E-FP-1542-001: CrashLoop config fix performs a real fix (sin
 		Expect(workflowUUIDs).To(HaveKey("crashloop-config-fix-v1:production"))
 	})
 
-	AfterEach(func() {
-		if testNamespace != "" {
+	AfterEach(func(specCtx SpecContext) {
+		if testNamespace == "" {
+			testCancel()
+			return
+		}
+		if specCtx.SpecReport().Failed() {
+			// The namespace is deleted below on success, and must-gather
+			// only covers fixed namespaces -- so without this dump a wait
+			// timeout leaves zero pod-level evidence in the CI log.
+			dumpCrashLoopDiagnostics(testNamespace)
+			GinkgoWriter.Printf("  ⚠️ spec failed: preserving namespace %s for triage (skipped AfterEach delete)\n", testNamespace)
+		} else {
 			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
 			_ = k8sClient.Delete(ctx, ns)
 		}
@@ -142,3 +153,47 @@ var _ = Describe("E2E-FP-1542-001: CrashLoop config fix performs a real fix (sin
 		})
 	})
 })
+
+// dumpCrashLoopDiagnostics lists the workload objects in a failed spec's test
+// namespace and renders them to the Ginkgo log. Called from AfterEach only
+// when the spec failed (the namespace is deleted on success and must-gather
+// never covers fp-e2e-* namespaces, so this is the only pod-level evidence a
+// recurrence leaves behind).
+func dumpCrashLoopDiagnostics(testNamespace string) {
+	listCtx := context.Background()
+
+	pods := &corev1.PodList{}
+	if err := apiReader.List(listCtx, pods, client.InNamespace(testNamespace),
+		client.MatchingLabels{"app": infrastructure.CrashLoopAppName}); err != nil {
+		GinkgoWriter.Printf("  diagnostics namespace=%s: pod list failed: %v\n", testNamespace, err)
+	} else {
+		GinkgoWriter.Printf("%s", infrastructure.SummarizePodsForDiagnostics(testNamespace, pods))
+	}
+
+	deps := &appsv1.DeploymentList{}
+	if err := apiReader.List(listCtx, deps, client.InNamespace(testNamespace)); err != nil {
+		GinkgoWriter.Printf("  diagnostics namespace=%s: deployment list failed: %v\n", testNamespace, err)
+	}
+	for _, d := range deps.Items {
+		GinkgoWriter.Printf("  diagnostics deployment=%s replicas=%d available=%d updated=%d\n",
+			d.Name, derefInt32CrashLoop(d.Spec.Replicas),
+			d.Status.AvailableReplicas, d.Status.UpdatedReplicas)
+	}
+
+	rss := &appsv1.ReplicaSetList{}
+	if err := apiReader.List(listCtx, rss, client.InNamespace(testNamespace)); err != nil {
+		GinkgoWriter.Printf("  diagnostics namespace=%s: replicaset list failed: %v\n", testNamespace, err)
+	}
+	for _, rs := range rss.Items {
+		GinkgoWriter.Printf("  diagnostics replicaset=%s replicas=%d ready=%d available=%d\n",
+			rs.Name, derefInt32CrashLoop(rs.Spec.Replicas),
+			rs.Status.ReadyReplicas, rs.Status.AvailableReplicas)
+	}
+}
+
+func derefInt32CrashLoop(p *int32) int32 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}

--- a/test/infrastructure/fleet_demo_helm.go
+++ b/test/infrastructure/fleet_demo_helm.go
@@ -196,8 +196,14 @@ func buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace string, fleetOp
 		"--set", "networkPolicies.console.ingressNamespaces[0]=" + fleetDemoTraefikNamespace,
 		// AF/Console browser+in-cluster OIDC: reuses the same Keycloak fleet
 		// infra already stands up (no DEX test double, unlike the FP suite).
+		// audience MUST match the kubernaut-apifrontend-audience client scope's
+		// oidc-audience-mapper (test/infrastructure/keycloak-realm-fleet.json),
+		// else AF's JWTValidator.validateAudience rejects every console token
+		// with ErrInvalidAudience -> 401 -> console "Unable to Verify Access"
+		// (issue #2352). Mirrors fullpipeline_e2e_helm.go:1088.
 		"--set", "apifrontend.config.auth.issuerURL=" + keycloakAuthBase,
 		"--set", "apifrontend.config.auth.jwksURL=" + keycloakInClusterBase + "/protocol/openid-connect/certs",
+		"--set", "apifrontend.config.auth.audience=kubernaut-apifrontend",
 		// Split browser/in-cluster OIDC endpoints (Keycloak lives in its own
 		// "idp" namespace, not kubernaut-system -- see keycloak_e2e.go).
 		"--set", "console.oauth2Proxy.skipDiscovery=true",

--- a/test/infrastructure/fleet_demo_helm.go
+++ b/test/infrastructure/fleet_demo_helm.go
@@ -133,6 +133,8 @@ type FleetDemoHelmOptions struct {
 	// does not bundle default Rego policies").
 	SPPolicyFile string
 	AAPolicyFile string
+	// allows overwritting the image tag used for the fleet demo chart, which defaults to "latest" (the current local build) but can be overridden to test a published image.
+	ImageTag string
 }
 
 // Validate reports every missing required flag in one error, so
@@ -173,6 +175,7 @@ func buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace string, fleetOp
 		"--namespace", namespace,
 		"--create-namespace",
 		"--timeout", "8m",
+		"--set", "global.image.tag=" + opts.ImageTag,
 		"--set", "global.llmProfiles.primary.provider=" + opts.LLMProvider,
 		"--set", "global.llmProfiles.primary.model=" + opts.LLMModel,
 		"--set", "global.llmProfiles.primary.endpoint=" + opts.LLMEndpoint,
@@ -395,7 +398,7 @@ func InstallFleetDemoHelmChart(ctx context.Context, kubeconfigPath, remoteKubeco
 
 	args := buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace, fleetOpts, opts, spPolicyFile, aaPolicyFile)
 
-	_, _ = fmt.Fprintln(writer, "\n🚀 helm upgrade --install kubernaut charts/kubernaut ...")
+	_, _ = fmt.Fprintf(writer, "\n🚀 helm upgrade --install kubernaut charts/kubernaut %s", args)
 	cmd := exec.CommandContext(ctx, "helm", args...)
 	cmd.Stdout = writer
 	cmd.Stderr = writer

--- a/test/infrastructure/fleet_demo_helm.go
+++ b/test/infrastructure/fleet_demo_helm.go
@@ -133,7 +133,10 @@ type FleetDemoHelmOptions struct {
 	// does not bundle default Rego policies").
 	SPPolicyFile string
 	AAPolicyFile string
-	// allows overwritting the image tag used for the fleet demo chart, which defaults to "latest" (the current local build) but can be overridden to test a published image.
+	// ImageTag optionally overrides the container image tag for the fleet
+	// demo chart (global.image.tag). When empty (the default), no --set is
+	// emitted and the chart's kubernaut.image helper falls back to
+	// .Chart.AppVersion (global.image.tag defaults to "").
 	ImageTag string
 }
 
@@ -175,7 +178,6 @@ func buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace string, fleetOp
 		"--namespace", namespace,
 		"--create-namespace",
 		"--timeout", "8m",
-		"--set", "global.image.tag=" + opts.ImageTag,
 		"--set", "global.llmProfiles.primary.provider=" + opts.LLMProvider,
 		"--set", "global.llmProfiles.primary.model=" + opts.LLMModel,
 		"--set", "global.llmProfiles.primary.endpoint=" + opts.LLMEndpoint,
@@ -221,6 +223,16 @@ func buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace string, fleetOp
 		"--set", "networkPolicies.idp.port=8443",
 		"--set-file", "signalprocessing.policies.content=" + spPolicyFile,
 		"--set-file", "aianalysis.policies.content=" + aaPolicyFile,
+	}
+
+	if opts.ImageTag != "" {
+		// Optional tag override (global.image.tag, consumed by the chart's
+		// kubernaut.image helper). Deliberately omitted when empty so the
+		// helper falls back to .Chart.AppVersion -- an unconditional
+		// "--set global.image.tag=" here would be shadowed by
+		// buildFleetOAuth2HelmArgs below anyway (helm --set is last-wins),
+		// which is why a provided override previously never took effect.
+		args = append(args, "--set", "global.image.tag="+opts.ImageTag)
 	}
 
 	if opts.Autonomous {

--- a/test/infrastructure/fleet_demo_helm.go
+++ b/test/infrastructure/fleet_demo_helm.go
@@ -26,6 +26,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
 )
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -138,6 +140,13 @@ type FleetDemoHelmOptions struct {
 	// emitted and the chart's kubernaut.image helper falls back to
 	// .Chart.AppVersion (global.image.tag defaults to "").
 	ImageTag string
+	// VertexProject/VertexLocation feed global.llmProfiles.primary.vertexProject
+	// / vertexLocation -- required by the chart when LLMProvider is vertex_ai
+	// (the provider hosts Claude/Gemini models and derives its endpoint from
+	// project/location). Empty for every other provider; no --set is emitted
+	// then, keeping non-Vertex renders unchanged.
+	VertexProject  string
+	VertexLocation string
 }
 
 // Validate reports every missing required flag in one error, so
@@ -151,8 +160,21 @@ func (o FleetDemoHelmOptions) Validate() error {
 	if o.LLMModel == "" {
 		missing = append(missing, "-llm-model")
 	}
-	if o.LLMEndpoint == "" {
+	// Endpoint is required for every provider except vertex_ai, whose
+	// endpoint is derived from project/location by the SDK (issue #2355) --
+	// mirrors the platform contract in pkg/shared/types LLMConfig
+	// validateProviderRequiredFields (endpoint required only for
+	// openai/openai_compatible).
+	if o.LLMEndpoint == "" && o.LLMProvider != sharedtypes.LLMProviderVertexAI {
 		missing = append(missing, "-llm-endpoint")
+	}
+	if o.LLMProvider == sharedtypes.LLMProviderVertexAI {
+		if o.VertexProject == "" {
+			missing = append(missing, "-vertex-project")
+		}
+		if o.VertexLocation == "" {
+			missing = append(missing, "-vertex-location")
+		}
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("missing required flags: %s", strings.Join(missing, ", "))
@@ -180,7 +202,6 @@ func buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace string, fleetOp
 		"--timeout", "8m",
 		"--set", "global.llmProfiles.primary.provider=" + opts.LLMProvider,
 		"--set", "global.llmProfiles.primary.model=" + opts.LLMModel,
-		"--set", "global.llmProfiles.primary.endpoint=" + opts.LLMEndpoint,
 		"--set", "global.llmProfiles.primary.credentialsSecretName=" + fleetDemoLLMSecretName,
 		"--set", fmt.Sprintf("gateway.enabled=%t", opts.Autonomous),
 		// Console: always on (BR-PLATFORM-014, Console-first default). Reuses
@@ -225,6 +246,14 @@ func buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace string, fleetOp
 		"--set-file", "aianalysis.policies.content=" + aaPolicyFile,
 	}
 
+	if opts.LLMEndpoint != "" {
+		// Omitted when empty so vertex_ai installs carry no endpoint at all:
+		// every Vertex consumer derives it from project/location (or honors
+		// the SDK default), and an explicit empty --set would only obscure
+		// that (issue #2355). Same omit-when-empty pattern as ImageTag below.
+		args = append(args, "--set", "global.llmProfiles.primary.endpoint="+opts.LLMEndpoint)
+	}
+
 	if opts.ImageTag != "" {
 		// Optional tag override (global.image.tag, consumed by the chart's
 		// kubernaut.image helper). Deliberately omitted when empty so the
@@ -233,6 +262,13 @@ func buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace string, fleetOp
 		// buildFleetOAuth2HelmArgs below anyway (helm --set is last-wins),
 		// which is why a provided override previously never took effect.
 		args = append(args, "--set", "global.image.tag="+opts.ImageTag)
+	}
+
+	if opts.VertexProject != "" {
+		args = append(args, "--set", "global.llmProfiles.primary.vertexProject="+opts.VertexProject)
+	}
+	if opts.VertexLocation != "" {
+		args = append(args, "--set", "global.llmProfiles.primary.vertexLocation="+opts.VertexLocation)
 	}
 
 	if opts.Autonomous {

--- a/test/infrastructure/fleet_demo_helm_test.go
+++ b/test/infrastructure/fleet_demo_helm_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package infrastructure
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -110,6 +112,15 @@ var _ = Describe("buildFleetOAuth2HelmArgs", func() {
 		args := buildFleetOAuth2HelmArgs(&FleetHelmOptions{})
 		Expect(args).To(ContainElements("--set", "fleetmetadatacache.namespace="))
 	})
+
+	It("UT-INFRA-FLEETDEMO-035: omits global.image.tag when ImageTag is empty (a trailing empty --set would clobber the demo override, helm last-wins)", func() {
+		args := buildFleetOAuth2HelmArgs(&FleetHelmOptions{FleetMetadataCacheNamespace: "kubernaut-system"})
+		for i, a := range args {
+			if a == "--set" && i+1 < len(args) {
+				Expect(args[i+1]).NotTo(HavePrefix("global.image.tag="))
+			}
+		}
+	})
 })
 
 var _ = Describe("buildFleetDemoHelmArgs", func() {
@@ -183,6 +194,28 @@ var _ = Describe("buildFleetDemoHelmArgs", func() {
 		Expect(args).To(ContainElements(
 			"--set", "apifrontend.config.auth.issuerURL=https://keycloak:8443/realms/kubernaut-fleet",
 		))
+	})
+
+	It("UT-INFRA-FLEETDEMO-036: omits global.image.tag when ImageTag is empty (chart falls back to .Chart.AppVersion)", func() {
+		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, baseOpts, "/tmp/sp.rego", "/tmp/aa.rego")
+		for i, a := range args {
+			if a == "--set" && i+1 < len(args) {
+				Expect(args[i+1]).NotTo(HavePrefix("global.image.tag="))
+			}
+		}
+	})
+
+	It("UT-INFRA-FLEETDEMO-037: sets exactly one global.image.tag when ImageTag is provided (no trailing empty duplicate)", func() {
+		opts := baseOpts
+		opts.ImageTag = "demo-v1.0"
+		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, opts, "/tmp/sp.rego", "/tmp/aa.rego")
+		var tags []string
+		for i, a := range args {
+			if a == "--set" && i+1 < len(args) && strings.HasPrefix(args[i+1], "global.image.tag=") {
+				tags = append(tags, args[i+1])
+			}
+		}
+		Expect(tags).To(Equal([]string{"global.image.tag=demo-v1.0"}))
 	})
 
 	It("UT-INFRA-FLEETDEMO-034: sets apifrontend.config.auth.audience to kubernaut-apifrontend (issue #2352, else AF 401s every console token -> 'Unable to Verify Access')", func() {

--- a/test/infrastructure/fleet_demo_helm_test.go
+++ b/test/infrastructure/fleet_demo_helm_test.go
@@ -183,6 +183,13 @@ var _ = Describe("buildFleetDemoHelmArgs", func() {
 		))
 	})
 
+	It("UT-INFRA-FLEETDEMO-034: sets apifrontend.config.auth.audience to kubernaut-apifrontend (issue #2352, else AF 401s every console token -> 'Unable to Verify Access')", func() {
+		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, baseOpts, "/tmp/sp.rego", "/tmp/aa.rego")
+		Expect(args).To(ContainElements(
+			"--set", "apifrontend.config.auth.audience=kubernaut-apifrontend",
+		))
+	})
+
 	It("UT-INFRA-FLEETDEMO-018: uses --set-file for the Rego policy paths passed in", func() {
 		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, baseOpts, "/tmp/sp.rego", "/tmp/aa.rego")
 		Expect(args).To(ContainElements(

--- a/test/infrastructure/fleet_demo_helm_test.go
+++ b/test/infrastructure/fleet_demo_helm_test.go
@@ -79,6 +79,7 @@ var _ = Describe("buildFleetOAuth2HelmArgs", func() {
 			OAuth2Scopes:                []string{"fleet.read", "fleet.write"},
 			SignalProcessingNamespace:   "kubernaut-system",
 			FleetMetadataCacheNamespace: "kubernaut-system",
+			ImageTag:                    "latest",
 		})
 		Expect(args).To(ContainElements(
 			"--set", "global.fleet.enabled=true",
@@ -92,6 +93,7 @@ var _ = Describe("buildFleetOAuth2HelmArgs", func() {
 			"--set", "global.fleet.oauth2.scopes[1]=fleet.write",
 			"--set", "signalprocessing.fleet.namespace=kubernaut-system",
 			"--set", "fleetmetadatacache.namespace=kubernaut-system",
+			"--set", "global.image.tag=latest",
 		))
 	})
 

--- a/test/infrastructure/fleet_demo_helm_test.go
+++ b/test/infrastructure/fleet_demo_helm_test.go
@@ -31,6 +31,11 @@ import (
 // (same as the existing E2E helpers), verified manually against a live Kind
 // cluster instead.
 
+// helmSetFlag is the helm arg separator preceding every rendered value in the
+// builders under test. A const (not a literal) so goconst stays quiet as the
+// prefix-assertion loops below multiply.
+const helmSetFlag = "--set"
+
 var _ = Describe("FleetDemoHelmOptions.Validate", func() {
 	DescribeTable("reporting every missing required LLM flag in one pass",
 		func(opts FleetDemoHelmOptions, expectErr bool, expectedSubstrings []string) {
@@ -54,6 +59,38 @@ var _ = Describe("FleetDemoHelmOptions.Validate", func() {
 			FleetDemoHelmOptions{}, true,
 			[]string{"-llm-provider", "-llm-model", "-llm-endpoint"}),
 		Entry("UT-INFRA-FLEETDEMO-003: missing only the endpoint reports just that one",
+			FleetDemoHelmOptions{
+				LLMProvider: "openai_compatible",
+				LLMModel:    "gpt-4o",
+			}, true, []string{"-llm-endpoint"}),
+		Entry("UT-INFRA-FLEETDEMO-038: vertex_ai without project/location reports both flags",
+			FleetDemoHelmOptions{
+				LLMProvider: "vertex_ai",
+				LLMModel:    "claude-haiku-4-5@20251001",
+				LLMEndpoint: "https://us-central1-aiplatform.googleapis.com",
+			}, true, []string{"-vertex-project", "-vertex-location"}),
+		Entry("UT-INFRA-FLEETDEMO-039: vertex_ai with project/location passes",
+			FleetDemoHelmOptions{
+				LLMProvider:    "vertex_ai",
+				LLMModel:       "claude-haiku-4-5@20251001",
+				LLMEndpoint:    "https://us-central1-aiplatform.googleapis.com",
+				VertexProject:  "my-gcp-project",
+				VertexLocation: "us-central1",
+			}, false, nil),
+		Entry("UT-INFRA-FLEETDEMO-040: non-vertex provider without project/location passes",
+			FleetDemoHelmOptions{
+				LLMProvider: "openai_compatible",
+				LLMModel:    "gpt-4o",
+				LLMEndpoint: "https://api.openai.com/v1",
+			}, false, nil),
+		Entry("UT-INFRA-FLEETDEMO-043: vertex_ai without endpoint passes (endpoint derived from project/location, issue #2355)",
+			FleetDemoHelmOptions{
+				LLMProvider:    "vertex_ai",
+				LLMModel:       "claude-haiku-4-5@20251001",
+				VertexProject:  "my-gcp-project",
+				VertexLocation: "us-central1",
+			}, false, nil),
+		Entry("UT-INFRA-FLEETDEMO-044: openai_compatible without endpoint still fails",
 			FleetDemoHelmOptions{
 				LLMProvider: "openai_compatible",
 				LLMModel:    "gpt-4o",
@@ -102,7 +139,7 @@ var _ = Describe("buildFleetOAuth2HelmArgs", func() {
 	It("UT-INFRA-FLEETDEMO-032: omits signalprocessing.fleet.namespace when empty (cluster-wide watch)", func() {
 		args := buildFleetOAuth2HelmArgs(&FleetHelmOptions{FleetMetadataCacheNamespace: "kubernaut-system"})
 		for i, a := range args {
-			if a == "--set" && i+1 < len(args) {
+			if a == helmSetFlag && i+1 < len(args) {
 				Expect(args[i+1]).NotTo(HavePrefix("signalprocessing.fleet.namespace="))
 			}
 		}
@@ -116,7 +153,7 @@ var _ = Describe("buildFleetOAuth2HelmArgs", func() {
 	It("UT-INFRA-FLEETDEMO-035: omits global.image.tag when ImageTag is empty (a trailing empty --set would clobber the demo override, helm last-wins)", func() {
 		args := buildFleetOAuth2HelmArgs(&FleetHelmOptions{FleetMetadataCacheNamespace: "kubernaut-system"})
 		for i, a := range args {
-			if a == "--set" && i+1 < len(args) {
+			if a == helmSetFlag && i+1 < len(args) {
 				Expect(args[i+1]).NotTo(HavePrefix("global.image.tag="))
 			}
 		}
@@ -199,7 +236,7 @@ var _ = Describe("buildFleetDemoHelmArgs", func() {
 	It("UT-INFRA-FLEETDEMO-036: omits global.image.tag when ImageTag is empty (chart falls back to .Chart.AppVersion)", func() {
 		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, baseOpts, "/tmp/sp.rego", "/tmp/aa.rego")
 		for i, a := range args {
-			if a == "--set" && i+1 < len(args) {
+			if a == helmSetFlag && i+1 < len(args) {
 				Expect(args[i+1]).NotTo(HavePrefix("global.image.tag="))
 			}
 		}
@@ -216,6 +253,40 @@ var _ = Describe("buildFleetDemoHelmArgs", func() {
 			}
 		}
 		Expect(tags).To(Equal([]string{"global.image.tag=demo-v1.0"}))
+	})
+
+	It("UT-INFRA-FLEETDEMO-041: omits vertexProject/vertexLocation --set when empty (non-Vertex providers)", func() {
+		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, baseOpts, "/tmp/sp.rego", "/tmp/aa.rego")
+		for i, a := range args {
+			if a == helmSetFlag && i+1 < len(args) {
+				Expect(args[i+1]).NotTo(HavePrefix("global.llmProfiles.primary.vertexProject="))
+				Expect(args[i+1]).NotTo(HavePrefix("global.llmProfiles.primary.vertexLocation="))
+			}
+		}
+	})
+
+	It("UT-INFRA-FLEETDEMO-042: sets vertexProject/vertexLocation --set when provided (BR-PLATFORM-014 Vertex AI demo)", func() {
+		opts := baseOpts
+		opts.VertexProject = "my-gcp-project"
+		opts.VertexLocation = "us-central1"
+		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, opts, "/tmp/sp.rego", "/tmp/aa.rego")
+		Expect(args).To(ContainElements(
+			"--set", "global.llmProfiles.primary.vertexProject=my-gcp-project",
+			"--set", "global.llmProfiles.primary.vertexLocation=us-central1",
+		))
+	})
+
+	It("UT-INFRA-FLEETDEMO-045: omits the endpoint --set when empty (vertex_ai derives it; issue #2355)", func() {
+		opts := baseOpts
+		opts.LLMEndpoint = ""
+		opts.VertexProject = "my-gcp-project"
+		opts.VertexLocation = "us-central1"
+		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, opts, "/tmp/sp.rego", "/tmp/aa.rego")
+		for i, a := range args {
+			if a == helmSetFlag && i+1 < len(args) {
+				Expect(args[i+1]).NotTo(HavePrefix("global.llmProfiles.primary.endpoint="))
+			}
+		}
 	})
 
 	It("UT-INFRA-FLEETDEMO-034: sets apifrontend.config.auth.audience to kubernaut-apifrontend (issue #2352, else AF 401s every console token -> 'Unable to Verify Access')", func() {

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -749,6 +749,7 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, r
 	_, _ = fmt.Fprintf(writer, "    global.fleet.oauth2.tokenURL=%s\n", fleetOpts.OAuth2TokenURL)
 	_, _ = fmt.Fprintf(writer, "    global.fleet.oauth2.credentialsSecretRef=%s\n", fleetOpts.OAuth2CredentialsSecret)
 	_, _ = fmt.Fprintf(writer, "    global.fleet.oauth2.scopes=%v\n", fleetOpts.OAuth2Scopes)
+	_, _ = fmt.Fprintf(writer, "    global.image.tag=%v\n", fleetOpts.ImageTag)
 	_, _ = fmt.Fprintf(writer, "    workflowexecution.fleet.oauth2.credentialsSecretRef=%s\n", fleetOpts.WEOAuth2CredentialsSecret)
 	_, _ = fmt.Fprintf(writer, "    signalprocessing.fleet.namespace=%s\n", fleetOpts.SignalProcessingNamespace)
 	_, _ = fmt.Fprintf(writer, "    fleetmetadatacache.namespace=%s\n", fleetOpts.FleetMetadataCacheNamespace)

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -774,6 +774,7 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, r
 	_, _ = fmt.Fprintln(writer, "  For AF/Console browser login (reuses the same Keycloak, no DEX):")
 	_, _ = fmt.Fprintln(writer, "    apifrontend.config.auth.issuerURL=https://keycloak:8443/realms/kubernaut-fleet")
 	_, _ = fmt.Fprintf(writer, "    apifrontend.config.auth.jwksURL=https://keycloak.%s.svc.cluster.local:8443/realms/kubernaut-fleet/protocol/openid-connect/certs\n", idpNamespace)
+	_, _ = fmt.Fprintln(writer, "    apifrontend.config.auth.audience=kubernaut-apifrontend (required; else AF 401s every token, issue #2352)")
 	_, _ = fmt.Fprintln(writer, "    console.enabled=true, console.ingress.className=traefik,")
 	_, _ = fmt.Fprintln(writer, "    console.ingress.host=kubernaut-console.local, console.ingress.port=8843")
 	_, _ = fmt.Fprintln(writer, "    Add to /etc/hosts:  127.0.0.1 keycloak kubernaut-console.local")

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -749,7 +749,9 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, r
 	_, _ = fmt.Fprintf(writer, "    global.fleet.oauth2.tokenURL=%s\n", fleetOpts.OAuth2TokenURL)
 	_, _ = fmt.Fprintf(writer, "    global.fleet.oauth2.credentialsSecretRef=%s\n", fleetOpts.OAuth2CredentialsSecret)
 	_, _ = fmt.Fprintf(writer, "    global.fleet.oauth2.scopes=%v\n", fleetOpts.OAuth2Scopes)
-	_, _ = fmt.Fprintf(writer, "    global.image.tag=%v\n", fleetOpts.ImageTag)
+	if fleetOpts.ImageTag != "" {
+		_, _ = fmt.Fprintf(writer, "    global.image.tag=%v\n", fleetOpts.ImageTag)
+	}
 	_, _ = fmt.Fprintf(writer, "    workflowexecution.fleet.oauth2.credentialsSecretRef=%s\n", fleetOpts.WEOAuth2CredentialsSecret)
 	_, _ = fmt.Fprintf(writer, "    signalprocessing.fleet.namespace=%s\n", fleetOpts.SignalProcessingNamespace)
 	_, _ = fmt.Fprintf(writer, "    fleetmetadatacache.namespace=%s\n", fleetOpts.FleetMetadataCacheNamespace)

--- a/test/infrastructure/fullpipeline_e2e_helm.go
+++ b/test/infrastructure/fullpipeline_e2e_helm.go
@@ -367,7 +367,12 @@ func buildFleetOAuth2HelmArgs(fleetOpts *FleetHelmOptions) []string {
 	// is set unconditionally here, unlike SignalProcessingNamespace above
 	// (which may legitimately watch cluster-wide).
 	args = append(args, "--set", "fleetmetadatacache.namespace="+fleetOpts.FleetMetadataCacheNamespace)
-	args = append(args, "--set", "global.image.tag="+fleetOpts.ImageTag)
+	if fleetOpts.ImageTag != "" {
+		// Optional tag override only: an unconditional empty --set here would
+		// clobber an earlier global.image.tag (helm --set is last-wins),
+		// silently forcing the chart's .Chart.AppVersion fallback.
+		args = append(args, "--set", "global.image.tag="+fleetOpts.ImageTag)
+	}
 	return args
 }
 

--- a/test/infrastructure/fullpipeline_e2e_helm.go
+++ b/test/infrastructure/fullpipeline_e2e_helm.go
@@ -323,6 +323,8 @@ type FleetHelmOptions struct {
 	// without it, so callers MUST set this whenever FleetHelmOptions is
 	// non-nil (FMC is chart-managed and effectively enabled in that case).
 	FleetMetadataCacheNamespace string
+
+	ImageTag string
 }
 
 // buildFleetOAuth2HelmArgs renders the global.fleet.*/workflowexecution.fleet.*/
@@ -365,6 +367,7 @@ func buildFleetOAuth2HelmArgs(fleetOpts *FleetHelmOptions) []string {
 	// is set unconditionally here, unlike SignalProcessingNamespace above
 	// (which may legitimately watch cluster-wide).
 	args = append(args, "--set", "fleetmetadatacache.namespace="+fleetOpts.FleetMetadataCacheNamespace)
+	args = append(args, "--set", "global.image.tag="+fleetOpts.ImageTag)
 	return args
 }
 

--- a/test/infrastructure/keycloak_e2e.go
+++ b/test/infrastructure/keycloak_e2e.go
@@ -483,6 +483,7 @@ func waitForKeycloakReady(ctx context.Context, kubeconfigPath string, hostPort i
 			_, _ = fmt.Fprintln(writer, "  ✅ Keycloak kubernaut-fleet realm reachable (HTTPS)")
 			return nil
 		}
+		fmt.Fprintln(writer, "resp.StatusCode:", resp.StatusCode, "waiting for Keycloak kubernaut-fleet realm to be reachable...")
 		if resp != nil {
 			_ = resp.Body.Close()
 		}

--- a/test/infrastructure/keycloak_e2e.go
+++ b/test/infrastructure/keycloak_e2e.go
@@ -483,8 +483,13 @@ func waitForKeycloakReady(ctx context.Context, kubeconfigPath string, hostPort i
 			_, _ = fmt.Fprintln(writer, "  ✅ Keycloak kubernaut-fleet realm reachable (HTTPS)")
 			return nil
 		}
-		fmt.Fprintln(writer, "resp.StatusCode:", resp.StatusCode, "waiting for Keycloak kubernaut-fleet realm to be reachable...")
-		if resp != nil {
+		// NB: resp is nil exactly when err != nil (transport failure, the
+		// common case while Keycloak is still starting) -- dereferencing it
+		// unconditionally panics here. Branch on err first (SA5011/errcheck).
+		if err != nil {
+			_, _ = fmt.Fprintln(writer, "  Keycloak not yet reachable, waiting:", err)
+		} else {
+			_, _ = fmt.Fprintln(writer, "resp.StatusCode:", resp.StatusCode, "waiting for Keycloak kubernaut-fleet realm to be reachable...")
 			_ = resp.Body.Close()
 		}
 		time.Sleep(3 * time.Second)

--- a/test/infrastructure/pod_diagnostics.go
+++ b/test/infrastructure/pod_diagnostics.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SummarizePodsForDiagnostics renders a compact, human-readable summary of
+// every pod in list for failure triage. E2E specs that delete their test
+// namespace in AfterEach call this (via GinkgoWriter) when a wait times out:
+// the dump is the only pod-level evidence left in the CI log, since
+// must-gather only covers fixed namespaces and the test namespace is gone
+// before collection runs.
+//
+// Pure function (no API calls) so it is unit-testable without a cluster;
+// callers own listing the pods. An empty list renders explicitly as
+// "no pods found" to distinguish "never created/scheduled" from "ran but
+// never reached the awaited state".
+func SummarizePodsForDiagnostics(namespace string, pods *corev1.PodList) string {
+	var b strings.Builder
+	if pods == nil || len(pods.Items) == 0 {
+		fmt.Fprintf(&b, "diagnostics namespace=%s: no pods found\n", namespace)
+		return b.String()
+	}
+	fmt.Fprintf(&b, "diagnostics namespace=%s pods=%d\n", namespace, len(pods.Items))
+	for _, pod := range pods.Items {
+		fmt.Fprintf(&b, "- pod=%s phase=%s node=%s\n",
+			pod.Name, pod.Status.Phase, pod.Spec.NodeName)
+		for _, cs := range pod.Status.InitContainerStatuses {
+			fmt.Fprintf(&b, "    init=%s %s\n", cs.Name, summarizeContainerState(cs))
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			fmt.Fprintf(&b, "    container=%s restarts=%d %s\n",
+				cs.Name, cs.RestartCount, summarizeContainerState(cs))
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Status != corev1.ConditionTrue {
+				fmt.Fprintf(&b, "    condition=%s status=%s reason=%s message=%s\n",
+					cond.Type, cond.Status, cond.Reason, cond.Message)
+			}
+		}
+	}
+	return b.String()
+}
+
+func summarizeContainerState(cs corev1.ContainerStatus) string {
+	switch {
+	case cs.State.Waiting != nil:
+		return "waiting=" + cs.State.Waiting.Reason
+	case cs.State.Terminated != nil:
+		return fmt.Sprintf("terminated=%s exit=%d",
+			cs.State.Terminated.Reason, cs.State.Terminated.ExitCode)
+	default:
+		// Running or a zero value (e.g. a status entry with no state set
+		// yet) -- either way the container is not waiting or terminated.
+		return "running"
+	}
+}

--- a/test/infrastructure/pod_diagnostics_test.go
+++ b/test/infrastructure/pod_diagnostics_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Failure-diagnostics formatter for E2E specs that delete their test
+// namespace in AfterEach: whatever is dumped here is the only pod-level
+// evidence left in the CI log (must-gather only covers fixed namespaces).
+var _ = Describe("SummarizePodsForDiagnostics", func() {
+	It("UT-INFRA-DIAG-001: reports no-pods-found for an empty list (distinguishes never-created)", func() {
+		out := SummarizePodsForDiagnostics("fp-e2e-crashloop-1", &corev1.PodList{})
+		Expect(out).To(ContainSubstring("fp-e2e-crashloop-1"))
+		Expect(out).To(ContainSubstring("no pods found"))
+	})
+
+	It("UT-INFRA-DIAG-002: surfaces CrashLoopBackOff waiting reason and restart count", func() {
+		pods := &corev1.PodList{Items: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "crashloop-app-abc", Namespace: "fp-e2e-x"},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:         "crashloop-app",
+					RestartCount: 7,
+					State:        corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+				}},
+			},
+		}}}
+		out := SummarizePodsForDiagnostics("fp-e2e-x", pods)
+		Expect(out).To(ContainSubstring("crashloop-app-abc"))
+		Expect(out).To(ContainSubstring("CrashLoopBackOff"))
+		Expect(out).To(ContainSubstring("restarts=7"))
+	})
+
+	It("UT-INFRA-DIAG-003: surfaces pending pods with their unschedulable condition message", func() {
+		pods := &corev1.PodList{Items: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "crashloop-app-def", Namespace: "fp-e2e-x"},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{{
+					Type:    corev1.PodScheduled,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Unschedulable",
+					Message: "0/1 nodes are available: 1 node(s) had untolerated taint(s)",
+				}},
+			},
+		}}}
+		out := SummarizePodsForDiagnostics("fp-e2e-x", pods)
+		Expect(out).To(ContainSubstring("Pending"))
+		Expect(out).To(ContainSubstring("Unschedulable"))
+		Expect(out).To(ContainSubstring("untolerated taint"))
+	})
+
+	It("UT-INFRA-DIAG-004: surfaces image-pull waiting reason and terminated exit codes", func() {
+		pods := &corev1.PodList{Items: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "crashloop-app-ghi", Namespace: "fp-e2e-x"},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:  "crashloop-app",
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+				}},
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name:  "init",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled", ExitCode: 137}},
+				}},
+			},
+		}}}
+		out := SummarizePodsForDiagnostics("fp-e2e-x", pods)
+		Expect(out).To(ContainSubstring("ImagePullBackOff"))
+		Expect(out).To(ContainSubstring("OOMKilled"))
+		Expect(out).To(ContainSubstring("exit=137"))
+	})
+})


### PR DESCRIPTION
Closes #2352
Closes #2354
Closes #2355

## Problem

The Kubernaut Console at `https://kubernaut-console.local:8843` showed **"Unable to Verify Access / Could not confirm Kubernaut access right now. Please try again shortly."** because `GET /a2a/access` returned **HTTP 401** for every Console token. `checkConsoleAccess()` treats any non-200/403 as an `access-error`.

**Root cause:** the fleet demo cluster provisioning (`buildFleetDemoHelmArgs`) wired `apifrontend.config.auth.issuerURL` and `jwksURL` but **omitted `audience`**. `buildAuthConfig` (`cmd/apifrontend/auth_wiring.go`) builds the OIDC provider with `Audiences: []string{cfg.Auth.Audience}`, which is `[]string{""}` when unset. `JWTValidator.validateAudience` then compares `[""]` against the token's `["kubernaut-apifrontend"]` → `ErrInvalidAudience` → 401. So every valid Keycloak-signed token was rejected.

The Keycloak realm (`test/infrastructure/keycloak-realm-fleet.json`) already injects `aud=kubernaut-apifrontend` via the `kubernaut-apifrontend-audience` default client scope's `oidc-audience-mapper` — AF just wasn't configured to expect it. The `fullpipeline_e2e_helm.go` path already set it (`--set apifrontend.config.auth.audience=kubernaut-apifrontend`); the fleet-demo path did not.

## Fix

- `test/infrastructure/fleet_demo_helm.go`: set `apifrontend.config.auth.audience=kubernaut-apifrontend`
- `test/infrastructure/fleet_demo_helm_test.go`: add `UT-INFRA-FLEETDEMO-034` asserting the audience `--set`
- `test/infrastructure/fleet_e2e.go`: document the required audience in the printed manual login instructions

## Verification

- Confirmed live against the running cluster: `/a2a/access` returned 401 with a real Keycloak `sre-user` token before, and **HTTP 200** after adding `audience: "kubernaut-apifrontend"` to the `apifrontend-config` ConfigMap and restarting AF.
- New test passes; full `test/infrastructure` suite (91 specs) passes; `go vet` and `gofmt` clean.

## Also included (pre-existing in-progress work, per request)

- `feat(fleet-demo): allow overriding the demo chart image tag` — `-image-tag` flag + `global.image.tag` wiring, chart bump to `1.6.0-rc9`, fleetmetadatacache image helper, and small logging/debug improvements.

## Test Plan

```bash
go test ./test/infrastructure/ -run TestInfrastructure -ginkgo.focus="FLEETDEMO-034"
go test ./test/infrastructure/ -run TestInfrastructure
```