### PR TITLE
fix(fleet-demo): wire AF alert tools to the fleet monitoring stack

### DIFF
--- a/test/infrastructure/fleet_demo_helm.go
+++ b/test/infrastructure/fleet_demo_helm.go
@@ -242,6 +242,18 @@ func buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace string, fleetOp
 		// uses it for browser-JWT JWKS validation (same host:port, unlike
 		// the FP suite's separate DEX-on-5556 case).
 		"--set", "networkPolicies.idp.port=8443",
+		// AF alert tools (list_alerts/get_alert_details/kubernaut_investigate_alert)
+		// only register when the chart renders severityTriage.enabled=true with
+		// a prometheusURL, which requires monitoring.prometheus.enabled=true.
+		// Without these, AF runs triage-disabled and Console reports alert
+		// querying as unconfigured -- even though the fleet monitoring stack
+		// below is already running. Matches the manual values printed by
+		// SetupFleetCoreInfrastructureWithGateway. Thanos Querier (not plain
+		// Prometheus) so alerts are fleet-wide (hub+spoke, ADR-068).
+		"--set", "monitoring.prometheus.enabled=true",
+		"--set", "monitoring.prometheus.url=http://thanos-querier-svc." + monitoringNamespace + ".svc.cluster.local:9090",
+		"--set", "monitoring.alertManager.enabled=true",
+		"--set", "monitoring.alertManager.url=http://alertmanager-svc." + monitoringNamespace + ".svc.cluster.local:9093",
 		"--set-file", "signalprocessing.policies.content=" + spPolicyFile,
 		"--set-file", "aianalysis.policies.content=" + aaPolicyFile,
 	}

--- a/test/infrastructure/fleet_demo_helm_test.go
+++ b/test/infrastructure/fleet_demo_helm_test.go
@@ -226,6 +226,16 @@ var _ = Describe("buildFleetDemoHelmArgs", func() {
 		}
 	})
 
+	It("UT-INFRA-FLEETDEMO-046: wires AF alert tools to the fleet monitoring stack (Thanos Querier + Alertmanager)", func() {
+		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, baseOpts, "/tmp/sp.rego", "/tmp/aa.rego")
+		Expect(args).To(ContainElements(
+			"--set", "monitoring.prometheus.enabled=true",
+			"--set", "monitoring.prometheus.url=http://thanos-querier-svc.monitoring.svc.cluster.local:9090",
+			"--set", "monitoring.alertManager.enabled=true",
+			"--set", "monitoring.alertManager.url=http://alertmanager-svc.monitoring.svc.cluster.local:9093",
+		))
+	})
+
 	It("UT-INFRA-FLEETDEMO-017: points APIFrontend/Console OIDC at Keycloak, not DEX", func() {
 		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, baseOpts, "/tmp/sp.rego", "/tmp/aa.rego")
 		Expect(args).To(ContainElements(


### PR DESCRIPTION
Closes #2358

## Problem

Fleet demo Console claimed alert querying was unconfigured
("Prometheus/Thanos integration is disabled") despite the monitoring stack
running. Root cause: the demo provisioning never set `monitoring.prometheus.*`,
so the chart rendered `severityTriage.enabled=false`, AF built no `PromClient`,
and the alert tools stayed unregistered. Full RCA in the issue.

## Fix

- `test/infrastructure/fleet_demo_helm.go`: set `monitoring.prometheus.enabled/url`
  (Thanos Querier, fleet-wide) and `monitoring.alertManager.enabled/url`
- `test/infrastructure/fleet_demo_helm_test.go`: `UT-INFRA-FLEETDEMO-046` pins
  all four `--set` values

## Verification

- New spec passes; full `test/infrastructure` suite, `go vet`, `gofmt` clean
- Live cluster: `helm upgrade --reuse-values` + AF restart →
  `severityTriage.enabled:true` with querier URL, "severity triage enabled"
  in logs, zero errors; AF's 9090 NetworkPolicy egress rule rendered
  (required — kindnet enforces policy via nftables on current kind)