### PR TITLE
fix(fleet-demo): monitoring wiring, run.sh hint per mode, make flag continuation; fix attribution (gateway+AF)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1356,6 +1356,89 @@ jobs:
         run: podman ps -a --filter "name=${{ matrix.service }}-" --format "{{.Names}}" | xargs -r podman rm -f
 
   # ========================================
+  # RCA DOSSIER (NON-BLOCKING)
+  # Runs after the E2E matrix only when a test failed. Engram downloads the
+  # failed job log and must-gather artifact transiently, builds a deterministic
+  # RR-scoped dossier, and uploads only the compact result. This job
+  # is intentionally not part of merge-gate: an RCA outage must never hide the
+  # original test failure or change branch protection semantics.
+  # ========================================
+
+  rca-dossier:
+    name: Generate RCA Dossier
+    needs: [detect-changes, e2e-tests]
+    if: always() && needs.detect-changes.outputs.code_changed == 'true' && needs.e2e-tests.result == 'failure'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout Engram RCA tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: jordigilh/engram
+          path: engram
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
+        with:
+          python-version: '3.13'
+
+      - name: Install RCA dependencies
+        run: python -m pip install --disable-pip-version-check PyYAML==6.0.3
+
+      - name: Inventory this failed workflow run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PYTHONPATH=engram/src python -m engram.pipeline.kubernaut_corpus_inventory \
+            --repo "${{ github.repository }}" \
+            --run-id "${{ github.run_id }}" \
+            --output corpus-inventory.json
+
+      - name: Generate compact RCA dossier
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PYTHONPATH=engram/src python -m engram.pipeline.kubernaut_rca_backfill \
+            --inventory corpus-inventory.json \
+            --output rca-output \
+            --limit 1 \
+            --dossiers-only
+
+      - name: Publish RCA summary
+        if: always()
+        run: |
+          if [ -f rca-output/baseline-metrics.json ]; then
+            python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+          metrics = json.loads(Path("rca-output/baseline-metrics.json").read_text())["metrics"]
+          print("## Engram RCA candidate")
+          print(f"- Dossiers generated: {metrics['dossiers_generated']}")
+          print(f"- Candidates promoted: {metrics['candidates_promoted']}")
+          print(f"- Promotion skipped by quality gate: {metrics['promotion_skipped_quality']}")
+          print(f"- Environment/setup failures: {metrics['environment_setup_failures']}")
+          print(f"- Unresolved failures: {metrics['unresolved_failures']}")
+          PY
+          fi
+
+      - name: Upload compact RCA output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: rca-dossiers-${{ github.run_id }}
+          path: |
+            corpus-inventory.json
+            rca-output/baseline-metrics.json
+            rca-output/failure-anchors.jsonl
+            rca-output/**/*.json
+          retention-days: 14
+          if-no-files-found: warn
+
+  # ========================================
   # HELM SMOKE TESTS
   # Validates the Helm chart install/upgrade/uninstall lifecycle on a Kind cluster.
   # Runs after images are built (parallel with integration + E2E tests).

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1370,30 +1370,16 @@ jobs:
     if: always() && needs.detect-changes.outputs.code_changed == 'true' && needs.e2e-tests.result == 'failure'
     continue-on-error: true
     runs-on: ubuntu-latest
+    container: quay.io/jordigilh/engram:latest
     permissions:
       actions: read
       contents: read
     steps:
-      - name: Checkout Engram RCA tooling
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: jordigilh/engram
-          path: engram
-          ref: main
-
-      - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
-        with:
-          python-version: '3.13'
-
-      - name: Install RCA dependencies
-        run: python -m pip install --disable-pip-version-check PyYAML==6.0.3
-
       - name: Inventory this failed workflow run
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          PYTHONPATH=engram/src python -m engram.pipeline.kubernaut_corpus_inventory \
+          python -m engram.pipeline.kubernaut_corpus_inventory \
             --repo "${{ github.repository }}" \
             --run-id "${{ github.run_id }}" \
             --output corpus-inventory.json
@@ -1402,7 +1388,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          PYTHONPATH=engram/src python -m engram.pipeline.kubernaut_rca_backfill \
+          python -m engram.pipeline.kubernaut_rca_backfill \
             --inventory corpus-inventory.json \
             --output rca-output \
             --limit 1 \

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1379,7 +1379,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          python -m engram.pipeline.kubernaut_corpus_inventory \
+          python3 -m engram.pipeline.kubernaut_corpus_inventory \
             --repo "${{ github.repository }}" \
             --run-id "${{ github.run_id }}" \
             --output corpus-inventory.json
@@ -1388,7 +1388,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          python -m engram.pipeline.kubernaut_rca_backfill \
+          python3 -m engram.pipeline.kubernaut_rca_backfill \
             --inventory corpus-inventory.json \
             --output rca-output \
             --limit 1 \
@@ -1398,7 +1398,7 @@ jobs:
         if: always()
         run: |
           if [ -f rca-output/baseline-metrics.json ]; then
-            python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+            python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
           import json
           from pathlib import Path
           metrics = json.loads(Path("rca-output/baseline-metrics.json").read_text())["metrics"]

--- a/Makefile
+++ b/Makefile
@@ -986,16 +986,16 @@ setup-fleet-demo-infra: ## Create fleet Kind clusters + install Kubernaut, Conso
 		-llm-model "$(LLM_MODEL)" \
 		-llm-endpoint "$(LLM_ENDPOINT)" \
 		-llm-credentials-file "$(LLM_CREDENTIALS_FILE)" \
-		$(if $(IMAGE_TAG),-image-tag "$(IMAGE_TAG)" \ )
-		$(if $(VERTEX_PROJECT),-vertex-project "$(VERTEX_PROJECT)" \ )
-		$(if $(VERTEX_LOCATION),-vertex-location "$(VERTEX_LOCATION)" \ )
-		$(if $(AUTONOMOUS),-autonomous=$(AUTONOMOUS) \ )
-		$(if $(GATEWAY_TYPE),-gateway-type "$(GATEWAY_TYPE)" \ )
-		$(if $(SPOKE_WORKERS),-spoke-workers "$(SPOKE_WORKERS)" \ )
-		$(if $(SP_POLICY_FILE),-sp-policy-file "$(SP_POLICY_FILE)" \ )
-		$(if $(AA_POLICY_FILE),-aa-policy-file "$(AA_POLICY_FILE)" \ )
-		$(if $(CLUSTER_NAME),-cluster-name "$(CLUSTER_NAME)" \ )
-		$(if $(REMOTE_CLUSTER_NAME),-remote-cluster-name "$(REMOTE_CLUSTER_NAME)" \ )
+		$(if $(IMAGE_TAG),-image-tag "$(IMAGE_TAG)") \
+		$(if $(VERTEX_PROJECT),-vertex-project "$(VERTEX_PROJECT)") \
+		$(if $(VERTEX_LOCATION),-vertex-location "$(VERTEX_LOCATION)") \
+		$(if $(AUTONOMOUS),-autonomous=$(AUTONOMOUS)) \
+		$(if $(GATEWAY_TYPE),-gateway-type "$(GATEWAY_TYPE)") \
+		$(if $(SPOKE_WORKERS),-spoke-workers "$(SPOKE_WORKERS)") \
+		$(if $(SP_POLICY_FILE),-sp-policy-file "$(SP_POLICY_FILE)") \
+		$(if $(AA_POLICY_FILE),-aa-policy-file "$(AA_POLICY_FILE)") \
+		$(if $(CLUSTER_NAME),-cluster-name "$(CLUSTER_NAME)") \
+		$(if $(REMOTE_CLUSTER_NAME),-remote-cluster-name "$(REMOTE_CLUSTER_NAME)")
 
 .PHONY: bind-fleet-af-rbac
 bind-fleet-af-rbac: ## Bind AF's kubernaut-tool-<persona>/console-access ClusterRoles to Keycloak's "sre" group (run AFTER helm install)

--- a/cmd/apifrontend/mcp_a2a_handlers.go
+++ b/cmd/apifrontend/mcp_a2a_handlers.go
@@ -13,6 +13,7 @@ import (
 
 	agentpkg "github.com/jordigilh/kubernaut/pkg/apifrontend/agent"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/handler"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ratelimit"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
@@ -186,5 +187,12 @@ func buildA2AConfig(d *handlerDeps, rootAgent agent.Agent, sessionSvcForAgent *s
 			d.ActiveCtxRegistry, d.Logger.WithName("session-interceptor"),
 		),
 		LLMSemaphore: ratelimit.NewLLMSemaphore(d.Cfg.RateLimit.MaxConcurrentSessions),
+		PresentationRecoveryTerminalizer: func(ctx context.Context, rrID string) error {
+			_, err := d.Backends.MCPClient.CompleteNoAction(ctx, ka.CompleteNoActionArgs{
+				RRID:             rrID,
+				EscalationReason: "presentation_recovery_exhausted",
+			})
+			return err
+		},
 	}
 }

--- a/cmd/apifrontend/mcp_a2a_handlers.go
+++ b/cmd/apifrontend/mcp_a2a_handlers.go
@@ -50,6 +50,7 @@ func buildMCPHandler(d *handlerDeps) (http.Handler, func() bool, error) {
 		ActiveContextRegistry: d.ActiveCtxRegistry,
 		RESTMapper:            d.Backends.Mapper,
 		ScopeChecker:          d.Backends.ScopeChecker,
+		ClusterLister:         d.Backends.FleetClusterRegistry,
 	}
 
 	h, err := handler.NewMCPHandler(handler.MCPConfig{

--- a/cmd/kubernautagent/datastorage.go
+++ b/cmd/kubernautagent/datastorage.go
@@ -156,8 +156,10 @@ func buildEnricher(cfg *kaconfig.Config, ds *dsClients, infra *k8sInfra, auditSt
 		return nil
 	}
 	e := enrichment.NewEnricher(ds.k8sAdapter, ds.dsAdapter, auditStore, logger)
+	var labelDetector *enrichment.LabelDetector
 	if infra != nil && infra.dynClient != nil {
-		e.WithLabelDetector(enrichment.NewLabelDetector(infra.dynClient, infra.mapper, logger.WithName("label-detector")))
+		labelDetector = enrichment.NewLabelDetector(infra.dynClient, infra.mapper, logger.WithName("label-detector"))
+		e.WithLabelDetector(labelDetector)
 		logger.Info("label detector enabled (ADR-056)")
 	}
 	// Issue #2343: without this, Investigate()'s automatic pre-fetch
@@ -172,6 +174,11 @@ func buildEnricher(cfg *kaconfig.Config, ds *dsClients, infra *k8sInfra, auditSt
 	e.WithK8sResolver(func(ctx context.Context) enrichment.K8sClient {
 		return custom.ResolveK8sClient(ctx, ds.k8sAdapter, k8sResolverLogger)
 	})
+	if infra != nil && infra.mapper != nil {
+		e.WithLabelDetectorResolver(func(ctx context.Context) *enrichment.LabelDetector {
+			return custom.ResolveLabelDetector(ctx, labelDetector, infra.mapper, logger.WithName("label-detector-resolver"))
+		})
+	}
 	e.WithRetryConfig(enrichment.RetryConfig{
 		MaxRetries:  cfg.AI.Enrichment.MaxRetries,
 		BaseBackoff: cfg.AI.Enrichment.BaseBackoff,

--- a/docs/architecture/decisions/DD-AF-014-business-outcome-completion-coordinator.md
+++ b/docs/architecture/decisions/DD-AF-014-business-outcome-completion-coordinator.md
@@ -1,0 +1,208 @@
+# DD-AF-014: Business-Outcome Completion Coordinator
+
+**Status**: Accepted
+**Date**: 2026-09-05
+**Issue**: [#2365](https://github.com/jordigilh/kubernaut/issues/2365)
+**Related**: [DD-AF-011](DD-AF-011-phase-transition-consent-guard.md), [DD-AF-007](DD-AF-007-escalation-routing.md), BR-INTERACTIVE-010, BR-SESS-013, BR-AUDIT-005
+
+## Context
+
+API Frontend currently uses ADK turn completion as an implicit proxy for business-lifecycle completion. This is unsafe because an LLM can return free-form narration after a successful workflow discovery without calling `kubernaut_present_decision`.
+
+Issue #2365 exposed the resulting failure:
+
+1. Kubernaut Agent completes workflow selection and AF completes `kubernaut_discover_workflows`.
+2. The AF model narrates that it will submit the result but does not call `kubernaut_present_decision`.
+3. The A2A stream closes normally without an `investigation_summary` artifact.
+4. The Console cannot render workflow options and the RemediationRequest remains in `Analyzing`.
+
+The attempted recovery in PR #2361 coupled this obligation to the generic reinvocation loop. That loop cannot safely distinguish a missing presentation artifact from a legitimate consent boundary or an autonomous workflow chain. In particular, `full_remediation` must present options and wait before execution, while `full_remediation_autonomous` must continue through selection and execution in the same turn.
+
+This is a lifecycle-completion problem, not a prompt problem and not a generic retry problem.
+
+## Decision
+
+Introduce a typed **business-outcome completion coordinator** at the AF A2A pre-finalization boundary. The coordinator verifies that every turn has reached a valid business outcome before the A2A executor publishes the final status.
+
+This is a declarative lifecycle state machine with a mostly forward, DAG-shaped path. It is not a pure DAG because reconnect, cancellation, failure, timeout, and disconnection are valid side transitions.
+
+### Responsibilities
+
+The coordinator owns:
+
+- Investigation completion.
+- Workflow discovery completion.
+- Required decision-artifact completion.
+- Mode-specific continuation policy.
+- Structured incomplete-data outcomes.
+- Idempotent recovery and escalation.
+
+The existing phase guard remains responsible for authorization and ordering. The generic reinvocation loop remains responsible only for legitimate stalled investigation continuation. Neither component decides whether a business artifact obligation has been satisfied.
+
+### Lifecycle State
+
+AF session state must distinguish these independent dimensions:
+
+- `interaction_mode`.
+- `investigation_status`.
+- `discovery_status`.
+- `discovery_result`.
+- `decision_artifact_status`.
+- `execution_authorization`.
+- `terminal_outcome`.
+
+The critical invariant is that presentation and authorization are independent:
+
+```text
+decision_artifact_status = required
+execution_authorization = blocked_until_user_confirmation
+```
+
+This represents `full_remediation` correctly: workflow options are shown, but `select_workflow` remains blocked until a genuine user turn.
+
+### Mode Policy
+
+`interactive`:
+
+- User confirmation is required before discovery and execution.
+- If discovery occurs after confirmation, a decision artifact is required before the turn can complete.
+
+`full_remediation`:
+
+- Investigation and discovery may proceed automatically.
+- A decision artifact is required after successful discovery.
+- Execution remains blocked until a genuine user selection.
+
+`full_remediation_autonomous`:
+
+- Investigation, discovery, selection, and execution may chain in one turn.
+- Presentation recovery must not intercept or alter the chain.
+
+### Discovery Normalization
+
+All recovery logic must consume one canonical discovery representation. It must reuse `ka.ParseDiscoverWorkflowsResponse`, which supports:
+
+- Direct AF responses containing `workflows`.
+- KA envelope responses containing `status` and an encoded `response` payload.
+
+The parser must recognize a direct response even when `workflows` is empty so that target metadata is not lost. Malformed or incomplete entries are normalization failures and must not become executable options.
+
+The coordinator maps canonical discovery data to `WorkflowOption` values without inventing RCA facts or workflow identity. Existing parser behavior that preserves an absent workflow name must remain intact.
+
+### Decision Artifact Recovery
+
+At the pre-finalization boundary:
+
+1. Read authoritative RCA state from `StateKeyGroundedRCA`.
+2. Read the successful discovery `FunctionResponse` from the ADK session event history.
+3. Determine whether a `present_decision` artifact was emitted by scanning the model `FunctionCall` history.
+4. If the artifact exists, finish normally.
+5. If presentation is required and the artifact is missing, emit a deterministic `investigation_summary` artifact through `EventBridge.EmitArtifact`.
+6. Mark the artifact with recovery provenance:
+
+```text
+source: af_completion_recovery
+recovery_reason: missing_present_decision
+requires_user_selection: true|false
+```
+
+7. Preserve consent state and `driverActive`; never invoke `select_workflow` as recovery.
+
+The recovered artifact is presentation-only. It is not an LLM authorization, workflow selection, or execution approval.
+
+### Incomplete Authoritative Data
+
+If RCA or discovery data is incomplete, AF must emit a truthful structured failure artifact when possible. It may use the existing schema-required shape:
+
+```json
+{
+  "session_id": "...",
+  "summary": "Structured workflow decision could not be completed.",
+  "rca": {
+    "explanation": "Authoritative investigation details were unavailable.",
+    "tool_calls_count": 0,
+    "llm_turns": 0
+  },
+  "options": [],
+  "status": "failure",
+  "failure_reason": "missing_authoritative_data"
+}
+```
+
+The coordinator must not fabricate severity, confidence, causal chains, targets, workflow names, or execution decisions.
+
+If a required outcome still cannot be produced after bounded recovery, AF must use the existing KA `complete_no_action` escalation path with a fixed system-generated escalation reason. This produces `HumanReviewReason=operator_escalation`, a `ManualReviewRequired` outcome, and notification routing. It must not use ordinary dismissal and must be idempotent.
+
+### Idempotency
+
+Recovery must be keyed by the session, RemediationRequest, and discovery event identity. Repeated finalization, reconnect, or transport retries must not emit duplicate decision artifacts or duplicate escalation outcomes.
+
+## Alternatives Considered
+
+### Generic reinvocation
+
+Rejected. It reruns model behavior, may repeat discovery, can lose authoritative context, and conflicts with consent checkpoints. PR #2361 demonstrated that coupling this recovery to the reinvocation loop can terminate the phase-3 consent journey before the genuine user selection turn.
+
+### Prompt-only correction
+
+Rejected as the control mechanism. Provider behavior, model drift, and prompt loss can reproduce the issue. Prompt guidance remains useful as defense-in-depth only.
+
+### Forced `present_decision` tool choice
+
+Rejected as the primary mechanism. Tool-choice behavior varies by provider and still leaves the system without a deterministic outcome when the provider ignores the constraint.
+
+### Unmarked server-side synthesis
+
+Rejected. An unmarked artifact could be mistaken for an LLM-authored decision. Deterministic recovery is accepted only as an explicitly attributed, presentation-only artifact that cannot authorize execution.
+
+### New AF terminal phase
+
+Rejected. AF already has a valid operator-escalation contract spanning KA, AA, RO, notification, and audit. Adding a new terminal phase would duplicate outcome semantics and require CRD/API changes.
+
+## Wiring Manifest
+
+| Component | Production Entry Point | Wiring Location | Integration Test |
+|---|---|---|---|
+| Canonical discovery normalization | `kubernaut_discover_workflows` response and completion recovery | `pkg/apifrontend/ka/config.go` | IT-AF-2365-004 |
+| Lifecycle state/obligation tracking | AF phase callbacks and session events | `pkg/apifrontend/agent/phase_guard.go`, `pkg/apifrontend/session/` | IT-AF-2365-005 |
+| Completion coordinator | A2A execution before final status | `pkg/apifrontend/launcher/streaming_executor.go` / coordinator package | IT-AF-2365-006 |
+| Recovered decision artifact | A2A EventBridge | `pkg/apifrontend/launcher/event_bridge.go` | IT-AF-2365-007 |
+| Bounded escalation | AF to KA MCP bridge | `pkg/apifrontend/tools/ka_tools.go` | IT-AF-2365-008 |
+
+## Security and Compliance
+
+The design supports:
+
+- **FedRAMP AC-6**: recovered presentation cannot bypass workflow-selection consent.
+- **FedRAMP SI-10**: discovery data is normalized and validated before becoming a Console option.
+- **FedRAMP AU-3/AU-12**: recovered artifacts and escalation carry provenance, correlation, and outcome data.
+- **FedRAMP SI-4**: missing artifact and bounded recovery are observable events.
+- **OWASP ASVS 5.1**: untrusted model/provider fields are schema-validated and malformed options are rejected.
+- **OWASP ASVS 5.5.2**: structured output is encoded through the existing sanitized A2A artifact boundary.
+
+## Consequences
+
+### Positive
+
+- A2A transport completion no longer implies remediation lifecycle completion.
+- Consent and presentation obligations cannot accidentally bypass one another.
+- Autonomous chaining remains unchanged.
+- Recovery is deterministic, auditable, and provider-independent.
+- The coordinator can later enforce other business-output obligations without expanding reinvocation logic.
+
+### Negative
+
+- AF session state becomes a typed lifecycle contract rather than a collection of independent booleans.
+- Discovery responses need one canonical normalization path and explicit malformed-data handling.
+- A new completion coordinator requires integration tests through the real A2A path.
+- The incomplete-data fallback escalates to human review and therefore creates an operator notification rather than silently completing.
+
+## Verification Requirements
+
+Implementation must follow the test plan at `docs/tests/2365/IMPLEMENTATION_PLAN.md`. The pyramid invariant is mandatory:
+
+- Unit tests prove normalization, state transitions, artifact construction, and idempotency.
+- Integration tests prove production A2A wiring, consent preservation, artifact delivery, and escalation.
+- E2E tests prove the Console-visible workflow-card journey and the autonomous regression path.
+
+No implementation is complete with unit tests alone.

--- a/docs/architecture/decisions/DD-AF-014-business-outcome-completion-coordinator.md
+++ b/docs/architecture/decisions/DD-AF-014-business-outcome-completion-coordinator.md
@@ -131,7 +131,9 @@ If RCA or discovery data is incomplete, AF must emit a truthful structured failu
 
 The coordinator must not fabricate severity, confidence, causal chains, targets, workflow names, or execution decisions.
 
-If a required outcome still cannot be produced after bounded recovery, AF must use the existing KA `complete_no_action` escalation path with a fixed system-generated escalation reason. This produces `HumanReviewReason=operator_escalation`, a `ManualReviewRequired` outcome, and notification routing. It must not use ordinary dismissal and must be idempotent.
+If a required outcome still cannot be produced after bounded recovery **and no consent boundary is active**, AF must use the existing KA `complete_no_action` escalation path with a fixed system-generated escalation reason. This produces `HumanReviewReason=operator_escalation`, a `ManualReviewRequired` outcome, and notification routing. It must not use ordinary dismissal and must be idempotent.
+
+When `phase3_blocked=true`, incomplete authoritative data is still recoverable from the lifecycle perspective: AF emits the truthful failure artifact, preserves the active session and consent gate, and waits for the genuine user turn. It must not escalate or terminate the RemediationRequest at that boundary.
 
 ### Idempotency
 

--- a/docs/architecture/decisions/DD-AF-014-business-outcome-completion-coordinator.md
+++ b/docs/architecture/decisions/DD-AF-014-business-outcome-completion-coordinator.md
@@ -206,5 +206,6 @@ Implementation must follow the test plan at `docs/tests/2365/IMPLEMENTATION_PLAN
 - Unit tests prove normalization, state transitions, artifact construction, and idempotency.
 - Integration tests prove production A2A wiring, consent preservation, artifact delivery, and escalation.
 - E2E tests prove the Console-visible workflow-card journey and the autonomous regression path.
+- Fleet E2E parity proves the same consent and autonomous contracts through the fleet-enabled AF/KA/RO deployment and remote-aware infrastructure.
 
 No implementation is complete with unit tests alone.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -61,6 +61,7 @@
 || DD-CONTEXT-002 | [Cache Size Limit Configuration](./DD-CONTEXT-002-cache-size-limit-configuration.md) | Context API | ✅ Approved | 2025-10-20 | OOM prevention, configurable limits |
 || DD-CONTEXT-003 | [Context Enrichment Placement](./DD-CONTEXT-003-Context-Enrichment-Placement.md) | Context API / KA | ✅ Approved | 2025-10-22 | LLM-driven tool call pattern, 36% token cost reduction |
 || DD-CONTEXT-004 | [BR-AI-002 Ownership](./DD-CONTEXT-004-BR-AI-002-Ownership.md) | AIAnalysis / Context API | ✅ Approved | 2025-10-22 | Keep BR-AI-002 in AIAnalysis (revised scope) |
+|| DD-AF-014 | [Business-Outcome Completion Coordinator](./DD-AF-014-business-outcome-completion-coordinator.md) | API Frontend / A2A | ✅ Accepted | 2026-09-05 | Separate business-lifecycle completion from ADK turn completion; preserve consent while recovering required decision artifacts |
 || DD-016 | [Dynamic Toolset V2.0 Deferral](./DD-016-dynamic-toolset-v2-deferral.md) | Dynamic Toolset | ✅ Approved | 2025-11-21 | Deferred to V2.0 (redundant with KA Prometheus discovery) |
 || DD-017 | [Effectiveness Monitor V1.1 Deferral](./DD-017-effectiveness-monitor-v1.1-deferral.md) | Effectiveness Monitor | ✅ Approved | 2025-12-01 | Level 1 in V1.0, Level 2 in V1.1 (DD-017 v2.0 partial reinstatement) |
 || DD-EFFECTIVENESS-001 | [Hybrid Automated + AI Analysis](./DD-EFFECTIVENESS-001-Hybrid-Automated-AI-Analysis.md) | Effectiveness Monitor | ✅ Level 1 V1.0 / Level 2 V1.1 | 2025-10-16 | 85-90% effectiveness, 11x ROI (DD-017) |

--- a/docs/operations/deployment/FLEET_SETUP_GUIDE.md
+++ b/docs/operations/deployment/FLEET_SETUP_GUIDE.md
@@ -452,7 +452,12 @@ paths against the same hub+spoke topology. Whether an individual `RemediationReq
 resolves to the hub or a spoke is driven entirely by
 `RemediationRequest.spec.clusterID` (SignalProcessing's `ClusterClassification`, or an
 explicit `cluster_id` in an interactive chat message) — independent of which path
-created it.
+created it. In fleet mode an interactive call *without* `cluster_id` whose target
+isn't hub-managed is refused outright (it names the known clusters instead of
+guessing) — see Issue #2362. For this to work end to end, every alerting rule
+must carry a static `cluster:` label: AlertManager groups by alertname, so the
+label never reaches Gateway/audit common labels otherwise, and Thanos does not
+propagate external labels to fired alert instances.
 
 ---
 

--- a/docs/operations/deployment/FLEET_SETUP_GUIDE.md
+++ b/docs/operations/deployment/FLEET_SETUP_GUIDE.md
@@ -61,6 +61,31 @@ SSH tunnel, no separate IdP per cluster.
 
 ---
 
+## Automated demo path
+
+If the goal is a disposable, ready-to-browse Kind demo rather than learning each
+hub/spoke component manually, use the dedicated
+[Fleet Demo Quick Start](./FLEET_DEMO_QUICKSTART.md):
+
+```bash
+make setup-fleet-demo-infra \
+  LLM_PROVIDER=openai_compatible \
+  LLM_MODEL=gpt-4o \
+  LLM_ENDPOINT=https://api.openai.com/v1 \
+  LLM_CREDENTIALS_FILE=/tmp/llm-credentials
+```
+
+That path provisions the hub, spoke, Keycloak, MCP Gateway, kube-mcp-server,
+monitoring, Helm installation, Console access, generated Secrets, default Rego
+policies, and fleet demo instructions. It is Console-first by default; set
+`AUTONOMOUS=true` to enable Gateway-driven remediation. Continue with Path A for
+the contributor E2E harness or Path B for the manual architecture walkthrough.
+
+The Quick Start is the canonical operator entry point for the throwaway demo;
+this guide remains the detailed topology and troubleshooting reference.
+
+---
+
 ## Path A (recommended): use the existing automation
 
 The full two-cluster topology is already wired into this repo's E2E harness and is
@@ -492,6 +517,7 @@ KUBECONFIG=$SPOKE_KUBECONFIG kubectl get jobs -n kubernaut-workflows -w
 | Kuadrant broker gets `401` discovering `remote-cluster` | No `credentialRef` on the `MCPServerRegistration`, or a stale/expired broker token | Re-mint `BROKER_TOKEN` and recreate the Secret |
 | `tools/call` against `remote_cluster_*` tools returns `403` on Job creation | Spoke RBAC only has the `view` binding, missing `fleet-exchanged-identity-job-write` | Apply B7's second `ClusterRoleBinding` |
 | Job never appears in `kubernaut-workflows` on the spoke | `RemediationRequest.ClusterID` wasn't set, or the alert used a different cluster identity than the `MCPServerRegistration`'s name | Confirm the alert payload's `cluster_id` matches `remote-cluster` exactly (case-sensitive) |
+| Fleet demo alert has no `cluster` label or AF cannot attribute the alert to a spoke | Thanos external labels are not reliably copied onto fired alert instances, and AlertManager grouping can remove labels from `commonLabels` | Add a static `cluster: <cluster-name>` label to every hub/spoke alerting rule; do not rely on Thanos `external_labels` alone. Verify the spoke rule carries `cluster: remote-cluster` before testing the demo |
 | Bridge Service connection refused | `port/targetPort` swapped between the Service (well-known port) and the Endpoints (peer's real NodePort) — see B5's note | Double-check which number is the NodePort vs. the in-cluster dial port |
 | Everything above already covered | Single-cluster loopback issues (Keycloak, Kuadrant, kube-mcp-server itself) | See [`fleet-mcp-gateway-keycloak-local-setup.md`](../../development/getting-started/fleet-mcp-gateway-keycloak-local-setup.md)'s own troubleshooting table |
 

--- a/docs/operations/deployment/INTERACTIVE_MODE_SETUP_GUIDE.md
+++ b/docs/operations/deployment/INTERACTIVE_MODE_SETUP_GUIDE.md
@@ -184,6 +184,7 @@ kubectl get investigationsessions,agentsessions -n kubernaut-system
 | Login succeeds, but every real tool call fails | No RBAC role binding for the logged-in user's group | See step 4 — configure `apifrontend.config.rbac.roleBindings` |
 | `helm install` fails before applying anything | Missing `console.auth.secretName`, OIDC issuer, or `console.ingress.host` while `console.enabled=true` | The chart's fail-fast validation names exactly which one is missing |
 | APIFrontend rejects every console-issued token outright | No audience mapper injecting `kubernaut-apifrontend` into `aud` | See step 1's note on audience mappers — common on a fresh Keycloak realm with no existing kubernaut-apifrontend-aware client scope |
+| Investigating a spoke resource fails with "cannot determine which cluster it belongs to" (or "not managed") despite the `kubernaut.ai/managed=true` label | No `cluster_id` was supplied and the alert/rule carries no `cluster` label, so fleet scope attribution is ambiguous — by design this refuses rather than guessing (Issue #2362) | Pass `cluster_id` (e.g. from the alert's `cluster` label, see `list_clusters` for IDs); for alerts, bake a static `cluster:` label into the alerting rule so every evaluation carries attribution |
 
 ---
 

--- a/docs/testing/TEST_PLAN_FLEET_MCP_POST_RCA.md
+++ b/docs/testing/TEST_PLAN_FLEET_MCP_POST_RCA.md
@@ -35,6 +35,7 @@ The plan passes only when all P0 scenarios pass, all affected existing tests pas
 
 ### End-to-End
 
+- `E2E-FLEET-017-000`: After the marker Deployment is Available, verify the same resource is readable through the authenticated `resources_get` MCP path before posting the alert; this prevents a false batch-parse failure caused by remote discovery convergence.
 - `E2E-FLEET-017-001`: Create remote HPA/PDB resources and retrieve them through the real MCP Gateway.
 - `E2E-FLEET-017-002`: Assert `hpaEnabled=true` and `pdbProtected=true`.
 - `E2E-FLEET-017-003`: Assert persisted `PostRCAContext.DetectedLabels`.

--- a/docs/testing/TEST_PLAN_FLEET_MCP_POST_RCA.md
+++ b/docs/testing/TEST_PLAN_FLEET_MCP_POST_RCA.md
@@ -36,6 +36,7 @@ The plan passes only when all P0 scenarios pass, all affected existing tests pas
 ### End-to-End
 
 - `E2E-FLEET-017-000`: After the marker Deployment is Available, verify the same resource is readable through the authenticated `resources_get` MCP path before posting the alert; this prevents a false batch-parse failure caused by remote discovery convergence.
+- `E2E-FLEET-017-000A`: Treat both HTTP 201 (created) and HTTP 202 (deduplicated replay) as accepted alert-ingestion outcomes when retrying the same fingerprint.
 - `E2E-FLEET-017-001`: Create remote HPA/PDB resources and retrieve them through the real MCP Gateway.
 - `E2E-FLEET-017-002`: Assert `hpaEnabled=true` and `pdbProtected=true`.
 - `E2E-FLEET-017-003`: Assert persisted `PostRCAContext.DetectedLabels`.

--- a/docs/testing/TEST_PLAN_FLEET_MCP_POST_RCA.md
+++ b/docs/testing/TEST_PLAN_FLEET_MCP_POST_RCA.md
@@ -36,7 +36,7 @@ The plan passes only when all P0 scenarios pass, all affected existing tests pas
 ### End-to-End
 
 - `E2E-FLEET-017-000`: After the marker Deployment is Available, verify the same resource is readable through the authenticated `resources_get` MCP path before posting the alert; this prevents a false batch-parse failure caused by remote discovery convergence.
-- `E2E-FLEET-017-000A`: Treat both HTTP 201 (created) and HTTP 202 (deduplicated replay) as accepted alert-ingestion outcomes when retrying the same fingerprint.
+- `E2E-FLEET-017-000A`: Use a unique alert name for each run so the expected HTTP 201 creation outcome cannot be replaced by a duplicate-signal replay from a prior run.
 - `E2E-FLEET-017-001`: Create remote HPA/PDB resources and retrieve them through the real MCP Gateway.
 - `E2E-FLEET-017-002`: Assert `hpaEnabled=true` and `pdbProtected=true`.
 - `E2E-FLEET-017-003`: Assert persisted `PostRCAContext.DetectedLabels`.

--- a/docs/testing/TEST_PLAN_FLEET_MCP_POST_RCA.md
+++ b/docs/testing/TEST_PLAN_FLEET_MCP_POST_RCA.md
@@ -36,7 +36,7 @@ The plan passes only when all P0 scenarios pass, all affected existing tests pas
 ### End-to-End
 
 - `E2E-FLEET-017-000`: After the marker Deployment is Available, verify the same resource is readable through the authenticated `resources_get` MCP path before posting the alert; this prevents a false batch-parse failure caused by remote discovery convergence.
-- `E2E-FLEET-017-000A`: Use a unique alert name for each run so the expected HTTP 201 creation outcome cannot be replaced by a duplicate-signal replay from a prior run.
+- `E2E-FLEET-017-000A`: Use a unique target resource identity when multiple cases exercise the same cluster, because Gateway deduplication fingerprints cluster, namespace, kind, and target name rather than alert name.
 - `E2E-FLEET-017-001`: Create remote HPA/PDB resources and retrieve them through the real MCP Gateway.
 - `E2E-FLEET-017-002`: Assert `hpaEnabled=true` and `pdbProtected=true`.
 - `E2E-FLEET-017-003`: Assert persisted `PostRCAContext.DetectedLabels`.

--- a/docs/testing/TEST_PLAN_FLEET_MCP_POST_RCA.md
+++ b/docs/testing/TEST_PLAN_FLEET_MCP_POST_RCA.md
@@ -1,0 +1,66 @@
+# Test Plan: Fleet MCP List Responses and Post-RCA Label Persistence
+
+**Test Plan Identifier**: TP-FLEET-MCP-POST-RCA-v1
+**Feature**: Parse remote MCP list responses and persist detected labels on every AgentSession result path.
+**Version**: 1.0
+**Status**: Active
+**Business Requirements**: BR-INTEGRATION-1489, BR-AI-056
+**Architecture References**: ADR-056, ADR-068
+
+## 1. Purpose and Success Criteria
+
+This plan verifies that remote HPA/PDB discovery works with the response shapes emitted by the MCP Gateway and that detected labels are persisted before every AIAnalysis terminal or continuing transition.
+
+The plan passes only when all P0 scenarios pass, all affected existing tests pass, the production wiring is exercised, and the focused fleet E2E proves the complete remote investigation journey.
+
+## 2. Pyramid Scenarios
+
+### Unit
+
+- `UT-KA-MCP-LIST-001`: Parse a top-level YAML sequence into unstructured objects.
+- `UT-KA-MCP-LIST-002`: Parse a top-level JSON array into unstructured objects.
+- `UT-KA-MCP-LIST-003`: Parse an `{items: [...]}` envelope.
+- `UT-KA-MCP-LIST-004`: Preserve an empty list.
+- `UT-KA-MCP-LIST-005`: Reject malformed, scalar, and non-array list responses.
+- `UT-AA-056-020`: Persist labels for problem-resolved responses.
+- `UT-AA-056-021`: Persist labels for not-actionable responses.
+- Existing `UT-AA-056-003`, `UT-AA-056-005`, `UT-AA-056-006`, `UT-AA-056-007`, and `UT-AA-056-008`: cover normal-path mapping, immutability timestamp, absent labels, failed detections, and malformed labels.
+
+### Integration
+
+- `IT-KA-MCP-LIST-001`: Exercise `overlayClientReader.List()` through the production reader with a top-level YAML response.
+- Existing overlay-reader tests: prove GVK, namespace, selector, and tool error wiring.
+- Existing MCP client tests: prove OAuth2 scope and cluster-prefixed routing.
+- Existing AIAnalysis response tests: prove production response processing and Rego consumption of `PostRCAContext`.
+
+### End-to-End
+
+- `E2E-FLEET-017-001`: Create remote HPA/PDB resources and retrieve them through the real MCP Gateway.
+- `E2E-FLEET-017-002`: Assert `hpaEnabled=true` and `pdbProtected=true`.
+- `E2E-FLEET-017-003`: Assert persisted `PostRCAContext.DetectedLabels`.
+- `E2E-FLEET-017-004`: Assert remote-cluster provenance and no wrong-cluster data.
+- `E2E-FLEET-017-005`: Assert remediation correlation and RCA reconstruction.
+
+## 3. Control Objective Traceability
+
+- FedRAMP `AC-4` and `SC-7`: IT/E2E verify cluster-prefixed reads use the intended remote boundary.
+- FedRAMP `AC-6`: existing negative MCP tests verify read-only identities cannot write.
+- FedRAMP `IA-5` and `SC-8`: existing OAuth2 and TLS tests verify authenticated transport.
+- FedRAMP `AU-3`: AIAnalysis tests verify detected labels and remediation context are persisted.
+- FedRAMP `SI-4`: parser and E2E failure assertions verify errors remain observable.
+- FedRAMP `SI-10`: parser tests verify malformed responses fail closed.
+- OWASP ASVS `V2` and `V4`: existing authentication and authorization tests.
+- OWASP ASVS `V5`: list parser malformed-input tests.
+- OWASP ASVS `V7`: contextual parser and response-processing errors.
+- OWASP ASVS `V9`: existing MCP TLS transport tests.
+- OWASP ASVS `V11`: detected labels affect the AIAnalysis business result.
+- OWASP ASVS `V13`: MCP list protocol and response-shape tests.
+
+## 4. Pyramid and Wiring Gates
+
+- Unit tests prove parser and response-processing logic.
+- Integration tests prove production overlay-reader and response-processor dispatch.
+- E2E proves the complete remote alert-to-analysis journey.
+- Every new production function has a non-test caller.
+- No scenario is skipped or pending.
+- Any failed control-objective scenario blocks completion.

--- a/docs/tests/2345/TEST_PLAN.md
+++ b/docs/tests/2345/TEST_PLAN.md
@@ -1,0 +1,66 @@
+# Test Plan: Fleet-Aware LabelDetector Enrichment (#2345)
+
+**Business requirement**: BR-INTEGRATION-1489
+**Scope**: KubernautAgent LabelDetector reads for fleet-target investigations
+**Status**: Implemented; validation tracked by this plan
+
+## Business Contract
+
+When an investigation targets a remote cluster, LabelDetector must read the
+target cluster through the fleet MCP overlay. It must not query the hub as a
+fallback. Detected HPA/PDB and related infrastructure labels must be available
+to workflow selection and persisted in the post-RCA context.
+
+## Control Objectives
+
+- **FedRAMP AC-4**: resource-enrichment data must flow from the selected cluster
+  boundary, not an unrelated hub cluster.
+- **FedRAMP AC-6**: fleet requests must not silently fall back to broader hub
+  access when the target is remote.
+- **FedRAMP SI-10**: MCP list arguments and responses must be validated and
+  malformed responses must fail as detection errors, not produce false labels.
+- **OWASP ASVS 5.1.x**: external MCP response data is parsed and validated
+  before use.
+- **OWASP ASVS 5.5.2**: cluster selection remains authoritative from request
+  context; detected labels never select or switch the target cluster.
+
+## Test Pyramid
+
+### Unit Tests
+
+- `UT-KA-FLEET-031`: `resources_list` arguments include kind, apiVersion,
+  namespace, and label selector.
+- `UT-KA-FLEET-032`: list responses populate unstructured items and reject
+  malformed responses/items.
+- `UT-KA-FLEET-033`: missing remote list capability is observable and does not
+  fall back to the hub.
+
+### Integration Tests
+
+- `IT-KA-FLEET-2345`: production-style Enricher resolver routes a fleet-target
+  investigation through remote `resources_get/resources_list`; HPA and PDB
+  detected labels are returned and no corresponding detection failure is
+  recorded.
+- `IT-KA-FLEET-036`: existing owner-chain production-path test proves the same
+  per-request overlay routing and hub-local regression behavior.
+
+### End-to-End Tests
+
+- `E2E-FLEET-2345`: real hub/spoke fleet lane creates a remote Deployment,
+  HPA, and PDB; real KA investigates through the MCP Gateway; assertions verify
+  `AIAnalysis.Status.PostRCAContext.DetectedLabels.HPAEnabled` and
+  `PDBProtected` are true.
+
+## Wiring Manifest
+
+| Component | Production entry point | Wiring location | Test |
+|---|---|---|---|
+| Fleet LabelDetector | KA automatic pre-fetch enrichment | `cmd/kubernautagent/datastorage.go` → `Enricher.WithLabelDetectorResolver` | `IT-KA-FLEET-2345`, `E2E-FLEET-2345` |
+
+## Validation
+
+- Targeted enrichment, custom-tool, and KA tests must pass.
+- `go build ./...` must pass.
+- Targeted `golangci-lint` must pass.
+- Fleet E2E must run in a real hub/spoke environment; an environment-gated
+  skip is not evidence of E2E completion.

--- a/docs/tests/2364/TEST_PLAN.md
+++ b/docs/tests/2364/TEST_PLAN.md
@@ -1,0 +1,146 @@
+# Test Plan: #2364 Ambient fleet-field tolerance in AF tool schemas
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Fleet-hinted turns die at ADK strict schema validation: the console appends a
+fleet cluster hint to investigate messages, the model propagates `cluster_id`
+(occasionally `rr_id`) into tool calls, and `functiontool` (`additionalProperties:
+false` at every struct level, ADK v2.0.0 + jsonschema-go v0.4.3) rejects the
+call. After 5 consecutive failures the reinvoking-runner circuit breaker trips
+and no `investigation_summary` artifact is emitted. Live evidence: 0 successful
+`kubernaut_present_decision` calls vs 15 failures in 2h (14x `cluster_id`, 1x
+`rr_id`+`cluster_id`).
+
+### 1.2 Objectives
+
+1. Every AF lifecycle tool schema tolerates ambient fleet/context fields
+   (`cluster_id`, `rr_id`, `session_id`) as ignored `omitempty` hints.
+2. Turn survival: a fleet-hinted `present_decision` / `discover` / `select` /
+   `watch` call executes its handler and emits its artifact.
+3. No regression: required fields stay required; handlers ignore new fields
+   (never routing/authz); zero-value omission preserved.
+
+### 1.3 Success Metrics
+
+- UT + IT suites for touched packages green; `go build ./...` clean.
+- New `UT-2364-*` / `IT-2364-*` all passing; no `XIt`/`Skip`.
+- Fleet E2E lifecycle emits `investigation_summary` (or documents live-infra
+  run in CI where kind hub+spoke exists).
+
+## 2. References
+
+### 2.1 Authority
+
+- Issue #2364 (+ #2073/#2074 precedent: `tool_calls_count`/`llm_turns` omitempty).
+- `BR-INTERACTIVE` (decision presentation), `BR-FLEET-003` (fleet context must
+  not break selection close-out), `BR-AUDIT-021-030` (selection audit trail).
+- FedRAMP SI-10 (input validation), AU-3 (audit content), AC-6 (least
+  privilege); SOC2 CC7.2 (reconstruction); OWASP ASVS 5.1 (validation), 5.5.2
+  (untrusted-field isolation).
+
+### 2.2 Cross-References
+
+- `pkg/apifrontend/tools/ka_tools.go` (PresentDecision/Discover/Select/RCAData/TargetInfo),
+  `crd_tools_watch.go` (WatchArgs), `ka_investigate_mcp.go`, `ka_interactive.go`,
+  `crd_tools.go`, `ds_tools.go`, `af_list_events.go`,
+  `pkg/apifrontend/agent/prompt.txt:87`, `phase_guard.go`.
+
+## 3. Risks & Mitigations
+
+| Risk | Mitigation | Proving test |
+|---|---|---|
+| Spoofed `cluster_id` used for routing/authz | Handlers ignore new fields; authority stays `RRContext` + injected `Namespace` | UT-2364-H* (handler ignores extras) |
+| Over-permissive schema masks malformed input | Core fields stay required; malformed payloads still rejected | UT-2364-S* (required-set intact) |
+| Nested rejection persists | `TargetInfo`/`RCAData` also gain `cluster_id` (infer.go proves nested strictness) | UT-2364-N*, IT-2364-001 |
+| Prompt keeps instructing cross-contamination | `prompt.txt:87` reworded (defense-in-depth) | Manual review |
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+Tier 1: `present_decision`, `discover_workflows`, `select_workflow`, `watch`
+(+ nested `RCAData`/`TargetInfo`). Tier 2: `investigate`, interactive
+actions, `complete_no_action`, `get_remediation`, `cancel_remediation`,
+`get_audit_trail`, `list_events`. Tier 3 folds in iff mechanical.
+
+### 4.2 Features Not to be Tested
+
+Live kind hub+spoke fleet run in this session if no cluster is available
+(spec written; execution deferred to CI with note). Console-side hint
+formatting (healthy per Playwright repro in issue).
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+UT proves tolerant-schema logic; IT proves production `functiontool`+`phase_guard`
+wiring; E2E proves the fleet journey. No `testing.T` (Ginkgo only).
+
+### 5.4 Pass/Fail Criteria
+
+Pass: all listed scenarios green, build+lint clean, no new anti-patterns.
+Fail: any scenario red, or any touched handler branches on the new fields.
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code
+
+Arg-struct schemas (`jsonschema.For`), JSON omission/round-trip,
+handler-ignores-extras.
+
+### 6.2 Integration-Testable Code
+
+Real `functiontool.New` tools invoked via `phase_guard` before-callback +
+`Run` with ambient extras (2092-test pattern). E2E fleet lifecycle.
+
+## 7. BR Coverage Matrix
+
+| BR / Control | Proving test |
+|---|---|
+| BR-INTERACTIVE-001 (decision presentation) | UT-2364-001, IT-2364-001 |
+| BR-FLEET-003 (fleet must not break close-out) | UT-2364-002, IT-2364-002/003, E2E-2364-001 |
+| BR-AUDIT-021-030 (selection audit trail) | IT-2364-001 (artifact emitted) |
+| SI-10 / ASVS 5.1.1, 5.1.4 | UT-2364-S*, UT-2364-001 |
+| AU-3 / CC7.2 | IT-2364-*, E2E-2364-001 |
+| AC-6 / ASVS 5.5.2 | UT-2364-H* |
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+`UT-2364-NNN` (unit), `IT-2364-NNN` (integration), `E2E-2364-NNN` (e2e).
+
+### Tier 1: Unit Tests
+
+| ID | Business behavior | Control |
+|---|---|---|
+| UT-2364-001 | `PresentDecisionArgs` schema: `cluster_id`/`rr_id` in Properties, absent from Required; `session_id`/`summary`/`rca` still required | SI-10 |
+| UT-2364-002 | `DiscoverWorkflowsArgs`/`SelectWorkflowArgs` schemas tolerate `cluster_id`+`session_id`; `rr_id` still required | SI-10, BR-FLEET-003 |
+| UT-2364-003 | `WatchArgs` schema tolerates `cluster_id`+`session_id` | SI-10 |
+| UT-2364-004 | Tier-2 structs (`InvestigateMCPArgs`, `InteractiveActionArgs`, `CompleteNoActionArgs`, `GetRemediationArgs`, `CancelRemediationArgs`, `GetAuditTrailArgs`, `ListEventsArgs`) tolerate ambient trio | SI-10 |
+| UT-2364-N01 | Nested `RCAData`/`TargetInfo` tolerate `cluster_id` | SI-10 |
+| UT-2364-S01 | Zero-value ambient fields omitted from JSON; genuine values round-trip (no #2074 regression) | AU-3 |
+| UT-2364-H01..H03 | `HandlePresentDecision`/`HandleDiscoverWorkflows`/`HandleSelectWorkflow` ignore ambient extras (same result with/without) | AC-6 |
+
+### Tier 2: Integration Tests
+
+| ID | Business behavior | Control |
+|---|---|---|
+| IT-2364-001 | Real `kubernaut_present_decision` tool via `phase_guard`+`Run` with `cluster_id`+`rr_id` extras succeeds end-to-end | SI-10, AU-3, BR-INTERACTIVE-001 |
+| IT-2364-002 | Real `discover`/`select` tools with `cluster_id`+`session_id` extras survive validation | SI-10, BR-FLEET-003 |
+| IT-2364-003 | `watch` tool schema tolerates ambient extras via real tool | SI-10 |
+
+### Tier 3: E2E
+
+| ID | Journey | Control |
+|---|---|---|
+| E2E-2364-001 | Fleet-hinted `investigate→discover→select→present→watch` emits `investigation_summary`, reconstructable by `correlation_id` | CC7.2, AU-3 |
+
+**Execution status:** `IT-2364-001..003` pass against the real ADK
+`functiontool` path. `E2E-2364-001` remains infrastructure-gated: the existing
+fleet journey (`test/e2e/fullpipeline/10_af_fleet_cluster_id_test.go`) requires
+a live hub+spoke fleet and is skipped when Fleet is unavailable. No new skipped
+spec was added; the existing fleet E2E is the required follow-up proving the
+complete journey and audit reconstruction in a fleet-enabled environment.

--- a/docs/tests/2365/IMPLEMENTATION_PLAN.md
+++ b/docs/tests/2365/IMPLEMENTATION_PLAN.md
@@ -98,9 +98,9 @@ The pyramid invariant is mandatory: unit tests prove logic, integration tests pr
 
 | Control objective | Business behavior | Unit | Integration | E2E |
 |---|---|---|---|---|
-| FedRAMP AC-6 | Recovery cannot authorize workflow execution | UT-AF-2365-003 | IT-AF-2365-006 | E2E-FP-2365-001 |
-| FedRAMP SI-10 / ASVS 5.1 | Only valid normalized discovery data becomes an option | UT-AF-2365-001/002 | IT-AF-2365-004/012 | E2E-FP-2365-001 |
-| FedRAMP AU-3/AU-12 | Artifact provenance, correlation, and escalation outcome are preserved | UT-AF-2365-007/009 | IT-AF-2365-007/008/010 | E2E-FP-2365-001 |
+| FedRAMP AC-6 | Recovery cannot authorize workflow execution | UT-AF-2365-003 | IT-AF-2365-006 | E2E-FP-2365-001, E2E-FLEET-2365-001/002 |
+| FedRAMP SI-10 / ASVS 5.1 | Only valid normalized discovery data becomes an option | UT-AF-2365-001/002 | IT-AF-2365-004/012 | E2E-FP-2365-001, E2E-FLEET-2365-001/002/003 |
+| FedRAMP AU-3/AU-12 | Artifact provenance, correlation, and escalation outcome are preserved | UT-AF-2365-007/009 | IT-AF-2365-007/008/010 | E2E-FP-2365-001, E2E-FLEET-2365-001/002 |
 | FedRAMP SI-4 | Missing presentation and recovery exhaustion are observable | UT-AF-2365-009 | IT-AF-2365-011 | E2E-FP-2365-002 |
 | ASVS 5.5.2 | Structured output passes the sanitized A2A boundary | UT-AF-2365-007/012 | IT-AF-2365-007 | E2E-FP-2365-001 |
 | BR-INTERACTIVE-010 | User receives options and can select on a genuine subsequent turn | UT-AF-2365-003 | IT-AF-2365-006 | E2E-FP-2365-001 |
@@ -157,6 +157,8 @@ CHECKPOINT W fails if any component lacks a production caller or if tests only c
 - `E2E-FP-2365-002`: authoritative data is incomplete outside an active consent boundary; Console receives a structured failure/escalation outcome, notification routing occurs, and the RR is not left in `Analyzing`.
 - Regression: `E2E-FP-1899-002` continues to enforce phase-3 consent.
 - Regression: `E2E-FP-1853-002` continues to complete autonomous discover/select/watch chaining.
+- Fleet parity: `E2E-FLEET-2365-001/002` repeat both consent boundaries through the fleet-enabled stack and prove no WorkflowExecution exists before genuine user confirmation.
+- Fleet regression: `E2E-FLEET-2365-003` repeats autonomous discover/select/watch chaining through fleet deployment and proves execution completion.
 
 ## 8. Execution Order
 

--- a/docs/tests/2365/IMPLEMENTATION_PLAN.md
+++ b/docs/tests/2365/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,199 @@
+# Implementation Plan: AF Business-Outcome Completion Coordinator
+
+> **Ephemeral plan**: this document is the implementation plan for issue #2365 and the redesign governed by [DD-AF-014](../../architecture/decisions/DD-AF-014-business-outcome-completion-coordinator.md). Replace or archive it with the final verification report after implementation.
+
+**Plan Identifier**: IP-2365-v1
+**Feature**: Prevent AF from closing a successful workflow-discovery turn without a structured decision artifact.
+**Created**: 2026-09-05
+**Author**: Kubernaut maintainers
+**Status**: Implemented; E2E/integration environment follow-up remains
+**Branch**: `fix/demo-scenario-run-hint`
+**Business Requirements**: BR-INTERACTIVE-010, BR-SESS-013, BR-AUDIT-005
+**Issue**: [#2365](https://github.com/jordigilh/kubernaut/issues/2365)
+**Authority**: [DD-AF-014](../../architecture/decisions/DD-AF-014-business-outcome-completion-coordinator.md)
+
+## 1. Business Outcome
+
+After successful workflow discovery, the Console must receive a structured decision artifact or a structured escalation/failure outcome. The RemediationRequest must not remain silently stuck in `Analyzing` because an LLM returned narration instead of calling `kubernaut_present_decision`.
+
+The implementation must preserve:
+
+- `full_remediation` consent before `select_workflow`.
+- `full_remediation_autonomous` discover/select/watch chaining.
+- Grounded RCA data integrity.
+- Audit reconstruction and operator escalation semantics.
+
+## 2. Preflight Evidence
+
+The preflight and design spike established:
+
+- RCA is available from `StateKeyGroundedRCA`.
+- Discovery results are available in ADK `FunctionResponse` events.
+- `ka.ParseDiscoverWorkflowsResponse` supports direct and KA envelope formats.
+- Direct empty workflow responses need parser hardening to preserve target metadata.
+- `StreamingExecutor.Execute` is the production pre-finalization wiring point.
+- `EventBridge.EmitArtifact` is the existing sanitized A2A artifact boundary.
+- `complete_no_action` with `escalation_reason` produces `operator_escalation` and `ManualReviewRequired`.
+- Affected package suites pass before implementation.
+
+## 3. TDD Sequence
+
+### RED
+
+Write failing Ginkgo/Gomega tests for:
+
+1. Direct and envelope discovery normalization, including empty direct results.
+2. Lifecycle obligation derivation for all three interaction modes.
+3. Detection of an existing decision artifact.
+4. Deterministic recovery from authoritative RCA and discovery data.
+5. Truthful incomplete-data artifact construction.
+6. Idempotent recovery and idempotent escalation.
+7. Consent preservation after recovery.
+8. Production A2A wiring through the finalization boundary.
+9. Autonomous chaining regression.
+
+All tests must assert business outcomes and include the BR/control mapping in their names or comments.
+
+### GREEN
+
+Implement the minimum behavior:
+
+1. Harden the canonical discovery parser.
+2. Introduce typed lifecycle/obligation state.
+3. Implement the completion coordinator.
+4. Wire it before A2A final status publication.
+5. Emit recovered artifacts through `EventBridge.EmitArtifact`.
+6. Escalate only after bounded recovery failure and only through the existing operator-escalation contract.
+
+Run CHECKPOINT W immediately after GREEN. Every wiring-manifest row must have a production caller and passing integration proof.
+
+### REFACTOR
+
+Refactor only after GREEN:
+
+- Replace duplicated boolean checks with named lifecycle predicates.
+- Centralize discovery-to-option normalization.
+- Centralize recovery idempotency keys.
+- Make provenance and failure reasons explicit.
+- Ensure errors are wrapped, logged, lowercase, and observable.
+- Keep the coordinator independent from provider-specific tool-choice behavior.
+
+Post-refactor validation is mandatory: `go build ./...`, affected tests, and lint.
+
+## 4. Risks and Mitigations
+
+| ID | Risk | Impact | Mitigation | Tests |
+|---|---|---|---|---|
+| R1 | Recovery bypasses phase-3 consent | Unauthorized WorkflowExecution | Coordinator emits presentation only and preserves `phase3_blocked` | UT-AF-2365-003, IT-AF-2365-006, E2E-FP-2365-001 |
+| R2 | Autonomous chain is intercepted | Regression of unattended remediation | Obligation policy excludes autonomous mode | IT-AF-2365-005, E2E-FP-1853-002 regression |
+| R3 | Discovery response is mis-normalized | Incorrect/missing workflow cards | One canonical parser; direct empty response test | UT-AF-2365-001/002, IT-AF-2365-004 |
+| R4 | Recovery fabricates RCA or workflow data | Incorrect operator decision/audit record | Only use grounded RCA/discovery; emit explicit incomplete outcome otherwise | UT-AF-2365-007, IT-AF-2365-008 |
+| R5 | Duplicate artifact/escalation | Duplicate Console events/notifications | Session/RR/discovery idempotency key | UT-AF-2365-009, IT-AF-2365-010 |
+| R6 | A2A closes before coordinator runs | Original issue persists | Wire coordinator before final status and prove real A2A path | IT-AF-2365-006/011, E2E-FP-2365-001 |
+| R7 | Malformed model fields reach output | Invalid or unsafe structured output | JSON schema validation and sanitized EventBridge boundary | UT-AF-2365-002/007, IT-AF-2365-012 |
+
+## 5. Pyramid and Control Matrix
+
+The pyramid invariant is mandatory: unit tests prove logic, integration tests prove wiring, and E2E proves the user journey and control objectives.
+
+| Control objective | Business behavior | Unit | Integration | E2E |
+|---|---|---|---|---|
+| FedRAMP AC-6 | Recovery cannot authorize workflow execution | UT-AF-2365-003 | IT-AF-2365-006 | E2E-FP-2365-001 |
+| FedRAMP SI-10 / ASVS 5.1 | Only valid normalized discovery data becomes an option | UT-AF-2365-001/002 | IT-AF-2365-004/012 | E2E-FP-2365-001 |
+| FedRAMP AU-3/AU-12 | Artifact provenance, correlation, and escalation outcome are preserved | UT-AF-2365-007/009 | IT-AF-2365-007/008/010 | E2E-FP-2365-001 |
+| FedRAMP SI-4 | Missing presentation and recovery exhaustion are observable | UT-AF-2365-009 | IT-AF-2365-011 | E2E-FP-2365-002 |
+| ASVS 5.5.2 | Structured output passes the sanitized A2A boundary | UT-AF-2365-007/012 | IT-AF-2365-007 | E2E-FP-2365-001 |
+| BR-INTERACTIVE-010 | User receives options and can select on a genuine subsequent turn | UT-AF-2365-003 | IT-AF-2365-006 | E2E-FP-2365-001 |
+| BR-SESS-013 | A stalled turn is recovered without confusing it with consent | UT-AF-2365-005 | IT-AF-2365-011 | E2E-FP-2365-002 |
+| BR-AUDIT-005 | Lifecycle remains reconstructable by correlation ID | UT-AF-2365-009 | IT-AF-2365-008/010 | E2E-FP-2365-002 |
+
+## 6. Wiring Manifest
+
+| Component | Production entry point | Wiring location | IT test |
+|---|---|---|---|
+| Discovery normalizer | `kubernaut_discover_workflows` response | `pkg/apifrontend/ka/config.go` | IT-AF-2365-004 |
+| Lifecycle obligation state | Phase callbacks/session events | `pkg/apifrontend/agent/phase_guard.go`, `pkg/apifrontend/session/` | IT-AF-2365-005 |
+| Completion coordinator | A2A request execution | `pkg/apifrontend/launcher/streaming_executor.go` | IT-AF-2365-006/011 |
+| Recovered artifact | EventBridge output | `pkg/apifrontend/launcher/event_bridge.go` | IT-AF-2365-007 |
+| Operator escalation | AF KA MCP bridge | `pkg/apifrontend/tools/ka_tools.go` | IT-AF-2365-008 |
+
+CHECKPOINT W fails if any component lacks a production caller or if tests only call the component directly without traversing the production A2A path.
+
+## 7. Test Scenarios
+
+### Unit Tests
+
+- `UT-AF-2365-001`: direct and envelope discovery payloads normalize to the same canonical workflow representation, including empty direct results with target metadata. BR-INTERACTIVE-010, SI-10, ASVS 5.1.
+- `UT-AF-2365-002`: malformed workflow entries are rejected and cannot become executable options. SI-10, ASVS 5.1.
+- `UT-AF-2365-003`: `full_remediation` requires presentation but remains execution-blocked; autonomous mode does not activate recovery. BR-INTERACTIVE-010, AC-6.
+- `UT-AF-2365-004`: existing `present_decision` FunctionCall satisfies the presentation obligation exactly once. BR-SESS-013.
+- `UT-AF-2365-005`: a successful discovery with no decision produces a recovery obligation without enabling `select_workflow`. AC-6.
+- `UT-AF-2365-006`: recovered artifact uses grounded RCA and normalized discovery data only. AU-3, SI-10, ASVS 5.1.
+- `UT-AF-2365-007`: missing RCA/discovery data produces truthful failure output without fabricated severity, confidence, target, or workflow. AU-3, ASVS 5.1.
+- `UT-AF-2365-008`: escalation reason is fixed, bounded, observable, and maps to `operator_escalation`. AU-12, SI-4.
+- `UT-AF-2365-009`: recovery idempotency prevents duplicate artifacts. AU-3.
+- `UT-AF-2365-010`: escalation idempotency prevents duplicate human-review notifications. AU-12.
+- `UT-AF-2365-011`: recovered artifact data remains safe through schema validation and sanitization. SI-10, ASVS 5.5.2.
+
+### Integration Tests
+
+- `IT-AF-2365-001`: real agent callbacks persist lifecycle obligation state.
+- `IT-AF-2365-002`: real ADK session history supplies the discovery FunctionResponse and present-decision detection.
+- `IT-AF-2365-003`: full-remediation consent state survives completion recovery.
+- `IT-AF-2365-004`: production discovery parser wiring handles direct and envelope responses.
+- `IT-AF-2365-005`: production mode policy distinguishes full-remediation and autonomous chaining.
+- `IT-AF-2365-006`: A2A execution invokes the coordinator before final status publication and emits the structured artifact.
+- `IT-AF-2365-007`: recovered artifact reaches the A2A queue with required metadata and correlation.
+- `IT-AF-2365-008`: incomplete recovery reaches KA operator escalation and finalizes the investigation outcome.
+- `IT-AF-2365-009`: normal `present_decision` does not produce a duplicate recovered artifact.
+- `IT-AF-2365-010`: repeated finalization does not duplicate escalation.
+- `IT-AF-2365-011`: existing reinvocation and consent integration behavior remains unchanged.
+- `IT-AF-2365-012`: malformed provider data is rejected before artifact emission.
+
+### E2E Tests
+
+- `E2E-FP-2365-001`: model narrates after successful discovery without calling `present_decision`; Console receives workflow options, RR leaves the pending analysis state, and a genuine selection turn executes the selected workflow without same-turn authorization.
+- `E2E-FP-2365-002`: authoritative data is incomplete; Console receives a structured failure/escalation outcome, notification routing occurs, and the RR is not left in `Analyzing`.
+- Regression: `E2E-FP-1899-002` continues to enforce phase-3 consent.
+- Regression: `E2E-FP-1853-002` continues to complete autonomous discover/select/watch chaining.
+
+## 8. Execution Order
+
+1. RED: add parser, lifecycle-policy, coordinator, artifact, idempotency, and wiring tests.
+2. GREEN: implement canonical parsing and minimal coordinator wiring.
+3. CHECKPOINT W: prove every new production path through A2A integration tests.
+4. REFACTOR: simplify state predicates, centralize normalization, and harden observability.
+5. E2E: run the missing-presentation and incomplete-data journeys plus consent/autonomous regressions.
+6. Validation: `go build ./...`, `golangci-lint run --timeout=5m`, affected tests, `make test`, and coverage/report checks.
+
+## 9. Completion Criteria
+
+- All P0 UT/IT/E2E scenarios pass.
+- No existing consent or autonomous-chain regressions.
+- Unit tests cover all business logic introduced.
+- Every wiring-manifest row has a passing integration test.
+- E2E scenarios prove AC-6, SI-10, AU-3, AU-12, SI-4, ASVS 5.1, and ASVS 5.5.2 objectives.
+- No standard `testing.T` business tests are added.
+- No `Skip`, `XIt`, or `PIt` is used.
+- All changed errors are logged and wrapped with context.
+- The final verification report replaces this ephemeral plan.
+
+## 10. Execution Results
+
+### Passed
+
+- `make test-unit-apifrontend`: 721/721 specs passed; 80.1% composite coverage.
+- `make test`: repository unit aggregation passed.
+- `make lint`: 0 issues.
+- `make vet`: passed.
+- `go build ./...`: passed.
+- `go test ./... -run '^$' -count=1`: all packages compiled.
+- `go test ./pkg/apifrontend/session ./pkg/apifrontend/agent ./pkg/apifrontend/launcher ./pkg/apifrontend/ka -count=1`: passed.
+- AF AgentSession-close and fleet integration suites: passed.
+
+### Environment-Gated
+
+- `make test-integration-apifrontend`: the shared AF integration suite failed during `SynchronizedBeforeSuite` infrastructure setup at `test/integration/apifrontend/suite_test.go:225`; zero feature specs ran. This was not a product-test failure. The independent AF integration suites in the same target completed successfully.
+- Live E2E execution was not run because the required cluster/mock-LLM environment was unavailable. E2E package compilation passed through `go test ./test/e2e/apifrontend -run '^$' -count=1`.
+
+The production-path integration proof for this change is implemented in `pkg/apifrontend/launcher/reinvoking_runner_test.go`: it exercises the real wrapped runner, ADK session state, EventBridge artifact delivery, consent preservation, and operator escalation. Live E2E execution remains a release-environment follow-up.

--- a/docs/tests/2365/IMPLEMENTATION_PLAN.md
+++ b/docs/tests/2365/IMPLEMENTATION_PLAN.md
@@ -145,6 +145,7 @@ CHECKPOINT W fails if any component lacks a production caller or if tests only c
 - `IT-AF-2365-006`: A2A execution invokes the coordinator before final status publication and emits the structured artifact.
 - `IT-AF-2365-007`: recovered artifact reaches the A2A queue with required metadata and correlation.
 - `IT-AF-2365-008`: incomplete recovery reaches KA operator escalation and finalizes the investigation outcome.
+- `IT-AF-2365-008b`: incomplete recovery at an active phase-3 consent boundary emits failure data but preserves the session and does not escalate.
 - `IT-AF-2365-009`: normal `present_decision` does not produce a duplicate recovered artifact.
 - `IT-AF-2365-010`: repeated finalization does not duplicate escalation.
 - `IT-AF-2365-011`: existing reinvocation and consent integration behavior remains unchanged.
@@ -153,7 +154,7 @@ CHECKPOINT W fails if any component lacks a production caller or if tests only c
 ### E2E Tests
 
 - `E2E-FP-2365-001`: model narrates after successful discovery without calling `present_decision`; Console receives workflow options, RR leaves the pending analysis state, and a genuine selection turn executes the selected workflow without same-turn authorization.
-- `E2E-FP-2365-002`: authoritative data is incomplete; Console receives a structured failure/escalation outcome, notification routing occurs, and the RR is not left in `Analyzing`.
+- `E2E-FP-2365-002`: authoritative data is incomplete outside an active consent boundary; Console receives a structured failure/escalation outcome, notification routing occurs, and the RR is not left in `Analyzing`.
 - Regression: `E2E-FP-1899-002` continues to enforce phase-3 consent.
 - Regression: `E2E-FP-1853-002` continues to complete autonomous discover/select/watch chaining.
 

--- a/internal/kubernautagent/enrichment/enricher.go
+++ b/internal/kubernautagent/enrichment/enricher.go
@@ -190,6 +190,7 @@ type Enricher struct {
 	auditStore    audit.AuditStore
 	logger        logr.Logger
 	labelDetector *LabelDetector
+	labelResolver func(ctx context.Context) *LabelDetector
 	retryConfig   RetryConfig
 	k8sResolver   func(ctx context.Context) K8sClient
 }
@@ -207,6 +208,13 @@ func NewEnricher(k8s K8sClient, ds DataStorageClient, auditStore audit.AuditStor
 // WithLabelDetector attaches a LabelDetector to run during Enrich().
 func (e *Enricher) WithLabelDetector(ld *LabelDetector) *Enricher {
 	e.labelDetector = ld
+	return e
+}
+
+// WithLabelDetectorResolver installs a per-call override for label detection,
+// matching WithK8sResolver's fleet routing semantics.
+func (e *Enricher) WithLabelDetectorResolver(resolver func(ctx context.Context) *LabelDetector) *Enricher {
+	e.labelResolver = resolver
 	return e
 }
 
@@ -242,6 +250,15 @@ func (e *Enricher) effectiveK8s(ctx context.Context) K8sClient {
 		}
 	}
 	return e.k8s
+}
+
+func (e *Enricher) effectiveLabelDetector(ctx context.Context) *LabelDetector {
+	if e.labelResolver != nil {
+		if detector := e.labelResolver(ctx); detector != nil {
+			return detector
+		}
+	}
+	return e.labelDetector
 }
 
 // resolveOwnerChainWithRetry calls GetOwnerChain with optional retry logic.
@@ -425,10 +442,11 @@ func (e *Enricher) populateOwnerChain(ctx context.Context, kind, name, namespace
 // stores the results on result. Returns a non-nil error only for a forbidden
 // error, signaling the caller to abort enrichment entirely.
 func (e *Enricher) populateDetectedLabels(ctx context.Context, kind, name, namespace string, result *EnrichmentResult) error {
-	if e.labelDetector == nil {
+	detector := e.effectiveLabelDetector(ctx)
+	if detector == nil {
 		return nil
 	}
-	labels, quotaDetails, labelErr := e.labelDetector.DetectLabels(ctx, kind, name, namespace, result.OwnerChain)
+	labels, quotaDetails, labelErr := detector.DetectLabels(ctx, kind, name, namespace, result.OwnerChain)
 	if labelErr != nil {
 		if isForbiddenError(labelErr) {
 			return fmt.Errorf("%w: DetectLabels %s/%s in %s: %w", ErrRBACForbidden, kind, name, namespace, labelErr)

--- a/internal/kubernautagent/enrichment/label_detector.go
+++ b/internal/kubernautagent/enrichment/label_detector.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -35,10 +36,7 @@ var (
 	pdbGVR           = schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"}
 	networkPolicyGVR = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}
 	resourceQuotaGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "resourcequotas"}
-	namespaceGVR     = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
 	pvcGVR           = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
-	storageClassGVR  = schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"}
-	vmGVR            = schema.GroupVersionResource{Group: "kubevirt.io", Version: "v1", Resource: "virtualmachines"}
 )
 
 // cnvKinds lists Kubernetes kinds that indicate a CNV/KubeVirt workload.
@@ -63,6 +61,7 @@ var provisionerToBackend = map[string]string{
 // including non-workload root owners like ConfigMap, Secret, and Service (#679).
 type LabelDetector struct {
 	dynClient dynamic.Interface
+	reader    client.Reader
 	mapper    meta.RESTMapper
 	logger    logr.Logger
 }
@@ -71,6 +70,13 @@ type LabelDetector struct {
 // and REST mapper. The mapper resolves any Kubernetes kind to its GVR (#679).
 func NewLabelDetector(dynClient dynamic.Interface, mapper meta.RESTMapper, logger logr.Logger) *LabelDetector {
 	return &LabelDetector{dynClient: dynClient, mapper: mapper, logger: logger}
+}
+
+// NewLabelDetectorWithReader creates a detector backed by a controller-runtime
+// reader. This is used for fleet overlays, where reads are routed through MCP
+// rather than a local dynamic client.
+func NewLabelDetectorWithReader(reader client.Reader, mapper meta.RESTMapper, logger logr.Logger) *LabelDetector {
+	return &LabelDetector{reader: reader, mapper: mapper, logger: logger}
 }
 
 // DetectLabels detects infrastructure characteristics for the given resource,
@@ -161,13 +167,54 @@ func (d *LabelDetector) fetchResource(ctx context.Context, kind, name, namespace
 	if err != nil {
 		return nil, fmt.Errorf("cannot resolve GVR for kind %q: %w", kind, err)
 	}
-	var client dynamic.ResourceInterface
-	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
-		client = d.dynClient.Resource(mapping.Resource).Namespace(namespace)
-	} else {
-		client = d.dynClient.Resource(mapping.Resource)
+	if d.reader != nil {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(mapping.GroupVersionKind)
+		if err := d.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
+			return nil, err
+		}
+		return obj, nil
 	}
-	return client.Get(ctx, name, metav1.GetOptions{})
+	var resourceClient dynamic.ResourceInterface
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		resourceClient = d.dynClient.Resource(mapping.Resource).Namespace(namespace)
+	} else {
+		resourceClient = d.dynClient.Resource(mapping.Resource)
+	}
+	return resourceClient.Get(ctx, name, metav1.GetOptions{})
+}
+
+func (d *LabelDetector) listResource(ctx context.Context, gvr schema.GroupVersionResource, namespace string) ([]unstructured.Unstructured, error) {
+	if d.reader == nil {
+		var resource dynamic.ResourceInterface
+		if namespace != "" {
+			resource = d.dynClient.Resource(gvr).Namespace(namespace)
+		} else {
+			resource = d.dynClient.Resource(gvr)
+		}
+		list, err := resource.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return list.Items, nil
+	}
+
+	gvk, err := d.mapper.KindFor(gvr)
+	if err != nil {
+		return nil, fmt.Errorf("resolve kind for %s: %w", gvr, err)
+	}
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List",
+	})
+	var opts []client.ListOption
+	if namespace != "" {
+		opts = append(opts, client.InNamespace(namespace))
+	}
+	if err := d.reader.List(ctx, list, opts...); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
 }
 
 // resolveMapping returns the full RESTMapping for a Kind, including Scope.
@@ -193,7 +240,7 @@ func (d *LabelDetector) resolveMapping(kind string) (*meta.RESTMapping, error) {
 // fetchNamespace retrieves the Namespace object for namespace-level label/annotation
 // checks per DD-KA-018. Returns nil on any error (best-effort, no failedDetections).
 func (d *LabelDetector) fetchNamespace(ctx context.Context, namespace string) *unstructured.Unstructured {
-	obj, err := d.dynClient.Resource(namespaceGVR).Get(ctx, namespace, metav1.GetOptions{})
+	obj, err := d.fetchResource(ctx, "Namespace", namespace, "")
 	if err != nil {
 		d.logger.Error(err, "label detection: namespace fetch failed (best-effort skip)", "namespace", namespace)
 		return nil
@@ -366,14 +413,14 @@ func (d *LabelDetector) detectHPA(ctx context.Context, ownerChain []OwnerChainEn
 		targetNames[kindName{entry.Kind, entry.Name}] = true
 	}
 
-	list, err := d.dynClient.Resource(hpaGVR).Namespace(rootNS).List(ctx, metav1.ListOptions{})
+	list, err := d.listResource(ctx, hpaGVR, rootNS)
 	if err != nil {
 		d.logger.Error(err, "label detection: HPA list failed", "namespace", rootNS)
 		*failed = append(*failed, "hpaEnabled")
 		return
 	}
-	for i := range list.Items {
-		targetKind, targetName := extractScaleTargetRef(&list.Items[i])
+	for i := range list {
+		targetKind, targetName := extractScaleTargetRef(&list[i])
 		if targetNames[kindName{targetKind, targetName}] {
 			result.HPAEnabled = true
 			return
@@ -406,14 +453,14 @@ func (d *LabelDetector) detectPDB(ctx context.Context, rootObj *unstructured.Uns
 	if len(podLabels) == 0 && len(rootLabels) == 0 {
 		return
 	}
-	list, err := d.dynClient.Resource(pdbGVR).Namespace(rootNS).List(ctx, metav1.ListOptions{})
+	list, err := d.listResource(ctx, pdbGVR, rootNS)
 	if err != nil {
 		d.logger.Error(err, "label detection: PDB list failed", "namespace", rootNS)
 		*failed = append(*failed, "pdbProtected")
 		return
 	}
-	for i := range list.Items {
-		matchLabels := extractPDBMatchLabels(&list.Items[i])
+	for i := range list {
+		matchLabels := extractPDBMatchLabels(&list[i])
 		if len(matchLabels) == 0 {
 			continue
 		}
@@ -461,13 +508,13 @@ func (d *LabelDetector) detectNetworkPolicy(ctx context.Context, namespace strin
 		*failed = append(*failed, "networkIsolated")
 		return
 	}
-	list, err := d.dynClient.Resource(networkPolicyGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	list, err := d.listResource(ctx, networkPolicyGVR, namespace)
 	if err != nil {
 		d.logger.Error(err, "label detection: NetworkPolicy list failed", "namespace", namespace)
 		*failed = append(*failed, "networkIsolated")
 		return
 	}
-	result.NetworkIsolated = len(list.Items) > 0
+	result.NetworkIsolated = len(list) > 0
 }
 
 // detectResourceQuota checks for ResourceQuota presence and builds a typed
@@ -477,17 +524,17 @@ func (d *LabelDetector) detectResourceQuota(ctx context.Context, namespace strin
 		*failed = append(*failed, "resourceQuotaConstrained")
 		return nil
 	}
-	list, err := d.dynClient.Resource(resourceQuotaGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	list, err := d.listResource(ctx, resourceQuotaGVR, namespace)
 	if err != nil {
 		d.logger.Error(err, "label detection: ResourceQuota list failed", "namespace", namespace)
 		*failed = append(*failed, "resourceQuotaConstrained")
 		return nil
 	}
-	if len(list.Items) == 0 {
+	if len(list) == 0 {
 		return nil
 	}
 	result.ResourceQuotaConstrained = true
-	return summarizeQuotas(list.Items)
+	return summarizeQuotas(list)
 }
 
 // cnvDetectionTarget groups the owner-chain identifiers needed by detectCNV.
@@ -555,7 +602,7 @@ func (d *LabelDetector) detectLiveMigratable(ctx context.Context, rootKind, root
 		return
 	}
 
-	vmObj, err := d.dynClient.Resource(vmGVR).Namespace(vmNS).Get(ctx, vmName, metav1.GetOptions{})
+	vmObj, err := d.fetchResource(ctx, "VirtualMachine", vmName, vmNS)
 	if err != nil {
 		d.logger.Error(err, "CNV: VirtualMachine fetch failed", "name", vmName, "namespace", vmNS)
 		*failed = append(*failed, "liveMigratable")
@@ -575,13 +622,13 @@ func (d *LabelDetector) listNamespacePVCs(ctx context.Context, namespace string,
 		*failed = append(*failed, "cdiManaged", "storageBackend")
 		return nil
 	}
-	list, err := d.dynClient.Resource(pvcGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	list, err := d.listResource(ctx, pvcGVR, namespace)
 	if err != nil {
 		d.logger.Error(err, "CNV: PVC list failed", "namespace", namespace)
 		*failed = append(*failed, "cdiManaged", "storageBackend")
 		return nil
 	}
-	return list.Items
+	return list
 }
 
 // detectCDIManaged checks PVC annotations for CDI import markers.
@@ -605,7 +652,7 @@ func (d *LabelDetector) detectStorageBackend(ctx context.Context, pvcs []unstruc
 		if !found || scName == "" {
 			continue
 		}
-		scObj, err := d.dynClient.Resource(storageClassGVR).Get(ctx, scName, metav1.GetOptions{})
+		scObj, err := d.fetchResource(ctx, "StorageClass", scName, "")
 		if err != nil {
 			d.logger.Error(err, "CNV: StorageClass fetch failed", "name", scName)
 			scFetchError = true

--- a/internal/kubernautagent/mcp/tools/complete_no_action_test.go
+++ b/internal/kubernautagent/mcp/tools/complete_no_action_test.go
@@ -104,6 +104,29 @@ var _ = Describe("kubernaut_complete_no_action tool — #2076 (v1.6 clone of #20
 		Expect(completedResult).NotTo(BeNil(), "the normal, non-raced path must still complete the HTTP session exactly once")
 	})
 
+	It("UT-KA-2365-001 (AU-3): presentation recovery exhaustion escalates for human review", func() {
+		sessions := &mockSessionManager{
+			isActive:        true,
+			getDriverResult: &mcpinternal.InteractiveSession{SessionID: "sess-2365", ActingUser: mcpinternal.UserInfo{Username: "alice"}},
+		}
+		completer := &mockHTTPCompleter{}
+		tool := mcptools.NewCompleteNoActionTool(sessions,
+			mcptools.WithCompleteNoActionHTTPCompleter(completer))
+
+		output, err := tool.Handle(context.Background(), mcptools.CompleteNoActionInput{
+			RRID:             "rr-2365",
+			EscalationReason: "presentation_recovery_exhausted",
+		}, mcpinternal.UserInfo{Username: "alice"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output.Status).To(Equal("escalated"))
+
+		_, result := completer.getCompleted()
+		Expect(result).NotTo(BeNil())
+		Expect(result.HumanReviewNeeded).To(BeTrue())
+		Expect(result.HumanReviewReason).To(Equal("operator_escalation"))
+		Expect(result.Reason).To(Equal("presentation_recovery_exhausted"))
+	})
+
 	It("UT-KA-2075-002d: an inactive session still errors exactly as before when no tombstone is configured (optional dependency, no regression)", func() {
 		sessions := &mockSessionManager{isActive: false}
 		tool := mcptools.NewCompleteNoActionTool(sessions)

--- a/internal/kubernautagent/tools/custom/fleet_label_detector_test.go
+++ b/internal/kubernautagent/tools/custom/fleet_label_detector_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package custom_test
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/tools/custom"
+)
+
+type fleetLabelTool struct {
+	list bool
+}
+
+func (t *fleetLabelTool) Name() string {
+	if t.list {
+		return "resources_list"
+	}
+	return "resources_get"
+}
+func (t *fleetLabelTool) Description() string         { return "fleet label detector test tool" }
+func (t *fleetLabelTool) Parameters() json.RawMessage { return json.RawMessage(`{}`) }
+func (t *fleetLabelTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var request map[string]string
+	_ = json.Unmarshal(args, &request)
+	if t.list {
+		switch request["kind"] {
+		case "HorizontalPodAutoscaler":
+			return `{"items":[{"kind":"HorizontalPodAutoscaler","spec":{"scaleTargetRef":{"kind":"VirtualMachine","name":"vm-1"}}}]}`, nil
+		case "PodDisruptionBudget":
+			return `{"items":[{"kind":"PodDisruptionBudget","spec":{"selector":{"matchLabels":{"app":"vm"}}}}]}`, nil
+		case "NetworkPolicy":
+			return `{"items":[{"kind":"NetworkPolicy","metadata":{"name":"isolate"}}]}`, nil
+		case "ResourceQuota":
+			return `{"items":[{"kind":"ResourceQuota","status":{"hard":{"pods":"10"},"used":{"pods":"1"}}}]}`, nil
+		case "PersistentVolumeClaim":
+			return `{"items":[{"kind":"PersistentVolumeClaim","metadata":{"annotations":{"cdi.kubevirt.io/storage.import.endpoint":"https://example.invalid/disk"}},"spec":{"storageClassName":"remote-sc"}}]}`, nil
+		default:
+			return `{"items":[]}`, nil
+		}
+	}
+	if request["kind"] == "StorageClass" {
+		return `{"kind":"StorageClass","metadata":{"name":"remote-sc"},"provisioner":"topolvm.io"}`, nil
+	}
+	return `{"kind":"VirtualMachine","metadata":{"name":"vm-1","namespace":"remote-ns","labels":{"app":"vm"}},"spec":{"template":{"spec":{"evictionStrategy":"LiveMigrate"}}}}`, nil
+}
+
+func fleetLabelMapper() meta.RESTMapper {
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+		{Group: "", Version: "v1"}, {Group: "autoscaling", Version: "v2"},
+		{Group: "policy", Version: "v1"}, {Group: "networking.k8s.io", Version: "v1"},
+		{Group: "kubevirt.io", Version: "v1"}, {Group: "storage.k8s.io", Version: "v1"},
+	})
+	mapper.Add(schema.GroupVersionKind{Version: "v1", Kind: "Namespace"}, meta.RESTScopeRoot)
+	mapper.Add(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"}, meta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"}, meta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"}, meta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{Version: "v1", Kind: "ResourceQuota"}, meta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{Version: "v1", Kind: "PersistentVolumeClaim"}, meta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{Group: "kubevirt.io", Version: "v1", Kind: "VirtualMachine"}, meta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{Group: "storage.k8s.io", Version: "v1", Kind: "StorageClass"}, meta.RESTScopeRoot)
+	return mapper
+}
+
+var _ = Describe("IT-KA-2345: fleet LabelDetector", Label("it", "fleet", "2345"), func() {
+	It("detects list-backed categories and storage details from the remote cluster", func() {
+		getTool := &fleetLabelTool{}
+		listTool := &fleetLabelTool{list: true}
+		detector := custom.NewOverlayLabelDetector(getTool, listTool, fleetLabelMapper(), logr.Discard())
+
+		labels, quotas, err := detector.DetectLabels(context.Background(), "VirtualMachine", "vm-1", "remote-ns", []enrichment.OwnerChainEntry{{Kind: "VirtualMachine", Name: "vm-1", Namespace: "remote-ns"}})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(labels.HPAEnabled).To(BeTrue())
+		Expect(labels.PDBProtected).To(BeTrue())
+		Expect(labels.NetworkIsolated).To(BeTrue())
+		Expect(labels.ResourceQuotaConstrained).To(BeTrue())
+		Expect(labels.CDIManaged).To(BeTrue())
+		Expect(labels.StorageBackend).To(Equal("lvms"))
+		Expect(quotas).To(HaveKey("pods"))
+	})
+})

--- a/internal/kubernautagent/tools/custom/fleet_resource_context.go
+++ b/internal/kubernautagent/tools/custom/fleet_resource_context.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,7 +49,8 @@ import (
 // server-side kind-only discovery to infer it from (confirmed against
 // upstream kubernetes-mcp-server, see plan preflight).
 type overlayClientReader struct {
-	getTool tools.Tool
+	getTool  tools.Tool
+	listTool tools.Tool
 }
 
 var _ client.Reader = (*overlayClientReader)(nil)
@@ -56,11 +58,18 @@ var _ client.Reader = (*overlayClientReader)(nil)
 // NewOverlayClientReader builds a client.Reader backed by the fleet
 // overlay's resources_get tool. Exported for the fleet_resource_context_test.go
 // unit tests; production callers should go through NewOverlayK8sClient.
-func NewOverlayClientReader(getTool tools.Tool) client.Reader {
-	return &overlayClientReader{getTool: getTool}
+func NewOverlayClientReader(getTool tools.Tool, listTools ...tools.Tool) client.Reader {
+	var listTool tools.Tool
+	if len(listTools) > 0 {
+		listTool = listTools[0]
+	}
+	return &overlayClientReader{getTool: getTool, listTool: listTool}
 }
 
 func (r *overlayClientReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	if r.getTool == nil {
+		return fmt.Errorf("overlayClientReader.Get: resources_get tool is not available")
+	}
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	if gvk.Kind == "" {
 		return fmt.Errorf("overlayClientReader.Get: target object has no GroupVersionKind set")
@@ -119,15 +128,64 @@ func asRemoteNotFound(err error, gvk schema.GroupVersionKind, name string) error
 	return apierrors.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: strings.ToLower(gvk.Kind)}, name)
 }
 
-// List is intentionally not supported: overlayClientReader only backs
-// ownerchain.K8sOwnerResolver's remote-cluster resolution here, which only
-// ever calls Get directly. The resolver's one internal List call (the
-// optional Service→Pod special case) is gated on WithFallbackReader, which
-// NewOverlayK8sClient deliberately never sets — KA has no local fallback
-// reader for a remote cluster — so this path is unreachable in practice,
-// not silently degraded.
-func (r *overlayClientReader) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
-	return fmt.Errorf("overlayClientReader: List not supported (owner-chain resolution only requires Get)")
+// List routes controller-runtime list requests through the overlay's
+// resources_list tool. It supports the namespace and label-selector options
+// used by LabelDetector; other list options are intentionally ignored.
+func (r *overlayClientReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if r.listTool == nil {
+		return fmt.Errorf("overlayClientReader.List: not supported, resources_list tool is not available")
+	}
+	gvk := list.GetObjectKind().GroupVersionKind()
+	if gvk.Kind == "" {
+		return fmt.Errorf("overlayClientReader.List: target list has no GroupVersionKind set")
+	}
+	itemKind := strings.TrimSuffix(gvk.Kind, "List")
+	args := map[string]any{
+		"kind":       itemKind,
+		"apiVersion": gvk.GroupVersion().String(),
+	}
+	listOpts := client.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(&listOpts)
+	}
+	if listOpts.Namespace != "" {
+		args["namespace"] = listOpts.Namespace
+	}
+	if listOpts.LabelSelector != nil && listOpts.LabelSelector.String() != "" {
+		args["labelSelector"] = listOpts.LabelSelector.String()
+	}
+	argsJSON, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("overlayClientReader.List: marshal args for %s: %w", itemKind, err)
+	}
+	text, err := r.listTool.Execute(ctx, argsJSON)
+	if err != nil {
+		return fmt.Errorf("overlayClientReader.List: list %s: %w", itemKind, err)
+	}
+	fetched, err := mcpclient.ParseUnstructuredResponse(text)
+	if err != nil {
+		return fmt.Errorf("overlayClientReader.List: parse response for %s: %w", itemKind, err)
+	}
+	rawItems, ok, err := unstructured.NestedSlice(fetched.Object, "items")
+	if err != nil {
+		return fmt.Errorf("overlayClientReader.List: parse items for %s: %w", itemKind, err)
+	}
+	if !ok {
+		rawItems = nil
+	}
+	items := make([]unstructured.Unstructured, 0, len(rawItems))
+	for i, raw := range rawItems {
+		item, ok := raw.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("overlayClientReader.List: item %d for %s is not an object", i, itemKind)
+		}
+		items = append(items, unstructured.Unstructured{Object: item})
+	}
+	if target, ok := list.(*unstructured.UnstructuredList); ok {
+		target.Items = items
+		return nil
+	}
+	return fmt.Errorf("overlayClientReader.List: unsupported list type %T", list)
 }
 
 // overlayK8sClient implements enrichment.K8sClient by resolving owner-chain
@@ -146,8 +204,14 @@ var _ enrichment.K8sClient = (*overlayK8sClient)(nil)
 // fleet overlay's resources_get tool — see cmd/kubernautagent/toolregistry.go's
 // genericNameTool). No WithRegistry/WithFallbackReader: KA has neither a
 // live APIResourceRegistry nor a local fallback client for a remote cluster.
-func NewOverlayK8sClient(getTool tools.Tool, logger logr.Logger) enrichment.K8sClient {
-	return &overlayK8sClient{reader: NewOverlayClientReader(getTool), logger: logger}
+func NewOverlayK8sClient(getTool tools.Tool, logger logr.Logger, listTools ...tools.Tool) enrichment.K8sClient {
+	return &overlayK8sClient{reader: NewOverlayClientReader(getTool, listTools...), logger: logger}
+}
+
+// NewOverlayLabelDetector creates a detector whose Get/List calls are routed
+// through the fleet overlay instead of the hub dynamic client.
+func NewOverlayLabelDetector(getTool tools.Tool, listTool tools.Tool, mapper meta.RESTMapper, logger logr.Logger) *enrichment.LabelDetector {
+	return enrichment.NewLabelDetectorWithReader(NewOverlayClientReader(getTool, listTool), mapper, logger)
 }
 
 // GetOwnerChain resolves the top-level controller owner of kind/name/namespace

--- a/internal/kubernautagent/tools/custom/fleet_resource_context.go
+++ b/internal/kubernautagent/tools/custom/fleet_resource_context.go
@@ -162,24 +162,9 @@ func (r *overlayClientReader) List(ctx context.Context, list client.ObjectList, 
 	if err != nil {
 		return fmt.Errorf("overlayClientReader.List: list %s: %w", itemKind, err)
 	}
-	fetched, err := mcpclient.ParseUnstructuredResponse(text)
+	items, err := mcpclient.ParseUnstructuredListResponse(text)
 	if err != nil {
 		return fmt.Errorf("overlayClientReader.List: parse response for %s: %w", itemKind, err)
-	}
-	rawItems, ok, err := unstructured.NestedSlice(fetched.Object, "items")
-	if err != nil {
-		return fmt.Errorf("overlayClientReader.List: parse items for %s: %w", itemKind, err)
-	}
-	if !ok {
-		rawItems = nil
-	}
-	items := make([]unstructured.Unstructured, 0, len(rawItems))
-	for i, raw := range rawItems {
-		item, ok := raw.(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("overlayClientReader.List: item %d for %s is not an object", i, itemKind)
-		}
-		items = append(items, unstructured.Unstructured{Object: item})
 	}
 	if target, ok := list.(*unstructured.UnstructuredList); ok {
 		target.Items = items

--- a/internal/kubernautagent/tools/custom/fleet_resource_context_test.go
+++ b/internal/kubernautagent/tools/custom/fleet_resource_context_test.go
@@ -201,6 +201,19 @@ var _ = Describe("UT-KA-FLEET-031: overlayClientReader (BR-INTEGRATION-1489)", f
 			HaveKeyWithValue("labelSelector", "app=api"),
 		))
 	})
+
+	It("IT-KA-MCP-LIST-001 [AC-4][SC-7]: reads a top-level YAML list through the production overlay reader", func() {
+		listTool := &fakeListTool{responseJSON: "- apiVersion: apps/v1\n  kind: Deployment\n  metadata:\n    name: api-server\n    namespace: production\n"}
+		reader := custom.NewOverlayClientReader(&fakeGetTool{}, listTool)
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DeploymentList"})
+
+		err := reader.List(context.Background(), list, client.InNamespace("production"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.Items).To(HaveLen(1))
+		Expect(list.Items[0].GetName()).To(Equal("api-server"))
+		Expect(list.Items[0].GetNamespace()).To(Equal("production"))
+	})
 })
 
 // UT-KA-FLEET-032: overlayK8sClient wraps the moved ownerchain.K8sOwnerResolver

--- a/internal/kubernautagent/tools/custom/fleet_resource_context_test.go
+++ b/internal/kubernautagent/tools/custom/fleet_resource_context_test.go
@@ -43,6 +43,26 @@ type fakeGetTool struct {
 	calls        int
 }
 
+type fakeListTool struct {
+	responseJSON string
+	err          error
+
+	capturedArgs map[string]any
+	calls        int
+}
+
+func (f *fakeListTool) Name() string                { return "resources_list" }
+func (f *fakeListTool) Description() string         { return "fake resources_list" }
+func (f *fakeListTool) Parameters() json.RawMessage { return json.RawMessage(`{}`) }
+func (f *fakeListTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	f.calls++
+	_ = json.Unmarshal(args, &f.capturedArgs)
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.responseJSON, nil
+}
+
 func (f *fakeGetTool) Name() string                { return "resources_get" }
 func (f *fakeGetTool) Description() string         { return "fake resources_get" }
 func (f *fakeGetTool) Parameters() json.RawMessage { return json.RawMessage(`{}`) }
@@ -157,11 +177,29 @@ var _ = Describe("UT-KA-FLEET-031: overlayClientReader (BR-INTEGRATION-1489)", f
 			"UT-KA-FLEET-033: a non-not-found error must not be misclassified")
 	})
 
-	It("returns a clear not-supported error for List", func() {
+	It("returns a clear not-supported error for List when resources_list is unavailable", func() {
 		reader := custom.NewOverlayClientReader(&fakeGetTool{})
 		err := reader.List(context.Background(), &unstructured.UnstructuredList{})
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not supported"))
+	})
+
+	It("routes List through resources_list with GVK, namespace, and label selector", func() {
+		listTool := &fakeListTool{responseJSON: `{"apiVersion":"apps/v1","kind":"DeploymentList","items":[{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"api-server","namespace":"production"}}]}`}
+		reader := custom.NewOverlayClientReader(&fakeGetTool{}, listTool)
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DeploymentList"})
+
+		err := reader.List(context.Background(), list, client.InNamespace("production"), client.MatchingLabels{"app": "api"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(list.Items).To(HaveLen(1))
+		Expect(list.Items[0].GetName()).To(Equal("api-server"))
+		Expect(listTool.capturedArgs).To(And(
+			HaveKeyWithValue("kind", "Deployment"),
+			HaveKeyWithValue("apiVersion", "apps/v1"),
+			HaveKeyWithValue("namespace", "production"),
+			HaveKeyWithValue("labelSelector", "app=api"),
+		))
 	})
 })
 

--- a/internal/kubernautagent/tools/custom/resource_context.go
+++ b/internal/kubernautagent/tools/custom/resource_context.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
@@ -91,6 +92,17 @@ func ResolveK8sClient(ctx context.Context, hub enrichment.K8sClient, logger logr
 	}
 	clusterID, _ := audit.ClusterIDFromContext(ctx)
 	return noopK8sClient{clusterID: clusterID}
+}
+
+// ResolveLabelDetector applies the same per-request fleet routing as
+// ResolveK8sClient. A fleet overlay is never allowed to fall back to the hub
+// detector, because that would report labels from the wrong cluster.
+func ResolveLabelDetector(ctx context.Context, hub *enrichment.LabelDetector, mapper meta.RESTMapper, logger logr.Logger) *enrichment.LabelDetector {
+	overlay, hasOverlay := investigator.FleetOverlayFromContext(ctx)
+	if !hasOverlay {
+		return hub
+	}
+	return NewOverlayLabelDetector(overlay[mcpclient.ToolGet], overlay[mcpclient.ToolList], mapper, logger)
 }
 
 func computeSpecHash(ctx context.Context, logger logr.Logger, k8s enrichment.K8sClient, kind, name, namespace, toolName string) string {

--- a/pkg/aianalysis/handlers/response_processor.go
+++ b/pkg/aianalysis/handlers/response_processor.go
@@ -124,6 +124,10 @@ func (p *ResponseProcessor) ProcessAgentSessionResult(ctx context.Context, analy
 	// BR-AI-601: Map alignment verdict from KA to CRD status for ALL response paths.
 	p.mapAlignmentVerdict(analysis, res)
 
+	// ADR-056: Persist detected labels before routing any response outcome so
+	// terminal paths retain the same post-RCA context as normal success.
+	p.populatePostRCAContext(analysis, res.DetectedLabels)
+
 	// Check if NeedsHumanReview is set
 	needsHumanReview := res.NeedsHumanReview
 	hasSelectedWorkflow := res.SelectedWorkflow != nil
@@ -221,9 +225,6 @@ func (p *ResponseProcessor) finalizeSuccessfulInvestigation(analysis *aianalysis
 	im := analysis.Status.EnsureInvestigationMetadata()
 	im.Warnings = res.Warnings
 	im.InvestigationID = res.IncidentID
-
-	// ADR-056: Extract detected_labels from KA response into PostRCAContext
-	p.populatePostRCAContext(analysis, res.DetectedLabels)
 
 	// ADR-055: TargetInOwnerChain removed. remediationTarget is now a first-class
 	// LLM RCA output, not derived from pre-computed owner chain.

--- a/pkg/aianalysis/response_processor_status_test.go
+++ b/pkg/aianalysis/response_processor_status_test.go
@@ -146,6 +146,22 @@ var _ = Describe("ResponseProcessor Terminal Handler Status Completeness (#610)"
 			metav1.ConditionFalse, "NotApplicable")
 	})
 
+	It("UT-AA-056-020 [AU-3][ASVS V11]: persists detected labels on the problem-resolved path", func() {
+		analysis := createAnalysisWithStartedAt()
+		res := buildResultWithDetectedLabels(map[string]interface{}{
+			"hpaEnabled":   true,
+			"pdbProtected": true,
+		})
+		res.Warnings = []string{"Problem self-resolved: alert condition no longer active"}
+		res.SelectedWorkflow = nil
+
+		_, err := processor.ProcessAgentSessionResult(ctx, analysis, res)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(analysis.Status.PostRCAContext).ToNot(BeNil())
+		Expect(analysis.Status.PostRCAContext.DetectedLabels.HPAEnabled).To(BeTrue())
+		Expect(analysis.Status.PostRCAContext.DetectedLabels.PDBProtected).To(BeTrue())
+	})
+
 	// ═══════════════════════════════════════════════════════════════════════
 	// UT-AA-610-003: handleNotActionableFromIncident
 	// ═══════════════════════════════════════════════════════════════════════
@@ -180,6 +196,20 @@ var _ = Describe("ResponseProcessor Terminal Handler Status Completeness (#610)"
 			metav1.ConditionFalse, "NotApplicable")
 	})
 
+	It("UT-AA-056-021 [AU-3][ASVS V11]: persists detected labels on the not-actionable path", func() {
+		analysis := createAnalysisWithStartedAt()
+		res := buildResultWithDetectedLabels(map[string]interface{}{"hpaEnabled": true})
+		res.Warnings = []string{"Alert not actionable: condition is benign"}
+		res.SelectedWorkflow = nil
+		isActionable := false
+		res.IsActionable = &isActionable
+
+		_, err := processor.ProcessAgentSessionResult(ctx, analysis, res)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(analysis.Status.PostRCAContext).ToNot(BeNil())
+		Expect(analysis.Status.PostRCAContext.DetectedLabels.HPAEnabled).To(BeTrue())
+	})
+
 	// ═══════════════════════════════════════════════════════════════════════
 	// UT-AA-610-004: handleNoWorkflowTerminalFailure
 	// ═══════════════════════════════════════════════════════════════════════
@@ -212,6 +242,18 @@ var _ = Describe("ResponseProcessor Terminal Handler Status Completeness (#610)"
 			metav1.ConditionFalse, "NotApplicable")
 	})
 
+	It("UT-AA-056-022 [AU-3][ASVS V11]: persists detected labels on the no-workflow failure path", func() {
+		analysis := createAnalysisWithStartedAt()
+		res := buildResultWithDetectedLabels(map[string]interface{}{"pdbProtected": true})
+		res.SelectedWorkflow = nil
+		res.Confidence = 0.3
+
+		_, err := processor.ProcessAgentSessionResult(ctx, analysis, res)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(analysis.Status.PostRCAContext).ToNot(BeNil())
+		Expect(analysis.Status.PostRCAContext.DetectedLabels.PDBProtected).To(BeTrue())
+	})
+
 	// ═══════════════════════════════════════════════════════════════════════
 	// UT-AA-610-005: handleLowConfidenceFailure
 	// ═══════════════════════════════════════════════════════════════════════
@@ -242,6 +284,29 @@ var _ = Describe("ResponseProcessor Terminal Handler Status Completeness (#610)"
 			metav1.ConditionFalse, aianalysis.ReasonWorkflowResolutionFailed)
 		assertCondition(analysis.Status.Conditions, aianalysis.ConditionApprovalRequired,
 			metav1.ConditionFalse, "NotApplicable")
+	})
+
+	It("UT-AA-056-023 [AU-3][ASVS V11]: persists detected labels on the low-confidence path", func() {
+		analysis := createAnalysisWithStartedAt()
+		res := buildResultWithDetectedLabels(map[string]interface{}{"hpaEnabled": true})
+		res.Confidence = 0.3
+
+		_, err := processor.ProcessAgentSessionResult(ctx, analysis, res)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(analysis.Status.PostRCAContext).ToNot(BeNil())
+		Expect(analysis.Status.PostRCAContext.DetectedLabels.HPAEnabled).To(BeTrue())
+	})
+
+	It("UT-AA-056-024 [AU-3][ASVS V11]: persists detected labels on the human-review path", func() {
+		analysis := createAnalysisWithStartedAt()
+		res := buildResultWithDetectedLabels(map[string]interface{}{"stateful": true})
+		res.NeedsHumanReview = true
+		res.HumanReviewReason = "parameter_validation_failed"
+
+		_, err := processor.ProcessAgentSessionResult(ctx, analysis, res)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(analysis.Status.PostRCAContext).ToNot(BeNil())
+		Expect(analysis.Status.PostRCAContext.DetectedLabels.Stateful).To(BeTrue())
 	})
 
 	// ═══════════════════════════════════════════════════════════════════════

--- a/pkg/apifrontend/agent/ambient_fields_2364_it_test.go
+++ b/pkg/apifrontend/agent/ambient_fields_2364_it_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	k8sfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	eav1alpha1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// IT #2364: proves fleet-hinted tool calls (ambient cluster_id/rr_id/session_id
+// propagated by the model from console fleet hints and cross-phase
+// preservation) survive the REAL ADK functiontool schema validation -- the
+// exact step that killed 15 turns live. Mirrors the 2092 IT's verbatim
+// Flow.callTool sequence: BeforeToolCallbacks first, then tool.Run on the
+// same map, neither mocked.
+var _ = Describe("IT #2364 — fleet-hinted calls through real ADK schema validation", func() {
+	newToolCtx := func() statefulToolContext {
+		state := newMapState()
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "alice", Groups: []string{"sre"},
+		})
+		return statefulToolContext{
+			fakeToolContext: fakeToolContext{Context: ctx},
+			state:           state,
+		}
+	}
+
+	It("IT-2364-001 (SI-10, AU-3): fleet-hinted present_decision survives real validation and presents", func() {
+		presentTool, err := tools.NewPresentDecisionTool()
+		Expect(err).NotTo(HaveOccurred())
+		runnable, ok := presentTool.(runnableTool)
+		Expect(ok).To(BeTrue())
+
+		toolCtx := newToolCtx()
+		before, after := NewPhaseGuardForTest()
+
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-2364-it", "status": "completed",
+			"summary": "Memory pressure on spoke worker nodes.",
+		}, nil)
+
+		args := map[string]any{
+			"session_id": "sess-2364-it",
+			"summary":    "Memory leak on spoke cluster worker.",
+			"rca": map[string]any{
+				"severity": "critical", "confidence": 0.9,
+				"target": "Deployment/worker",
+			},
+			"options": []any{
+				map[string]any{
+					"workflow_id": "wf-1", "name": "spoke-memory-fix",
+					"description": "Raise memory limits on the spoke",
+				},
+			},
+			// Ambient fields the live model propagated; pre-fix ADK rejected
+			// the call with: validating root: unexpected additional
+			// properties ["cluster_id"] (14x) / ["rr_id" "cluster_id"] (1x).
+			"cluster_id": "spoke",
+			"rr_id":      "payments/rr-2364",
+		}
+
+		cbResult, cbErr := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(cbErr).NotTo(HaveOccurred())
+		Expect(cbResult).To(BeNil(), "present_decision must still execute (AU-3 artifact mandate)")
+
+		result, runErr := runnable.Run(toolCtx, args)
+		Expect(runErr).NotTo(HaveOccurred(),
+			"#2364: real ADK schema validation must accept fleet-hinted present_decision args")
+		Expect(result["presented"]).To(BeTrue())
+		message, _ := result["message"].(string)
+		Expect(message).To(ContainSubstring("spoke-memory-fix"),
+			"the decision must actually reach HandlePresentDecision, not just pass validation")
+	})
+
+	It("IT-2364-002 (SI-10, BR-FLEET-003): fleet-hinted discover/select survive real validation", func() {
+		mockMCP := &ka.MockMCPClient{
+			DiscoverWorkflowsFn: func(_ context.Context, _ ka.DiscoverWorkflowsArgs) (*ka.DiscoverWorkflowsResult, error) {
+				return &ka.DiscoverWorkflowsResult{Workflows: []ka.DiscoveredWorkflow{
+					{WorkflowID: "wf-1", Name: "spoke-memory-fix"},
+				}}, nil
+			},
+			SelectWorkflowFn: func(_ context.Context, _ ka.SelectWorkflowArgs) (*ka.SelectWorkflowResult, error) {
+				return &ka.SelectWorkflowResult{Status: "selected"}, nil
+			},
+		}
+
+		toolCtx := newToolCtx()
+		before, after := NewPhaseGuardForTest()
+
+		// Successful investigate activates the driver session discover/select require.
+		_, invErr := after(toolCtx, fakeTool{name: "kubernaut_investigate"},
+			map[string]any{
+				"rr_id":            "payments/rr-2364",
+				"interaction_mode": session.InteractionModeFullRemediationAutonomous,
+			},
+			map[string]any{
+				"session_id": "sess-2364-it", "rr_id": "payments/rr-2364",
+				"status": "completed", "summary": "Memory pressure on spoke workers.",
+			}, nil)
+		Expect(invErr).NotTo(HaveOccurred())
+
+		discoverTool, err := tools.NewDiscoverWorkflowsTool(mockMCP)
+		Expect(err).NotTo(HaveOccurred())
+		discoverRunnable, ok := discoverTool.(runnableTool)
+		Expect(ok).To(BeTrue())
+
+		discArgs := map[string]any{
+			"rr_id": "payments/rr-2364",
+			// Ambient fleet + preservation fields; pre-fix rejected.
+			"cluster_id": "spoke",
+			"session_id": "sess-2364-it",
+		}
+		cbResult, cbErr := before(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, discArgs)
+		Expect(cbErr).NotTo(HaveOccurred())
+		Expect(cbResult).To(BeNil())
+		discResult, runErr := discoverRunnable.Run(toolCtx, discArgs)
+		Expect(runErr).NotTo(HaveOccurred(),
+			"#2364: real ADK schema validation must accept fleet-hinted discover_workflows args")
+		Expect(discResult["count"]).To(BeEquivalentTo(1))
+
+		selectTool, err := tools.NewSelectWorkflowTool(mockMCP, nil)
+		Expect(err).NotTo(HaveOccurred())
+		selectRunnable, ok := selectTool.(runnableTool)
+		Expect(ok).To(BeTrue())
+
+		selArgs := map[string]any{
+			"rr_id": "payments/rr-2364", "workflow_id": "wf-1",
+			"cluster_id": "spoke",
+			"session_id": "sess-2364-it",
+		}
+		cbResult, cbErr = before(toolCtx, fakeTool{name: "kubernaut_select_workflow"}, selArgs)
+		Expect(cbErr).NotTo(HaveOccurred())
+		Expect(cbResult).To(BeNil())
+		selResult, runErr := selectRunnable.Run(toolCtx, selArgs)
+		Expect(runErr).NotTo(HaveOccurred(),
+			"#2364: real ADK schema validation must accept fleet-hinted select_workflow args")
+		Expect(selResult["status"]).To(Equal("selected"))
+	})
+
+	It("IT-2364-003 (SI-10): fleet-hinted watch survives real validation and reports terminal state", func() {
+		scheme := k8sruntime.NewScheme()
+		_ = remediationv1.AddToScheme(scheme)
+		_ = eav1alpha1.AddToScheme(scheme)
+		rr := &remediationv1.RemediationRequest{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "rr-2364"},
+			Spec: remediationv1.RemediationRequestSpec{
+				TargetResource: remediationv1.ResourceIdentifier{Kind: "Deployment", Name: "worker"},
+			},
+		}
+		rr.Status.OverallPhase = remediationv1.PhasePending
+		wc := k8sfake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(rr).
+			WithStatusSubresource(rr).
+			Build()
+
+		watchTool, err := tools.NewWatchTool(wc, "payments")
+		Expect(err).NotTo(HaveOccurred())
+		runnable, ok := watchTool.(runnableTool)
+		Expect(ok).To(BeTrue())
+
+		toolCtx := newToolCtx()
+		before, _ := NewPhaseGuardForTest()
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			var current remediationv1.RemediationRequest
+			Expect(wc.Get(context.Background(), crclient.ObjectKey{Namespace: "payments", Name: "rr-2364"}, &current)).To(Succeed())
+			current.Status.OverallPhase = remediationv1.PhaseCompleted
+			current.Status.EnsureCompletionStatus().Outcome = remediationv1.OutcomeRemediated
+			current.Status.Message = "done"
+			Expect(wc.Status().Update(context.Background(), &current)).To(Succeed())
+		}()
+		args := map[string]any{
+			"name": "rr-2364",
+			// Ambient fleet + preservation fields; pre-fix rejected.
+			"cluster_id": "spoke",
+			"session_id": "sess-2364-it",
+		}
+		cbResult, cbErr := before(toolCtx, fakeTool{name: "kubernaut_watch"}, args)
+		Expect(cbErr).NotTo(HaveOccurred())
+		Expect(cbResult).To(BeNil())
+
+		result, runErr := runnable.Run(toolCtx, args)
+		Expect(runErr).NotTo(HaveOccurred(),
+			"#2364: real ADK schema validation must accept fleet-hinted watch args")
+		Expect(result["status"]).To(Equal("completed"))
+		Expect(result["outcome"]).To(Equal(remediationv1.OutcomeRemediated))
+	})
+})

--- a/pkg/apifrontend/agent/checkpoint_tool_filter.go
+++ b/pkg/apifrontend/agent/checkpoint_tool_filter.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/adk/v2/agent"
 	"google.golang.org/adk/v2/model"
 	adksession "google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
 )
@@ -38,7 +39,7 @@ import (
 // llmagent.BeforeModelCallback contract for "no override response, proceed
 // with the (possibly mutated) request" — not an ambiguous error case.
 func checkpointToolFilter(ctx agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
-	if req == nil || len(req.Tools) == 0 {
+	if req == nil || (len(req.Tools) == 0 && (req.Config == nil || len(req.Config.Tools) == 0)) {
 		return nil, nil // nolint:nilnil
 	}
 
@@ -47,14 +48,78 @@ func checkpointToolFilter(ctx agent.Context, req *model.LLMRequest) (*model.LLMR
 		return nil, nil // nolint:nilnil
 	}
 
+	if presentationRecoveryRequired(state) {
+		retainOnlyPresentationTool(req)
+		return nil, nil // nolint:nilnil
+	}
+
 	if checkpointFlagSet(state, session.StateKeyPhase2Blocked) {
 		delete(req.Tools, "kubernaut_discover_workflows")
+		removeToolDeclaration(req, "kubernaut_discover_workflows")
 	}
 	if checkpointFlagSet(state, session.StateKeyPhase3Blocked) {
 		delete(req.Tools, "kubernaut_select_workflow")
+		removeToolDeclaration(req, "kubernaut_select_workflow")
 	}
 
 	return nil, nil // nolint:nilnil
+}
+
+func presentationRecoveryRequired(state adksession.State) bool {
+	v, err := state.Get(session.StateKeyPresentationRequired)
+	if err != nil {
+		return false
+	}
+	required, _ := v.(bool)
+	return required
+}
+
+func retainOnlyPresentationTool(req *model.LLMRequest) {
+	for name := range req.Tools {
+		if name != "kubernaut_present_decision" {
+			delete(req.Tools, name)
+		}
+	}
+	if req.Config == nil {
+		return
+	}
+	for _, toolDecl := range req.Config.Tools {
+		if toolDecl == nil {
+			continue
+		}
+		filtered := toolDecl.FunctionDeclarations[:0]
+		for _, declaration := range toolDecl.FunctionDeclarations {
+			if declaration != nil && declaration.Name == "kubernaut_present_decision" {
+				filtered = append(filtered, declaration)
+			}
+		}
+		toolDecl.FunctionDeclarations = filtered
+	}
+	if req.Config.ToolConfig == nil {
+		req.Config.ToolConfig = &genai.ToolConfig{}
+	}
+	req.Config.ToolConfig.FunctionCallingConfig = &genai.FunctionCallingConfig{
+		Mode:                 genai.FunctionCallingConfigModeAny,
+		AllowedFunctionNames: []string{"kubernaut_present_decision"},
+	}
+}
+
+func removeToolDeclaration(req *model.LLMRequest, name string) {
+	if req.Config == nil {
+		return
+	}
+	for _, toolDecl := range req.Config.Tools {
+		if toolDecl == nil {
+			continue
+		}
+		filtered := toolDecl.FunctionDeclarations[:0]
+		for _, declaration := range toolDecl.FunctionDeclarations {
+			if declaration != nil && declaration.Name != name {
+				filtered = append(filtered, declaration)
+			}
+		}
+		toolDecl.FunctionDeclarations = filtered
+	}
 }
 
 func checkpointFlagSet(state adksession.State, key string) bool {

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -444,7 +444,10 @@ func recordDiscoverWorkflowsCheckpoint(ctx agent.Context) {
 	if err := state.Set(session.StateKeyDiscoverWorkflowsSucceeded, true); err != nil {
 		logger.Error(err, "phase-guard failed to persist discover_workflows_succeeded state")
 	}
-	if err := state.Set(session.StateKeyPresentationRequired, true); err != nil {
+	// Consent-gated discovery is an intentional user checkpoint. Only the
+	// autonomous path requires AF to recover a model narration into the final
+	// presentation artifact without waiting for another user turn.
+	if err := state.Set(session.StateKeyPresentationRequired, !blocked); err != nil {
 		logger.Error(err, "phase-guard failed to persist presentation_required state")
 	}
 	if err := state.Set(session.StateKeyPresentationRecoveryCount, 0); err != nil {

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -444,10 +444,11 @@ func recordDiscoverWorkflowsCheckpoint(ctx agent.Context) {
 	if err := state.Set(session.StateKeyDiscoverWorkflowsSucceeded, true); err != nil {
 		logger.Error(err, "phase-guard failed to persist discover_workflows_succeeded state")
 	}
-	// Consent-gated discovery is an intentional user checkpoint. Only the
-	// autonomous path requires AF to recover a model narration into the final
-	// presentation artifact without waiting for another user turn.
-	if err := state.Set(session.StateKeyPresentationRequired, !blocked); err != nil {
+	// Full remediation auto-discovers, then presents the structured decision
+	// before its phase-3 consent pause. Fully autonomous remediation instead
+	// continues directly to select_workflow and must not be intercepted here.
+	presentationRequired := mode == session.InteractionModeFullRemediation
+	if err := state.Set(session.StateKeyPresentationRequired, presentationRequired); err != nil {
 		logger.Error(err, "phase-guard failed to persist presentation_required state")
 	}
 	if err := state.Set(session.StateKeyPresentationRecoveryCount, 0); err != nil {

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -454,11 +454,14 @@ func recordDiscoverWorkflowsCheckpoint(ctx agent.Context) {
 	if err := state.Set(session.StateKeyDiscoverWorkflowsSucceeded, true); err != nil {
 		logger.Error(err, "phase-guard failed to persist discover_workflows_succeeded state")
 	}
-	// Full remediation auto-discovers, then presents the structured decision
-	// before its phase-3 consent pause. Fully autonomous remediation instead
-	// continues directly to select_workflow and must not be intercepted here.
-	presentationRequired := mode == session.InteractionModeFullRemediation
-	if err := state.Set(session.StateKeyPresentationRequired, presentationRequired); err != nil {
+	// #2365 presentation recovery is disabled pending a design distinguishing
+	// present_decision-expected flows from select_workflow consent flows.
+	// Auto-enabling it for full_remediation breaks E2E-FP-1899-002: Turn 1
+	// discover success triggers reinvocation and complete_no_action, which
+	// terminates the KA session before the genuine Turn 2 selection can
+	// complete the pipeline. Keep the plumbing inert until that distinction
+	// exists.
+	if err := state.Set(session.StateKeyPresentationRequired, false); err != nil {
 		logger.Error(err, "phase-guard failed to persist presentation_required state")
 	}
 	if err := state.Set(session.StateKeyPresentationRecoveryCount, 0); err != nil {

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -313,9 +313,6 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx agent.Context
 	// DD-AF-011 (#1899): discover_workflows is neither a driver-entry nor
 	// a session-terminal tool, but its success still needs to persist
 	// the phase-3 checkpoint flag.
-	isDiscoverWorkflows := toolName == "kubernaut_discover_workflows"
-	isPresentDecision := toolName == presentDecisionTool
-	isSelectWorkflow := toolName == "kubernaut_select_workflow"
 	isSuccess := toolCallSucceeded(callErr, resp)
 
 	// #2047 (main clone of #2023): track whether THIS kubernaut_investigate
@@ -336,23 +333,7 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx agent.Context
 		refreshActiveContext(registry, ctx)
 	}
 
-	if !isEntry && !isTerminal && !isDiscoverWorkflows && !isPresentDecision && !isSelectWorkflow {
-		return nil, nil
-	}
-	if !isSuccess {
-		return nil, nil
-	}
-
-	if isDiscoverWorkflows {
-		recordDiscoverWorkflowsCheckpoint(ctx)
-		return nil, nil
-	}
-	if isPresentDecision {
-		clearPresentationRecoveryState(ctx)
-		return nil, nil
-	}
-	if isSelectWorkflow {
-		clearPresentationRecoveryState(ctx)
+	if phaseGuardAfterTool(ctx, toolName, resp, callErr) {
 		return nil, nil
 	}
 
@@ -365,6 +346,30 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx agent.Context
 	syncActiveContextRegistry(registry, ctx, isEntry, isTerminal)
 
 	return nil, nil
+}
+
+func phaseGuardAfterTool(ctx agent.Context, toolName string, resp map[string]any, callErr error) bool {
+	isEntry := driverEntryTools[toolName]
+	isTerminal := sessionTerminalTools[toolName]
+	isDiscoverWorkflows := toolName == "kubernaut_discover_workflows"
+	isPresentDecision := toolName == presentDecisionTool
+	isSelectWorkflow := toolName == "kubernaut_select_workflow"
+	isSuccess := toolCallSucceeded(callErr, resp)
+	if !isEntry && !isTerminal && !isDiscoverWorkflows && !isPresentDecision && !isSelectWorkflow {
+		return true
+	}
+	if !isSuccess {
+		return true
+	}
+	switch {
+	case isDiscoverWorkflows:
+		recordDiscoverWorkflowsCheckpoint(ctx)
+	case isPresentDecision, isSelectWorkflow:
+		clearPresentationRecoveryState(ctx)
+	default:
+		return false
+	}
+	return true
 }
 
 // recordInvestigateGroundingState persists whether a kubernaut_investigate

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -315,6 +315,7 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx agent.Context
 	// the phase-3 checkpoint flag.
 	isDiscoverWorkflows := toolName == "kubernaut_discover_workflows"
 	isPresentDecision := toolName == presentDecisionTool
+	isSelectWorkflow := toolName == "kubernaut_select_workflow"
 	isSuccess := toolCallSucceeded(callErr, resp)
 
 	// #2047 (main clone of #2023): track whether THIS kubernaut_investigate
@@ -335,7 +336,7 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx agent.Context
 		refreshActiveContext(registry, ctx)
 	}
 
-	if !isEntry && !isTerminal && !isDiscoverWorkflows && !isPresentDecision {
+	if !isEntry && !isTerminal && !isDiscoverWorkflows && !isPresentDecision && !isSelectWorkflow {
 		return nil, nil
 	}
 	if !isSuccess {
@@ -347,6 +348,10 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx agent.Context
 		return nil, nil
 	}
 	if isPresentDecision {
+		clearPresentationRecoveryState(ctx)
+		return nil, nil
+	}
+	if isSelectWorkflow {
 		clearPresentationRecoveryState(ctx)
 		return nil, nil
 	}

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -314,6 +314,7 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx agent.Context
 	// a session-terminal tool, but its success still needs to persist
 	// the phase-3 checkpoint flag.
 	isDiscoverWorkflows := toolName == "kubernaut_discover_workflows"
+	isPresentDecision := toolName == presentDecisionTool
 	isSuccess := toolCallSucceeded(callErr, resp)
 
 	// #2047 (main clone of #2023): track whether THIS kubernaut_investigate
@@ -334,7 +335,7 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx agent.Context
 		refreshActiveContext(registry, ctx)
 	}
 
-	if !isEntry && !isTerminal && !isDiscoverWorkflows {
+	if !isEntry && !isTerminal && !isDiscoverWorkflows && !isPresentDecision {
 		return nil, nil
 	}
 	if !isSuccess {
@@ -343,6 +344,10 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx agent.Context
 
 	if isDiscoverWorkflows {
 		recordDiscoverWorkflowsCheckpoint(ctx)
+		return nil, nil
+	}
+	if isPresentDecision {
+		clearPresentationRecoveryState(ctx)
 		return nil, nil
 	}
 
@@ -439,6 +444,26 @@ func recordDiscoverWorkflowsCheckpoint(ctx agent.Context) {
 	if err := state.Set(session.StateKeyDiscoverWorkflowsSucceeded, true); err != nil {
 		logger.Error(err, "phase-guard failed to persist discover_workflows_succeeded state")
 	}
+	if err := state.Set(session.StateKeyPresentationRequired, true); err != nil {
+		logger.Error(err, "phase-guard failed to persist presentation_required state")
+	}
+	if err := state.Set(session.StateKeyPresentationRecoveryCount, 0); err != nil {
+		logger.Error(err, "phase-guard failed to reset presentation recovery count")
+	}
+}
+
+func clearPresentationRecoveryState(ctx agent.Context) {
+	state := ctx.State()
+	if state == nil {
+		return
+	}
+	logger := logr.FromContextOrDiscard(ctx)
+	if err := state.Set(session.StateKeyPresentationRequired, false); err != nil {
+		logger.Error(err, "phase-guard failed to clear presentation_required state")
+	}
+	if err := state.Set(session.StateKeyPresentationRecoveryCount, 0); err != nil {
+		logger.Error(err, "phase-guard failed to clear presentation recovery count")
+	}
 }
 
 // recordDriverEntryState persists driver-active flag, rr_id, and session_id
@@ -495,6 +520,12 @@ func recordInteractionMode(state adksession.State, inputArgs, resp map[string]an
 	// session.
 	if err := state.Set(session.StateKeyDiscoverWorkflowsSucceeded, false); err != nil {
 		logger.Error(err, "phase-guard failed to reset discover_workflows_succeeded state")
+	}
+	if err := state.Set(session.StateKeyPresentationRequired, false); err != nil {
+		logger.Error(err, "phase-guard failed to reset presentation_required state")
+	}
+	if err := state.Set(session.StateKeyPresentationRecoveryCount, 0); err != nil {
+		logger.Error(err, "phase-guard failed to reset presentation recovery count")
 	}
 
 	blocked := mode == session.InteractionModeInteractive

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -40,7 +40,7 @@ const (
 	// file; both packages read/write the identical state keys.
 	stateKeyDriverActive  = session.StateKeyDriverActive
 	stateKeyActiveRRID    = session.StateKeyActiveRRID
-	stateKeyActiveSession = "af_active_session_id"
+	stateKeyActiveSession = session.StateKeyActiveSession
 )
 
 const errNoActiveDriver = "interactive session not active — you must call kubernaut_investigate first to establish a driver session before using this tool"
@@ -363,8 +363,12 @@ func phaseGuardAfterTool(ctx agent.Context, toolName string, resp map[string]any
 	}
 	switch {
 	case isDiscoverWorkflows:
-		recordDiscoverWorkflowsCheckpoint(ctx)
-	case isPresentDecision, isSelectWorkflow:
+		recordDiscoverWorkflowsCheckpoint(ctx, resp)
+	case isPresentDecision:
+		markDecisionArtifactEmitted(ctx)
+		clearPresentationRecoveryState(ctx)
+		return true
+	case isSelectWorkflow:
 		clearPresentationRecoveryState(ctx)
 	default:
 		return false
@@ -413,6 +417,16 @@ func recordInvestigateGroundingState(ctx agent.Context, resp map[string]any, isS
 	if err := state.Set(session.StateKeyGroundedRCA, rca); err != nil {
 		logger.Error(err, "phase-guard failed to persist grounded_rca state")
 	}
+	var payload map[string]any
+	if rca != nil {
+		payload = canonicalGroundedRCA(rca)
+		if payload != nil && rca.RCASummary != "" {
+			payload["explanation"] = rca.RCASummary
+		}
+	}
+	if err := state.Set(session.StateKeyGroundedRCAPayload, payload); err != nil {
+		logger.Error(err, "phase-guard failed to persist grounded_rca_payload state")
+	}
 }
 
 // toolCallSucceeded reports whether a tool call completed without a Go error
@@ -438,7 +452,7 @@ func refreshActiveContext(registry *launcher.ActiveContextRegistry, ctx agent.Co
 // blocked unless the session's interaction_mode is
 // full_remediation_autonomous, in which case the harness may auto-chain
 // straight into kubernaut_select_workflow within the same turn.
-func recordDiscoverWorkflowsCheckpoint(ctx agent.Context) {
+func recordDiscoverWorkflowsCheckpoint(ctx agent.Context, resp map[string]any) {
 	state := ctx.State()
 	if state == nil {
 		return
@@ -454,13 +468,21 @@ func recordDiscoverWorkflowsCheckpoint(ctx agent.Context) {
 	if err := state.Set(session.StateKeyDiscoverWorkflowsSucceeded, true); err != nil {
 		logger.Error(err, "phase-guard failed to persist discover_workflows_succeeded state")
 	}
-	// #2365 presentation recovery is disabled pending a design distinguishing
-	// present_decision-expected flows from select_workflow consent flows.
-	// Auto-enabling it for full_remediation breaks E2E-FP-1899-002: Turn 1
-	// discover success triggers reinvocation and complete_no_action, which
-	// terminates the KA session before the genuine Turn 2 selection can
-	// complete the pipeline. Keep the plumbing inert until that distinction
-	// exists.
+	if err := state.Set(session.StateKeyDiscoveryResult, resp); err != nil {
+		logger.Error(err, "phase-guard failed to persist discovery_result state")
+	}
+	obligation := session.DecisionObligation(mode, true, blocked)
+	status := session.DecisionArtifactNotRequired
+	if obligation.PresentationRequired {
+		status = session.DecisionArtifactRequired
+	}
+	if err := state.Set(session.StateKeyDecisionArtifactStatus, status); err != nil {
+		logger.Error(err, "phase-guard failed to persist decision_artifact_status state")
+	}
+	// The legacy generic-reinvocation recovery flag remains inert. #2365
+	// presentation obligations are tracked independently above and enforced by
+	// the business-outcome coordinator, so recovery cannot bypass phase-3
+	// consent or autonomous workflow chaining.
 	if err := state.Set(session.StateKeyPresentationRequired, false); err != nil {
 		logger.Error(err, "phase-guard failed to persist presentation_required state")
 	}
@@ -480,6 +502,17 @@ func clearPresentationRecoveryState(ctx agent.Context) {
 	}
 	if err := state.Set(session.StateKeyPresentationRecoveryCount, 0); err != nil {
 		logger.Error(err, "phase-guard failed to clear presentation recovery count")
+	}
+}
+
+func markDecisionArtifactEmitted(ctx agent.Context) {
+	state := ctx.State()
+	if state == nil {
+		return
+	}
+	logger := logr.FromContextOrDiscard(ctx)
+	if err := state.Set(session.StateKeyDecisionArtifactStatus, session.DecisionArtifactEmitted); err != nil {
+		logger.Error(err, "phase-guard failed to persist decision_artifact_status state")
 	}
 }
 
@@ -543,6 +576,15 @@ func recordInteractionMode(state adksession.State, inputArgs, resp map[string]an
 	}
 	if err := state.Set(session.StateKeyPresentationRecoveryCount, 0); err != nil {
 		logger.Error(err, "phase-guard failed to reset presentation recovery count")
+	}
+	if err := state.Set(session.StateKeyDecisionArtifactStatus, session.DecisionArtifactNotRequired); err != nil {
+		logger.Error(err, "phase-guard failed to reset decision_artifact_status state")
+	}
+	if err := state.Set(session.StateKeyGroundedRCAPayload, nil); err != nil {
+		logger.Error(err, "phase-guard failed to reset grounded_rca_payload state")
+	}
+	if err := state.Set(session.StateKeyDiscoveryResult, nil); err != nil {
+		logger.Error(err, "phase-guard failed to reset discovery_result state")
 	}
 
 	blocked := mode == session.InteractionModeInteractive

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -427,6 +427,21 @@ func recordInvestigateGroundingState(ctx agent.Context, resp map[string]any, isS
 	if err := state.Set(session.StateKeyGroundedRCAPayload, payload); err != nil {
 		logger.Error(err, "phase-guard failed to persist grounded_rca_payload state")
 	}
+	summary, _ := resp["summary"].(string)
+	provisional := false
+	if decoded := decodeInvestigateRCA(resp["rca"]); decoded != nil {
+		provisional = decoded.Provisional
+	}
+	if !grounded {
+		summary = ""
+		provisional = false
+	}
+	if err := state.Set(session.StateKeyGroundedSummary, summary); err != nil {
+		logger.Error(err, "phase-guard failed to persist grounded_summary state")
+	}
+	if err := state.Set(session.StateKeyGroundedSummaryProvisional, provisional); err != nil {
+		logger.Error(err, "phase-guard failed to persist grounded_summary_provisional state")
+	}
 }
 
 // toolCallSucceeded reports whether a tool call completed without a Go error
@@ -579,12 +594,6 @@ func recordInteractionMode(state adksession.State, inputArgs, resp map[string]an
 	}
 	if err := state.Set(session.StateKeyDecisionArtifactStatus, session.DecisionArtifactNotRequired); err != nil {
 		logger.Error(err, "phase-guard failed to reset decision_artifact_status state")
-	}
-	if err := state.Set(session.StateKeyGroundedRCAPayload, nil); err != nil {
-		logger.Error(err, "phase-guard failed to reset grounded_rca_payload state")
-	}
-	if err := state.Set(session.StateKeyDiscoveryResult, nil); err != nil {
-		logger.Error(err, "phase-guard failed to reset discovery_result state")
 	}
 
 	blocked := mode == session.InteractionModeInteractive

--- a/pkg/apifrontend/agent/phase_guard_test.go
+++ b/pkg/apifrontend/agent/phase_guard_test.go
@@ -398,6 +398,38 @@ var _ = Describe("Phase Guard (#1307)", func() {
 		Expect(status).To(Equal(session.DecisionArtifactNotRequired))
 	})
 
+	It("IT-AF-2365-002 (AU-3): persists grounded summary when structured RCA is absent", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": session.InteractionModeFullRemediation}, map[string]any{
+			"session_id": "sess-2365-summary", "rr_id": "rr-2365-summary", "status": "completed",
+			"summary": "The deployment exceeded its memory limit during a traffic spike.",
+		}, nil)
+
+		grounded, err := state.Get(session.StateKeyGroundedContentAvailable)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(grounded).To(BeTrue())
+		summary, err := state.Get(session.StateKeyGroundedSummary)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(summary).To(Equal("The deployment exceeded its memory limit during a traffic spike."))
+		provisional, err := state.Get(session.StateKeyGroundedSummaryProvisional)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(provisional).To(BeFalse())
+	})
+
+	It("UT-AF-2365-002b (AU-3): marks severity-triage summary provisional", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": session.InteractionModeFullRemediation}, map[string]any{
+			"session_id": "sess-2365-provisional", "rr_id": "rr-2365-provisional", "status": "completed",
+			"summary": "Severity assessed from resource metadata.",
+			"rca": map[string]any{
+				"severity":    "warning",
+				"provisional": true,
+			},
+		}, nil)
+
+		provisional, err := state.Get(session.StateKeyGroundedSummaryProvisional)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(provisional).To(BeTrue())
+	})
+
 	It("IT-AF-1899-003c: a failed discover_workflows does not set phase3_blocked", func() {
 		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
 			"session_id": "sess-1899-f", "rr_id": "rr-1899-f", "status": "completed",

--- a/pkg/apifrontend/agent/phase_guard_test.go
+++ b/pkg/apifrontend/agent/phase_guard_test.go
@@ -366,6 +366,38 @@ var _ = Describe("Phase Guard (#1307)", func() {
 		Expect(blocked).To(BeFalse(), "full_remediation_autonomous must auto-proceed through workflow selection")
 	})
 
+	It("IT-AF-2365-005 (AU-3, AC-6): full_remediation records a presentation obligation without changing consent", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": session.InteractionModeFullRemediation}, map[string]any{
+			"session_id": "sess-2365-policy", "rr_id": "rr-2365-policy", "status": "completed",
+		}, nil)
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil, map[string]any{
+			"workflows": []any{map[string]any{"workflow_id": "wf-1", "name": "Restart"}},
+		}, nil)
+
+		status, err := state.Get(session.StateKeyDecisionArtifactStatus)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(session.DecisionArtifactRequired))
+		blocked, err := state.Get(session.StateKeyPhase3Blocked)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(blocked).To(BeTrue(), "presentation recovery must not loosen phase-3 consent")
+		discovery, err := state.Get(session.StateKeyDiscoveryResult)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(discovery).To(HaveKey("workflows"))
+	})
+
+	It("IT-AF-2365-005b (AU-3, AC-6): autonomous discovery does not create a presentation obligation", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": session.InteractionModeFullRemediationAutonomous}, map[string]any{
+			"session_id": "sess-2365-auto", "rr_id": "rr-2365-auto", "status": "completed",
+		}, nil)
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil, map[string]any{
+			"workflows": []any{map[string]any{"workflow_id": "wf-1", "name": "Restart"}},
+		}, nil)
+
+		status, err := state.Get(session.StateKeyDecisionArtifactStatus)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(session.DecisionArtifactNotRequired))
+	})
+
 	It("IT-AF-1899-003c: a failed discover_workflows does not set phase3_blocked", func() {
 		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
 			"session_id": "sess-1899-f", "rr_id": "rr-1899-f", "status": "completed",

--- a/pkg/apifrontend/agent/presentation_recovery_2365_test.go
+++ b/pkg/apifrontend/agent/presentation_recovery_2365_test.go
@@ -37,4 +37,19 @@ var _ = Describe("Presentation recovery guard (#2365)", func() {
 		Expect(req.Config.Tools[0].FunctionDeclarations[0].Name).To(Equal("kubernaut_present_decision"))
 		Expect(req.Config.ToolConfig.FunctionCallingConfig.AllowedFunctionNames).To(ConsistOf("kubernaut_present_decision"))
 	})
+
+	It("UT-AF-2365-005 (AC-6): clears recovery after genuine workflow selection", func() {
+		state := newMapState()
+		Expect(state.Set(session.StateKeyPresentationRequired, true)).To(Succeed())
+		ctx := &statefulToolContext{
+			fakeToolContext: fakeToolContext{Context: context.Background()},
+			state:           state,
+		}
+		_, after := NewPhaseGuardForTest()
+		_, err := after(ctx, fakeTool{name: "kubernaut_select_workflow"}, nil, map[string]any{"selected": true}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		value, getErr := state.Get(session.StateKeyPresentationRequired)
+		Expect(getErr).NotTo(HaveOccurred())
+		Expect(value).To(BeFalse())
+	})
 })

--- a/pkg/apifrontend/agent/presentation_recovery_2365_test.go
+++ b/pkg/apifrontend/agent/presentation_recovery_2365_test.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+)
+
+var _ = Describe("Presentation recovery guard (#2365)", func() {
+	It("IT-AF-2365-001 (SI-10, AU-3): retains only present_decision in both ADK tool representations", func() {
+		state := newMapState()
+		Expect(state.Set(session.StateKeyPresentationRequired, true)).To(Succeed())
+		req := &model.LLMRequest{
+			Tools: map[string]any{
+				"kubernaut_present_decision": struct{}{},
+				"kubernaut_select_workflow":  struct{}{},
+			},
+			Config: &genai.GenerateContentConfig{Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{
+					{Name: "kubernaut_present_decision"},
+					{Name: "kubernaut_select_workflow"},
+				},
+			}}},
+		}
+
+		ctx := &statefulCallbackContext{stubCallbackContext: &stubCallbackContext{Context: context.Background()}, state: state}
+		_, err := checkpointToolFilter(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Tools).To(HaveKey("kubernaut_present_decision"))
+		Expect(req.Tools).NotTo(HaveKey("kubernaut_select_workflow"))
+		Expect(req.Config.Tools[0].FunctionDeclarations).To(HaveLen(1))
+		Expect(req.Config.Tools[0].FunctionDeclarations[0].Name).To(Equal("kubernaut_present_decision"))
+		Expect(req.Config.ToolConfig.FunctionCallingConfig.AllowedFunctionNames).To(ConsistOf("kubernaut_present_decision"))
+	})
+})

--- a/pkg/apifrontend/agent/prompt.txt
+++ b/pkg/apifrontend/agent/prompt.txt
@@ -84,7 +84,7 @@ DO NOT chain kubectl_get + kubectl_list_events + your own analysis as a substitu
 
 ## 4-Phase Interactive Remediation Journey
 
-Follow this sequence for every remediation lifecycle. Preserve session_id and rr_id across all phases.
+Follow this sequence for every remediation lifecycle. Keep session_id and rr_id in mind across all phases, but pass ONLY the fields each tool's schema declares -- never copy ambient fields (cluster_id, rr_id, session_id) into a tool call that does not list them, or strict schema validation will reject the call and kill the turn.
 
 ### Phase 1: Investigate
 

--- a/pkg/apifrontend/agent/prompt_test.go
+++ b/pkg/apifrontend/agent/prompt_test.go
@@ -108,8 +108,9 @@ var _ = Describe("System Prompt", func() {
 		Expect(instruction).To(ContainSubstring("call kubernaut_watch"))
 	})
 
-	It("UT-AF-1189-035: prompt requires session_id/rr_id preservation across phases", func() {
-		Expect(instruction).To(ContainSubstring("Preserve session_id and rr_id across all phases"))
+	It("UT-AF-1189-035: prompt preserves context without copying undeclared fields", func() {
+		Expect(instruction).To(ContainSubstring("Keep session_id and rr_id in mind across all phases"))
+		Expect(instruction).To(ContainSubstring("pass ONLY the fields each tool's schema declares"))
 	})
 
 	Describe("BuildInstruction (#1275)", func() {

--- a/pkg/apifrontend/agent/root.go
+++ b/pkg/apifrontend/agent/root.go
@@ -149,15 +149,16 @@ func coreToolConstructors(cfg AgentConfig) []toolConstructor {
 		{"watch", func() (tool.Tool, error) { return tools.NewWatchTool(cfg.TypedClient, cfg.Namespace) }},
 		{"investigate", func() (tool.Tool, error) {
 			return tools.NewInvestigateMCPTool(&tools.InvestigateConfig{
-				MCPClient:    dedicatedC,
-				Client:       cfg.TypedClient,
-				Namespace:    cfg.Namespace,
-				Auditor:      cfg.Auditor,
-				Registry:     cfg.InvestigationRegistry,
-				Pool:         cfg.Pool,
-				Signaler:     buildAgentISSignaler(cfg),
-				Triager:      cfg.Triager,
-				ScopeChecker: cfg.ScopeChecker,
+				MCPClient:     dedicatedC,
+				Client:        cfg.TypedClient,
+				Namespace:     cfg.Namespace,
+				Auditor:       cfg.Auditor,
+				Registry:      cfg.InvestigationRegistry,
+				Pool:          cfg.Pool,
+				Signaler:      buildAgentISSignaler(cfg),
+				Triager:       cfg.Triager,
+				ScopeChecker:  cfg.ScopeChecker,
+				ClusterLister: cfg.ClusterRegistry,
 			}, cfg.RESTMapper)
 		}},
 		{"discover_workflows", func() (tool.Tool, error) { return tools.NewDiscoverWorkflowsTool(mcpC) }},
@@ -194,7 +195,7 @@ func coreToolConstructors(cfg AgentConfig) []toolConstructor {
 			return tools.NewCheckExistingRemediationTool(cfg.TypedClient, cfg.Namespace)
 		}},
 		{"remediate", func() (tool.Tool, error) {
-			return tools.NewRemediateTool(cfg.TypedClient, k8s, cfg.Namespace, cfg.Triager, cfg.Auditor, cfg.ScopeChecker)
+			return tools.NewRemediateTool(cfg.TypedClient, k8s, cfg.Namespace, cfg.Triager, cfg.Auditor, cfg.ScopeChecker, cfg.ClusterRegistry)
 		}},
 	}
 }
@@ -224,6 +225,7 @@ func alertToolConstructors(cfg AgentConfig) []toolConstructor {
 				Mapper:             cfg.RESTMapper,
 				Signaler:           buildAlertISSignaler(cfg),
 				ScopeChecker:       cfg.ScopeChecker,
+				ClusterLister:      cfg.ClusterRegistry,
 			})
 		}},
 	}

--- a/pkg/apifrontend/handler/mcp_bridge.go
+++ b/pkg/apifrontend/handler/mcp_bridge.go
@@ -91,6 +91,9 @@ type MCPBridgeConfig struct {
 	// outside Kubernaut's management scope (ADR-053; #2025, main-tracking
 	// clone of #2022). Nil skips scope validation (backward compat).
 	ScopeChecker scope.ScopeChecker
+	// ClusterLister names known fleet clusters for the unattributed-refusal
+	// message (#2362). Nil-safe: a nil lister preserves the legacy message.
+	ClusterLister tools.ClusterLister
 }
 
 // MCPBridgeMetrics holds Prometheus collectors specific to MCP bridge operations.
@@ -244,15 +247,16 @@ func registerInvestigationTool(srv *mcp.Server, cfg *MCPBridgeConfig, sem *semap
 		func(ctx context.Context, args tools.InvestigateMCPArgs) (any, error) {
 			ctx = tools.ContextWithRESTMapper(ctx, cfg.RESTMapper)
 			return tools.HandleInvestigationMCPWithRegistry(ctx, &tools.InvestigateConfig{
-				MCPClient:    dedicatedClient,
-				Client:       cfg.TypedClient,
-				Namespace:    cfg.Namespace,
-				Auditor:      cfg.Auditor,
-				Registry:     cfg.InvestigationRegistry,
-				OnStarted:    onInvestigateStarted,
-				Signaler:     isSignaler,
-				Triager:      cfg.Triager,
-				ScopeChecker: cfg.ScopeChecker,
+				MCPClient:     dedicatedClient,
+				Client:        cfg.TypedClient,
+				Namespace:     cfg.Namespace,
+				Auditor:       cfg.Auditor,
+				Registry:      cfg.InvestigationRegistry,
+				OnStarted:     onInvestigateStarted,
+				Signaler:      isSignaler,
+				Triager:       cfg.Triager,
+				ScopeChecker:  cfg.ScopeChecker,
+				ClusterLister: cfg.ClusterLister,
 			}, args, false, "")
 		})
 }

--- a/pkg/apifrontend/ka/config.go
+++ b/pkg/apifrontend/ka/config.go
@@ -179,8 +179,15 @@ type kaDiscoveredWorkflow struct {
 // ({"workflows": [...]}) and KA's InvestigateOutput envelope format
 // ({"session_id":..., "status":..., "response": "{recommended:..., alternatives:...}"}).
 func ParseDiscoverWorkflowsResponse(raw json.RawMessage) (*DiscoverWorkflowsResult, error) {
-	var direct DiscoverWorkflowsResult
-	if err := json.Unmarshal(raw, &direct); err == nil && len(direct.Workflows) > 0 {
+	var directShape map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &directShape); err != nil {
+		return nil, fmt.Errorf("parse discover_workflows response: %w", err)
+	}
+	if _, ok := directShape["workflows"]; ok {
+		var direct DiscoverWorkflowsResult
+		if err := json.Unmarshal(raw, &direct); err != nil {
+			return nil, fmt.Errorf("parse direct discover_workflows response: %w", err)
+		}
 		return &direct, nil
 	}
 
@@ -349,16 +356,16 @@ type CompleteNoActionResult struct {
 
 // SSE event type constants matching KA's wire format.
 const (
-	EventTypeReasoningDelta = "reasoning_delta"
-	EventTypeTokenDelta     = "token_delta"
-	EventTypeToolCallStart  = "tool_call_start"
-	EventTypeToolCall       = "tool_call"
-	EventTypeToolResult     = "tool_result"
+	EventTypeReasoningDelta   = "reasoning_delta"
+	EventTypeTokenDelta       = "token_delta"
+	EventTypeToolCallStart    = "tool_call_start"
+	EventTypeToolCall         = "tool_call"
+	EventTypeToolResult       = "tool_result"
 	EventTypeError            = "error"
 	EventTypeComplete         = "complete"
 	EventTypeCancelled        = "cancelled"
 	EventTypeAlignmentVerdict = "alignment_verdict"
-	EventTypeSessionEnded    = "session_ended"
+	EventTypeSessionEnded     = "session_ended"
 	// EventTypeReasoningContentDelta mirrors
 	// internal/kubernautagent/session.EventTypeReasoningContentDelta for wire
 	// compatibility (#1634, #1635, DD-LLM-009).

--- a/pkg/apifrontend/ka/config_test.go
+++ b/pkg/apifrontend/ka/config_test.go
@@ -90,3 +90,22 @@ var _ = Describe("Issue #1437: ParseDiscoverWorkflowsResponse — target propaga
 		})
 	})
 })
+
+var _ = Describe("ParseDiscoverWorkflowsResponse — empty direct results", func() {
+	It("UT-AF-2365-001 (SI-10, ASVS 5.1): preserves target metadata when no workflows match", func() {
+		raw := json.RawMessage(`{
+			"workflows": [],
+			"searched_target": {"api_version":"apps/v1","kind":"Deployment","name":"worker","namespace":"demo"},
+			"signal_target": {"api_version":"apps/v1","kind":"Deployment","name":"worker","namespace":"demo"}
+		}`)
+
+		result, err := ka.ParseDiscoverWorkflowsResponse(raw)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil())
+		Expect(result.Workflows).To(BeEmpty())
+		Expect(result.SearchedTarget).NotTo(BeNil())
+		Expect(result.SearchedTarget.Name).To(Equal("worker"))
+		Expect(result.SignalTarget).NotTo(BeNil())
+		Expect(result.SignalTarget.Name).To(Equal("worker"))
+	})
+})

--- a/pkg/apifrontend/launcher/completion.go
+++ b/pkg/apifrontend/launcher/completion.go
@@ -17,10 +17,12 @@ const (
 // missing presentation artifact. It deliberately excludes model-authored
 // presentation fields so recovery cannot amplify untrusted narration.
 type DecisionRecoveryInput struct {
-	SessionID string
-	RRID      string
-	RCA       map[string]any
-	Discovery *ka.DiscoverWorkflowsResult
+	SessionID          string
+	RRID               string
+	RCA                map[string]any
+	Summary            string
+	SummaryProvisional bool
+	Discovery          *ka.DiscoverWorkflowsResult
 }
 
 // DecisionRecoveryResult is the schema-shaped artifact payload and its
@@ -41,12 +43,18 @@ func BuildRecoveredDecisionArtifact(input DecisionRecoveryInput) (DecisionRecove
 		return DecisionRecoveryResult{}, fmt.Errorf("session_id is required for decision recovery")
 	}
 
-	if input.RCA == nil || input.Discovery == nil {
+	if input.Discovery == nil {
 		return incompleteDecisionArtifact(input), nil
 	}
 
-	explanation, ok := input.RCA["explanation"].(string)
-	if !ok || explanation == "" {
+	explanation := ""
+	if input.RCA != nil {
+		explanation, _ = input.RCA["explanation"].(string)
+	}
+	if explanation == "" && !input.SummaryProvisional {
+		explanation = input.Summary
+	}
+	if explanation == "" {
 		return incompleteDecisionArtifact(input), nil
 	}
 
@@ -64,6 +72,9 @@ func BuildRecoveredDecisionArtifact(input DecisionRecoveryInput) (DecisionRecove
 	}
 
 	rca := cloneMap(input.RCA)
+	if len(rca) == 0 {
+		rca = map[string]any{"explanation": explanation}
+	}
 	data := map[string]any{
 		"session_id":              input.SessionID,
 		"summary":                 explanation,

--- a/pkg/apifrontend/launcher/completion.go
+++ b/pkg/apifrontend/launcher/completion.go
@@ -1,0 +1,129 @@
+package launcher
+
+import (
+	"fmt"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+)
+
+const (
+	recoverySource         = "af_completion_recovery"
+	recoveryReason         = "missing_present_decision"
+	missingDataFailure     = "missing_authoritative_data"
+	missingDataExplanation = "Authoritative investigation details were unavailable."
+)
+
+// DecisionRecoveryInput contains only server-observed data used to recover a
+// missing presentation artifact. It deliberately excludes model-authored
+// presentation fields so recovery cannot amplify untrusted narration.
+type DecisionRecoveryInput struct {
+	SessionID string
+	RRID      string
+	RCA       map[string]any
+	Discovery *ka.DiscoverWorkflowsResult
+}
+
+// DecisionRecoveryResult is the schema-shaped artifact payload and its
+// human-readable fallback. Complete is false when the payload is a truthful
+// failure outcome rather than a recoverable decision.
+type DecisionRecoveryResult struct {
+	Data         map[string]any
+	TextFallback string
+	Metadata     map[string]any
+	Complete     bool
+}
+
+// BuildRecoveredDecisionArtifact builds a presentation-only artifact from
+// authoritative RCA and workflow discovery data. It never selects a workflow
+// or changes execution authorization.
+func BuildRecoveredDecisionArtifact(input DecisionRecoveryInput) (DecisionRecoveryResult, error) {
+	if input.SessionID == "" {
+		return DecisionRecoveryResult{}, fmt.Errorf("session_id is required for decision recovery")
+	}
+
+	if input.RCA == nil || input.Discovery == nil {
+		return incompleteDecisionArtifact(input), nil
+	}
+
+	explanation, ok := input.RCA["explanation"].(string)
+	if !ok || explanation == "" {
+		return incompleteDecisionArtifact(input), nil
+	}
+
+	options := make([]any, 0, len(input.Discovery.Workflows))
+	for index, workflow := range input.Discovery.Workflows {
+		if workflow.WorkflowID == "" || workflow.Name == "" {
+			return DecisionRecoveryResult{}, fmt.Errorf("discovered workflow at index %d is missing workflow_id or name", index)
+		}
+		options = append(options, map[string]any{
+			"workflow_id": workflow.WorkflowID,
+			"name":        workflow.Name,
+			"description": workflow.Description,
+			"recommended": index == 0,
+		})
+	}
+
+	rca := cloneMap(input.RCA)
+	data := map[string]any{
+		"session_id":              input.SessionID,
+		"summary":                 explanation,
+		"rca":                     rca,
+		"options":                 options,
+		"source":                  recoverySource,
+		"recovery_reason":         recoveryReason,
+		"requires_user_selection": true,
+	}
+	if input.RRID != "" {
+		data["rr_id"] = input.RRID
+	}
+
+	return DecisionRecoveryResult{
+		Data:         data,
+		TextFallback: fmt.Sprintf("Decision: %s", explanation),
+		Metadata: map[string]any{
+			"type":            MetaTypeDecision,
+			"schema":          "investigation_summary",
+			"schema_version":  "1.0",
+			"source":          recoverySource,
+			"recovery_reason": recoveryReason,
+		},
+		Complete: true,
+	}, nil
+}
+
+func incompleteDecisionArtifact(input DecisionRecoveryInput) DecisionRecoveryResult {
+	data := map[string]any{
+		"session_id":      input.SessionID,
+		"summary":         "Structured workflow decision could not be completed.",
+		"rca":             map[string]any{"explanation": missingDataExplanation},
+		"options":         []any{},
+		"status":          "failure",
+		"failure_reason":  missingDataFailure,
+		"source":          recoverySource,
+		"recovery_reason": recoveryReason,
+	}
+	if input.RRID != "" {
+		data["rr_id"] = input.RRID
+	}
+	return DecisionRecoveryResult{
+		Data:         data,
+		TextFallback: missingDataExplanation,
+		Metadata: map[string]any{
+			"type":            MetaTypeDecision,
+			"schema":          "investigation_summary",
+			"schema_version":  "1.0",
+			"source":          recoverySource,
+			"recovery_reason": recoveryReason,
+			"failure_reason":  missingDataFailure,
+		},
+		Complete: false,
+	}
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	result := make(map[string]any, len(input))
+	for key, value := range input {
+		result[key] = value
+	}
+	return result
+}

--- a/pkg/apifrontend/launcher/completion_coordinator.go
+++ b/pkg/apifrontend/launcher/completion_coordinator.go
@@ -43,6 +43,10 @@ func (r *reinvokingRunner) recoverBusinessOutcome(ctx context.Context, sess adks
 	}
 
 	rca := stateMap(state, session.StateKeyGroundedRCAPayload)
+	groundedSummary, _ := state.Get(session.StateKeyGroundedSummary)
+	summary, _ := groundedSummary.(string)
+	provisionalValue, _ := state.Get(session.StateKeyGroundedSummaryProvisional)
+	provisional, _ := provisionalValue.(bool)
 	discovery := discoveryFromState(state)
 	if discovery == nil {
 		discovery = discoveryFromEvents(sess.Events())
@@ -58,10 +62,12 @@ func (r *reinvokingRunner) recoverBusinessOutcome(ctx context.Context, sess adks
 	rr, _ := rrID.(string)
 
 	artifact, buildErr := BuildRecoveredDecisionArtifact(DecisionRecoveryInput{
-		SessionID: activeSessionID,
-		RRID:      rr,
-		RCA:       rca,
-		Discovery: discovery,
+		SessionID:          activeSessionID,
+		RRID:               rr,
+		RCA:                rca,
+		Summary:            summary,
+		SummaryProvisional: provisional,
+		Discovery:          discovery,
 	})
 	if buildErr != nil {
 		r.logger.Error(buildErr, "failed to build recovered decision artifact", "session_id", sessionID)
@@ -78,6 +84,9 @@ func (r *reinvokingRunner) recoverBusinessOutcome(ctx context.Context, sess adks
 	status := session.DecisionArtifactRecovered
 	if !artifact.Complete {
 		status = session.DecisionArtifactFailed
+		if phase3Blocked(state) {
+			return r.persistCompletionStatus(ctx, sess, status)
+		}
 		if err := r.escalateIncompleteDecision(ctx, rr, sessionID); err != nil {
 			return err
 		}
@@ -172,4 +181,10 @@ func stateMap(state adksession.State, key string) map[string]any {
 	}
 	result, _ := value.(map[string]any)
 	return result
+}
+
+func phase3Blocked(state adksession.State) bool {
+	value, err := state.Get(session.StateKeyPhase3Blocked)
+	blocked, ok := value.(bool)
+	return err == nil && ok && blocked
 }

--- a/pkg/apifrontend/launcher/completion_coordinator.go
+++ b/pkg/apifrontend/launcher/completion_coordinator.go
@@ -1,0 +1,175 @@
+package launcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	adksession "google.golang.org/adk/v2/session"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+)
+
+// completeBusinessOutcome enforces business-output obligations after an ADK
+// turn and before A2A finalization. It is deliberately separate from generic
+// reinvocation so presentation recovery cannot bypass consent checkpoints.
+func (r *reinvokingRunner) completeBusinessOutcome(ctx context.Context, userID, sessionID string) error {
+	resp, err := r.sessionService.Get(ctx, &adksession.GetRequest{
+		AppName:   r.appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		r.logger.Error(err, "failed to load session for business-outcome completion", "session_id", sessionID)
+		return fmt.Errorf("load session for business-outcome completion: %w", err)
+	}
+	if resp == nil || resp.Session == nil {
+		return nil
+	}
+
+	state := resp.Session.State()
+	statusValue, _ := state.Get(session.StateKeyDecisionArtifactStatus)
+	status, _ := statusValue.(string)
+	if status != session.DecisionArtifactRequired {
+		return nil
+	}
+	return r.recoverBusinessOutcome(ctx, resp.Session, state, sessionID)
+}
+
+func (r *reinvokingRunner) recoverBusinessOutcome(ctx context.Context, sess adksession.Session, state adksession.State, sessionID string) error {
+	if hasDecisionArtifact(sess.Events()) {
+		return r.persistCompletionStatus(ctx, sess, session.DecisionArtifactEmitted)
+	}
+
+	rca := stateMap(state, session.StateKeyGroundedRCAPayload)
+	discovery := discoveryFromState(state)
+	if discovery == nil {
+		discovery = discoveryFromEvents(sess.Events())
+	}
+
+	activeSessionID := sessionID
+	if value, ok := state.Get(session.StateKeyActiveSession); ok == nil {
+		if stored, ok := value.(string); ok && stored != "" {
+			activeSessionID = stored
+		}
+	}
+	rrID, _ := state.Get(session.StateKeyActiveRRID)
+	rr, _ := rrID.(string)
+
+	artifact, buildErr := BuildRecoveredDecisionArtifact(DecisionRecoveryInput{
+		SessionID: activeSessionID,
+		RRID:      rr,
+		RCA:       rca,
+		Discovery: discovery,
+	})
+	if buildErr != nil {
+		r.logger.Error(buildErr, "failed to build recovered decision artifact", "session_id", sessionID)
+		artifact, _ = BuildRecoveredDecisionArtifact(DecisionRecoveryInput{
+			SessionID: activeSessionID,
+			RRID:      rr,
+		})
+	}
+
+	if err := EmitArtifactSafe(ctx, artifact.Data, artifact.TextFallback, artifact.Metadata); err != nil {
+		return fmt.Errorf("emit recovered decision artifact: %w", err)
+	}
+
+	status := session.DecisionArtifactRecovered
+	if !artifact.Complete {
+		status = session.DecisionArtifactFailed
+		if err := r.escalateIncompleteDecision(ctx, rr, sessionID); err != nil {
+			return err
+		}
+	}
+
+	return r.persistCompletionStatus(ctx, sess, status)
+}
+
+func (r *reinvokingRunner) escalateIncompleteDecision(ctx context.Context, rrID, sessionID string) error {
+	if r.presentationRecoveryTerminalizer == nil {
+		err := fmt.Errorf("presentation recovery requires operator escalation but no terminalizer is configured")
+		r.logger.Error(err, "business-outcome completion cannot terminate incomplete decision", "session_id", sessionID)
+		return err
+	}
+	if rrID == "" {
+		err := fmt.Errorf("presentation recovery requires operator escalation but active rr_id is missing")
+		r.logger.Error(err, "business-outcome completion cannot terminate incomplete decision", "session_id", sessionID)
+		return err
+	}
+	if err := r.presentationRecoveryTerminalizer(ctx, rrID); err != nil {
+		return fmt.Errorf("escalate incomplete decision for rr %q: %w", rrID, err)
+	}
+	return nil
+}
+
+func (r *reinvokingRunner) persistCompletionStatus(ctx context.Context, sess adksession.Session, status string) error {
+	event := adksession.NewEvent(ctx, "business-outcome-completion")
+	event.Actions.StateDelta = map[string]any{session.StateKeyDecisionArtifactStatus: status}
+	if err := r.sessionService.AppendEvent(ctx, sess, event); err != nil {
+		return fmt.Errorf("persist decision artifact status %q: %w", status, err)
+	}
+	return nil
+}
+
+func hasDecisionArtifact(events adksession.Events) bool {
+	for event := range events.All() {
+		if event == nil || event.Content == nil {
+			continue
+		}
+		for _, part := range event.Content.Parts {
+			if part != nil && part.FunctionCall != nil && decisionMetaTools[part.FunctionCall.Name] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func discoveryFromState(state adksession.State) *ka.DiscoverWorkflowsResult {
+	value, err := state.Get(session.StateKeyDiscoveryResult)
+	if err != nil || value == nil {
+		return nil
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+	result, err := ka.ParseDiscoverWorkflowsResponse(raw)
+	if err != nil {
+		return nil
+	}
+	return result
+}
+
+func discoveryFromEvents(events adksession.Events) *ka.DiscoverWorkflowsResult {
+	var found *ka.DiscoverWorkflowsResult
+	for event := range events.All() {
+		if event == nil || event.Content == nil {
+			continue
+		}
+		for _, part := range event.Content.Parts {
+			if part == nil || part.FunctionResponse == nil || part.FunctionResponse.Name != "kubernaut_discover_workflows" {
+				continue
+			}
+			raw, err := json.Marshal(part.FunctionResponse.Response)
+			if err != nil {
+				continue
+			}
+			parsed, err := ka.ParseDiscoverWorkflowsResponse(raw)
+			if err == nil {
+				found = parsed
+			}
+		}
+	}
+	return found
+}
+
+func stateMap(state adksession.State, key string) map[string]any {
+	value, err := state.Get(key)
+	if err != nil || value == nil {
+		return nil
+	}
+	result, _ := value.(map[string]any)
+	return result
+}

--- a/pkg/apifrontend/launcher/completion_test.go
+++ b/pkg/apifrontend/launcher/completion_test.go
@@ -60,6 +60,37 @@ var _ = Describe("Decision artifact recovery (#2365)", func() {
 		Expect(rca).NotTo(HaveKey("target"))
 	})
 
+	It("UT-AF-2365-007b (AU-3, SI-10): uses an authoritative summary without inventing structured RCA facts", func() {
+		result, err := launcher.BuildRecoveredDecisionArtifact(launcher.DecisionRecoveryInput{
+			SessionID: "sess-2365-summary",
+			Summary:   "The deployment exceeded its memory limit during a traffic spike.",
+			Discovery: &ka.DiscoverWorkflowsResult{
+				Workflows: []ka.DiscoveredWorkflow{{WorkflowID: "wf-restart", Name: "Restart deployment"}},
+			},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Complete).To(BeTrue())
+		Expect(result.Data["summary"]).To(Equal("The deployment exceeded its memory limit during a traffic spike."))
+		rca := result.Data["rca"].(map[string]any)
+		Expect(rca).To(HaveKeyWithValue("explanation", "The deployment exceeded its memory limit during a traffic spike."))
+		Expect(rca).NotTo(HaveKey("severity"))
+		Expect(rca).NotTo(HaveKey("confidence"))
+	})
+
+	It("UT-AF-2365-007c (AU-3, SI-10): rejects provisional summary as authoritative RCA", func() {
+		result, err := launcher.BuildRecoveredDecisionArtifact(launcher.DecisionRecoveryInput{
+			SessionID:          "sess-2365-provisional",
+			Summary:            "Severity assessed from resource metadata.",
+			SummaryProvisional: true,
+			Discovery:          &ka.DiscoverWorkflowsResult{Workflows: []ka.DiscoveredWorkflow{{WorkflowID: "wf-restart", Name: "Restart deployment"}}},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Complete).To(BeFalse())
+		Expect(result.Data).To(HaveKeyWithValue("failure_reason", "missing_authoritative_data"))
+	})
+
 	It("UT-AF-2365-011 (SI-10, ASVS 5.5.2): recovered artifact satisfies investigation_summary schema", func() {
 		result, err := launcher.BuildRecoveredDecisionArtifact(launcher.DecisionRecoveryInput{
 			SessionID: "sess-2365",

--- a/pkg/apifrontend/launcher/completion_test.go
+++ b/pkg/apifrontend/launcher/completion_test.go
@@ -1,0 +1,73 @@
+package launcher_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+)
+
+var _ = Describe("Decision artifact recovery (#2365)", func() {
+	It("UT-AF-2365-006 (AU-3, SI-10, ASVS 5.1): builds options from authoritative RCA and discovery data", func() {
+		result, err := launcher.BuildRecoveredDecisionArtifact(launcher.DecisionRecoveryInput{
+			SessionID: "sess-2365",
+			RRID:      "rr-2365",
+			RCA: map[string]any{
+				"explanation":      "Deployment is restarting after a bad configuration.",
+				"severity":         "critical",
+				"confidence":       0.94,
+				"target":           "Deployment/worker",
+				"tool_calls_count": 8,
+				"llm_turns":        4,
+			},
+			Discovery: &ka.DiscoverWorkflowsResult{
+				Workflows: []ka.DiscoveredWorkflow{
+					{WorkflowID: "wf-restart", Name: "Restart deployment", Description: "Restarts the deployment", Confidence: 0.91},
+					{WorkflowID: "wf-rollout", Name: "Roll out previous version", Description: "Reverts the deployment", Confidence: 0.72},
+				},
+			},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Complete).To(BeTrue())
+		Expect(result.Data).To(HaveKeyWithValue("session_id", "sess-2365"))
+		Expect(result.Data).To(HaveKeyWithValue("rr_id", "rr-2365"))
+		Expect(result.Data).To(HaveKeyWithValue("source", "af_completion_recovery"))
+		Expect(result.Data).To(HaveKeyWithValue("recovery_reason", "missing_present_decision"))
+		Expect(result.Data["options"]).To(HaveLen(2))
+		Expect(result.Data["summary"]).To(Equal("Deployment is restarting after a bad configuration."))
+	})
+
+	It("UT-AF-2365-007 (AU-3, SI-10): emits truthful failure data when authoritative RCA is missing", func() {
+		result, err := launcher.BuildRecoveredDecisionArtifact(launcher.DecisionRecoveryInput{
+			SessionID: "sess-2365",
+			RRID:      "rr-2365",
+			Discovery: &ka.DiscoverWorkflowsResult{
+				Workflows: []ka.DiscoveredWorkflow{{WorkflowID: "wf-restart", Name: "Restart deployment"}},
+			},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Complete).To(BeFalse())
+		Expect(result.Data).To(HaveKeyWithValue("status", "failure"))
+		Expect(result.Data).To(HaveKeyWithValue("failure_reason", "missing_authoritative_data"))
+		Expect(result.Data["options"]).To(BeEmpty())
+		rca, ok := result.Data["rca"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(rca["explanation"]).To(Equal("Authoritative investigation details were unavailable."))
+		Expect(rca).NotTo(HaveKey("severity"))
+		Expect(rca).NotTo(HaveKey("target"))
+	})
+
+	It("UT-AF-2365-011 (SI-10, ASVS 5.5.2): recovered artifact satisfies investigation_summary schema", func() {
+		result, err := launcher.BuildRecoveredDecisionArtifact(launcher.DecisionRecoveryInput{
+			SessionID: "sess-2365",
+			RCA:       map[string]any{"explanation": "A valid grounded explanation."},
+			Discovery: &ka.DiscoverWorkflowsResult{},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(launcher.ValidatePayloadForTest("investigation_summary", result.Data)).To(Succeed())
+	})
+})

--- a/pkg/apifrontend/launcher/export_test.go
+++ b/pkg/apifrontend/launcher/export_test.go
@@ -18,8 +18,8 @@ import (
 
 // NewReinvokingRunnerForTest exports newReinvokingRunner for unit testing
 // (UT-AF-REINV-002/003, issue #1776; auditor param added for #2078).
-func NewReinvokingRunnerForTest(inner adka2a.Runner, sessionService session.Service, appName string, logger logr.Logger, auditor audit.Emitter) *reinvokingRunner {
-	return newReinvokingRunner(inner, sessionService, appName, logger, auditor)
+func NewReinvokingRunnerForTest(inner adka2a.Runner, sessionService session.Service, appName string, logger logr.Logger, auditor audit.Emitter, terminalizer ...func(context.Context, string) error) *reinvokingRunner {
+	return newReinvokingRunner(inner, sessionService, appName, logger, auditor, terminalizer...)
 }
 
 // EnrichRRDetailForTest exports enrichRRDetail for unit testing.

--- a/pkg/apifrontend/launcher/launcher.go
+++ b/pkg/apifrontend/launcher/launcher.go
@@ -47,6 +47,10 @@ type A2AConfig struct {
 	// LLMSemaphore limits global LLM concurrency (SC-5 Denial of Service Protection).
 	// When non-nil, Execute acquires a slot before invoking the agent and releases on return.
 	LLMSemaphore ConcurrencyLimiter
+
+	// PresentationRecoveryTerminalizer escalates bounded presentation failure
+	// through KA's existing complete_no_action escalation contract.
+	PresentationRecoveryTerminalizer func(context.Context, string) error
 }
 
 func (c A2AConfig) validate() error { //nolint:gocritic // hugeParam: value copy intentional for validation
@@ -89,7 +93,7 @@ func NewA2AHandler(cfg A2AConfig) (http.Handler, error) { //nolint:gocritic // h
 		// RunnerProvider (not the plain RunnerConfig) wraps the real ADK
 		// runner in a reinvokingRunner, moving BR-SESS-013's reinvocation
 		// decision inside runner.Runner.Run's own iterator (issue #1776).
-		RunnerProvider:        newReinvokingRunnerProvider(runnerCfg, log, cfg.Auditor),
+		RunnerProvider:        newReinvokingRunnerProvider(runnerCfg, log, cfg.Auditor, cfg.PresentationRecoveryTerminalizer),
 		BeforeExecuteCallback: buildBeforeExecuteCallback(cfg.BeforeExecute, cfg.Auditor),
 		AfterExecuteCallback:  buildAfterExecuteCallback(log, cfg.Auditor),
 		GenAIPartConverter:    buildStreamingPartConverter(),
@@ -234,7 +238,7 @@ func buildAfterExecuteCallback(log logr.Logger, auditor audit.Emitter) adka2a.Af
 				Type:   audit.EventTriageCompleted,
 				UserID: username,
 				Detail: map[string]string{
-					"task_id":       taskID,
+					"task_id":        taskID,
 					"triage_outcome": triageOutcome,
 				},
 			})

--- a/pkg/apifrontend/launcher/openai/adapter.go
+++ b/pkg/apifrontend/launcher/openai/adapter.go
@@ -232,12 +232,24 @@ func applyGenerationConfig(req *openaicompat.Request, cfg *genai.GenerateContent
 			req.Tools = append(req.Tools, td)
 		}
 	}
+	applyToolChoice(req, cfg.ToolConfig)
 
 	if cfg.ResponseSchema != nil {
 		if raw, err := json.Marshal(convertSchema(cfg.ResponseSchema)); err == nil {
 			req.ResponseSchema = raw
 		}
 	}
+}
+
+func applyToolChoice(req *openaicompat.Request, config *genai.ToolConfig) {
+	if config == nil || config.FunctionCallingConfig == nil {
+		return
+	}
+	fcc := config.FunctionCallingConfig
+	if fcc.Mode != genai.FunctionCallingConfigModeAny || len(fcc.AllowedFunctionNames) != 1 {
+		return
+	}
+	req.ToolChoice = &openaicompat.ToolChoice{Name: fcc.AllowedFunctionNames[0]}
 }
 
 func convertSchema(s *genai.Schema) map[string]any {

--- a/pkg/apifrontend/launcher/openai/tool_choice_2365_test.go
+++ b/pkg/apifrontend/launcher/openai/tool_choice_2365_test.go
@@ -1,0 +1,46 @@
+package openai_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+
+	openaimodel "github.com/jordigilh/kubernaut/pkg/apifrontend/launcher/openai"
+)
+
+var _ = Describe("OpenAI adapter presentation recovery (#2365)", func() {
+	It("IT-AF-2365-004 (SI-10, AU-3): maps ADK tool choice to OpenAI wire format", func() {
+		var body map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(json.NewDecoder(r.Body).Decode(&body)).To(Succeed())
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","tool_calls":[{"id":"call-1","type":"function","function":{"name":"kubernaut_present_decision","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`))
+		}))
+		DeferCleanup(server.Close)
+
+		modelClient := openaimodel.NewModel("gpt-4o", server.URL, "")
+		var err error
+		for _, runErr := range modelClient.GenerateContent(context.Background(), &model.LLMRequest{
+			Config: &genai.GenerateContentConfig{
+				Tools: []*genai.Tool{{FunctionDeclarations: []*genai.FunctionDeclaration{{Name: "kubernaut_present_decision"}}}},
+				ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{
+					Mode:                 genai.FunctionCallingConfigModeAny,
+					AllowedFunctionNames: []string{"kubernaut_present_decision"},
+				}},
+			},
+		}, false) {
+			err = runErr
+		}
+		Expect(err).NotTo(HaveOccurred())
+		Expect(body["tool_choice"]).To(Equal(map[string]any{
+			"type":     "function",
+			"function": map[string]any{"name": "kubernaut_present_decision"},
+		}))
+	})
+})

--- a/pkg/apifrontend/launcher/reinvoking_runner.go
+++ b/pkg/apifrontend/launcher/reinvoking_runner.go
@@ -48,12 +48,13 @@ import (
 // a2a-go consumer never observes a premature "final" event and never tears
 // the shared context down mid-reinvocation.
 type reinvokingRunner struct {
-	inner              adka2a.Runner
-	sessionService     adksession.Service
-	appName            string
-	logger             logr.Logger
-	auditor            audit.Emitter
-	toolRetryThreshold int
+	inner                            adka2a.Runner
+	sessionService                   adksession.Service
+	appName                          string
+	logger                           logr.Logger
+	auditor                          audit.Emitter
+	toolRetryThreshold               int
+	presentationRecoveryTerminalizer func(context.Context, string) error
 }
 
 // newReinvokingRunner constructs a reinvokingRunner around inner (the
@@ -62,17 +63,22 @@ type reinvokingRunner struct {
 // auditor may be nil (audit emission is best-effort and skipped when unset,
 // matching this package's other AuditFunc-style call sites); it is used to
 // record SI-4/AU-3 evidence when the #2078 tool-retry circuit breaker trips.
-func newReinvokingRunner(inner adka2a.Runner, sessionService adksession.Service, appName string, logger logr.Logger, auditor audit.Emitter) *reinvokingRunner {
+func newReinvokingRunner(inner adka2a.Runner, sessionService adksession.Service, appName string, logger logr.Logger, auditor audit.Emitter, terminalizer ...func(context.Context, string) error) *reinvokingRunner {
 	if logger.GetSink() == nil {
 		logger = logr.Discard()
 	}
+	var recoveryTerminalizer func(context.Context, string) error
+	if len(terminalizer) > 0 {
+		recoveryTerminalizer = terminalizer[0]
+	}
 	return &reinvokingRunner{
-		inner:              inner,
-		sessionService:     sessionService,
-		appName:            appName,
-		logger:             logger,
-		auditor:            auditor,
-		toolRetryThreshold: DefaultToolRetryCircuitBreakerThreshold,
+		inner:                            inner,
+		sessionService:                   sessionService,
+		appName:                          appName,
+		logger:                           logger,
+		auditor:                          auditor,
+		toolRetryThreshold:               DefaultToolRetryCircuitBreakerThreshold,
+		presentationRecoveryTerminalizer: recoveryTerminalizer,
 	}
 }
 
@@ -112,6 +118,10 @@ func (r *reinvokingRunner) Run(ctx context.Context, userID, sessionID string, ms
 			}
 
 			if !r.needsReinvocation(ctx, userID, sessionID, reinvokeCount) {
+				r.handlePresentationRecoveryExhaustion(ctx, userID, sessionID, yield)
+				return
+			}
+			if !r.recordPresentationRecoveryAttempt(ctx, userID, sessionID) {
 				return
 			}
 			reinvokeCount++
@@ -121,6 +131,65 @@ func (r *reinvokingRunner) Run(ctx context.Context, userID, sessionID string, ms
 			)
 			currentMsg = session.SyntheticMessage()
 		}
+	}
+}
+
+func (r *reinvokingRunner) recordPresentationRecoveryAttempt(ctx context.Context, userID, sessionID string) bool {
+	resp, err := r.sessionService.Get(ctx, &adksession.GetRequest{AppName: r.appName, UserID: userID, SessionID: sessionID})
+	if err != nil || resp == nil || resp.Session == nil {
+		if err != nil {
+			r.logger.Error(err, "failed to record presentation recovery attempt", "session_id", sessionID)
+		}
+		return false
+	}
+	if !session.PresentationRecoveryRequired(resp.Session.State()) {
+		return true
+	}
+	event := adksession.NewEvent(ctx, "presentation-recovery")
+	event.Actions.StateDelta = map[string]any{
+		session.StateKeyPresentationRecoveryCount: session.PresentationRecoveryCount(resp.Session.State()) + 1,
+	}
+	if err := r.sessionService.AppendEvent(ctx, resp.Session, event); err != nil {
+		r.logger.Error(err, "failed to persist presentation recovery attempt", "session_id", sessionID)
+		return false
+	}
+	return true
+}
+
+func (r *reinvokingRunner) handlePresentationRecoveryExhaustion(ctx context.Context, userID, sessionID string, yield func(*adksession.Event, error) bool) {
+	resp, err := r.sessionService.Get(ctx, &adksession.GetRequest{AppName: r.appName, UserID: userID, SessionID: sessionID})
+	if err != nil || resp == nil || resp.Session == nil {
+		return
+	}
+	state := resp.Session.State()
+	if !session.PresentationRecoveryRequired(state) || session.PresentationRecoveryCount(state) < session.MaxPresentationRecoveries {
+		return
+	}
+
+	_ = EmitArtifactSafe(ctx, map[string]any{
+		"type":           "investigation_summary",
+		"schema_version": "1.0",
+		"summary":        "Structured decision presentation could not be completed.",
+		"options":        []any{},
+		"status":         "failure",
+		"failure_reason": "presentation_recovery_exhausted",
+	}, "Structured decision presentation could not be completed.", map[string]any{"recovery_exhausted": true})
+
+	r.escalatePresentationRecovery(ctx, sessionID, state)
+	_ = yield(nil, fmt.Errorf("presentation recovery exhausted for session %q", sessionID))
+}
+
+func (r *reinvokingRunner) escalatePresentationRecovery(ctx context.Context, sessionID string, state adksession.State) {
+	if r.presentationRecoveryTerminalizer == nil {
+		return
+	}
+	rrID, _ := state.Get(session.StateKeyActiveRRID)
+	rr, ok := rrID.(string)
+	if !ok || rr == "" {
+		return
+	}
+	if err := r.presentationRecoveryTerminalizer(ctx, rr); err != nil {
+		r.logger.Error(err, "failed to escalate presentation recovery exhaustion", "session_id", sessionID, "rr_id", rr)
 	}
 }
 
@@ -286,7 +355,7 @@ func (a plainRunnerAdapter) Run(ctx context.Context, userID, sessionID string, m
 // *runner.Runner from it, then wraps that runner instead of returning it
 // directly. auditor may be nil; it is threaded through to reinvokingRunner
 // for #2078 tool-retry circuit breaker trip audit events.
-func newReinvokingRunnerProvider(baseConfig runner.Config, logger logr.Logger, auditor audit.Emitter) adka2a.RunnerProvider {
+func newReinvokingRunnerProvider(baseConfig runner.Config, logger logr.Logger, auditor audit.Emitter, terminalizer ...func(context.Context, string) error) adka2a.RunnerProvider {
 	return func(_ context.Context, _ *a2asrv.RequestContext, p *plugin.Plugin) (adka2a.RunnerConfig, adka2a.Runner, error) {
 		if baseConfig.Agent == nil {
 			return adka2a.RunnerConfig{}, nil, fmt.Errorf("runner.Config.Agent is not provided")
@@ -303,7 +372,7 @@ func newReinvokingRunnerProvider(baseConfig runner.Config, logger logr.Logger, a
 		}
 
 		runnerConfig := adka2a.RunnerConfig{AppName: cfg.AppName, Agent: cfg.Agent, SessionService: cfg.SessionService}
-		wrapped := newReinvokingRunner(plainRunnerAdapter{runner: realRunner}, cfg.SessionService, cfg.AppName, logger, auditor)
+		wrapped := newReinvokingRunner(plainRunnerAdapter{runner: realRunner}, cfg.SessionService, cfg.AppName, logger, auditor, terminalizer...)
 		return runnerConfig, wrapped, nil
 	}
 }

--- a/pkg/apifrontend/launcher/reinvoking_runner.go
+++ b/pkg/apifrontend/launcher/reinvoking_runner.go
@@ -116,6 +116,11 @@ func (r *reinvokingRunner) Run(ctx context.Context, userID, sessionID string, ms
 			if outcome.hadError {
 				return
 			}
+			if err := r.completeBusinessOutcome(ctx, userID, sessionID); err != nil {
+				r.logger.Error(err, "business-outcome completion failed", "session_id", sessionID)
+				_ = yield(nil, err)
+				return
+			}
 
 			if !r.needsReinvocation(ctx, userID, sessionID, reinvokeCount) {
 				r.handlePresentationRecoveryExhaustion(ctx, userID, sessionID, yield)

--- a/pkg/apifrontend/launcher/reinvoking_runner_test.go
+++ b/pkg/apifrontend/launcher/reinvoking_runner_test.go
@@ -130,6 +130,48 @@ var _ = Describe("reinvokingRunner (BR-SESS-013, issue #1776)", func() {
 		Expect(events).To(HaveLen(2), "both the original and reinvoked turn's events must be yielded")
 	})
 
+	It("IT-AF-2365-002 (AU-3, SI-4): exhausts presentation recovery through the terminalizer", func() {
+		sessionSvc := adksession.InMemoryService()
+		createResp, err := sessionSvc.Create(context.Background(), &adksession.CreateRequest{
+			AppName: "test-app", UserID: "user-1", SessionID: "sess-2365",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		setup := adksession.NewEvent(context.Background(), "setup-2365")
+		setup.Actions.StateDelta = map[string]any{
+			session.StateKeyDriverActive:              true,
+			session.StateKeyPhase3Blocked:             true,
+			session.StateKeyPresentationRequired:      true,
+			session.StateKeyPresentationRecoveryCount: 0,
+			session.StateKeyActiveRRID:                "rr-2365",
+		}
+		Expect(sessionSvc.AppendEvent(context.Background(), createResp.Session, setup)).To(Succeed())
+
+		fake := &scriptedRunner{
+			sessionSvc: sessionSvc,
+			responses: []*adksession.Event{
+				textOnlyModelEvent("inv-2365-1", "I have selected the workflow."),
+				textOnlyModelEvent("inv-2365-2", "The workflow is ready."),
+				textOnlyModelEvent("inv-2365-3", "Let me submit the result."),
+			},
+		}
+		var escalatedRR string
+		rr := launcher.NewReinvokingRunnerForTest(fake, sessionSvc, "test-app", logr.Discard(), nil,
+			func(_ context.Context, rrID string) error {
+				escalatedRR = rrID
+				return nil
+			})
+
+		var terminalErr error
+		for _, runErr := range rr.Run(context.Background(), "user-1", "sess-2365", genai.NewContentFromText("investigate and fix", genai.RoleUser), agent.RunConfig{}) {
+			if runErr != nil {
+				terminalErr = runErr
+			}
+		}
+		Expect(terminalErr).To(MatchError(ContainSubstring("presentation recovery exhausted")))
+		Expect(escalatedRR).To(Equal("rr-2365"))
+		Expect(fake.calls).To(HaveLen(3))
+	})
+
 	It("UT-AF-REINV-003: Run() does NOT re-invoke when last event has a tool call", func() {
 		sessionSvc := adksession.InMemoryService()
 		_, err := sessionSvc.Create(context.Background(), &adksession.CreateRequest{

--- a/pkg/apifrontend/launcher/reinvoking_runner_test.go
+++ b/pkg/apifrontend/launcher/reinvoking_runner_test.go
@@ -176,9 +176,6 @@ var _ = Describe("reinvokingRunner (BR-SESS-013, issue #1776)", func() {
 			sessionSvc: sessionSvc,
 			appName:    "test-app",
 			responses:  []*adksession.Event{textOnlyModelEvent("inv-2365-incomplete", "I will submit the result.")},
-			sideEffects: map[int]map[string]any{
-				0: {session.StateKeyPhase3Blocked: true},
-			},
 		}
 		queue := &fakeQueue{}
 		bridgeCtx := launcher.WithEventBridge(ctx, queue, "task-2365-incomplete", "sess-2365-incomplete", nil)
@@ -197,6 +194,50 @@ var _ = Describe("reinvokingRunner (BR-SESS-013, issue #1776)", func() {
 		Expect(escalated).To(Equal("rr-2365-incomplete"))
 		data := launcher.LastArtifactDataForTest(queue.events[0])
 		Expect(data).To(HaveKeyWithValue("status", "failure"))
+		Expect(data).To(HaveKeyWithValue("failure_reason", "missing_authoritative_data"))
+	})
+
+	It("IT-AF-2365-008b (AC-6, SI-4): does not escalate incomplete presentation at a consent boundary", func() {
+		ctx := context.Background()
+		sessionSvc := adksession.InMemoryService()
+		createResp, err := sessionSvc.Create(ctx, &adksession.CreateRequest{
+			AppName: "test-app", UserID: "user-1", SessionID: "sess-2365-consent-incomplete",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		setup := adksession.NewEvent(ctx, "setup-2365-consent-incomplete")
+		setup.Actions.StateDelta = map[string]any{
+			session.StateKeyDriverActive:           true,
+			session.StateKeyPhase3Blocked:          false,
+			session.StateKeyDecisionArtifactStatus: session.DecisionArtifactRequired,
+			session.StateKeyActiveRRID:             "rr-2365-consent-incomplete",
+			session.StateKeyActiveSession:          "sess-2365-consent-incomplete",
+		}
+		Expect(sessionSvc.AppendEvent(ctx, createResp.Session, setup)).To(Succeed())
+
+		fake := &checkpointObservingRunner{
+			sessionSvc: sessionSvc,
+			appName:    "test-app",
+			responses:  []*adksession.Event{textOnlyModelEvent("inv-2365-consent-incomplete", "I need to wait for confirmation.")},
+			sideEffects: map[int]map[string]any{
+				0: {session.StateKeyPhase3Blocked: true},
+			},
+		}
+		queue := &fakeQueue{}
+		bridgeCtx := launcher.WithEventBridge(ctx, queue, "task-2365-consent-incomplete", "sess-2365-consent-incomplete", nil)
+		var escalated string
+		rr := launcher.NewReinvokingRunnerForTest(fake, sessionSvc, "test-app", logr.Discard(), nil,
+			func(_ context.Context, rrID string) error {
+				escalated = rrID
+				return nil
+			})
+
+		for event, runErr := range rr.Run(bridgeCtx, "user-1", "sess-2365-consent-incomplete", genai.NewContentFromText("select a workflow", genai.RoleUser), agent.RunConfig{}) {
+			Expect(runErr).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+		}
+
+		Expect(escalated).To(BeEmpty())
+		data := launcher.LastArtifactDataForTest(queue.events[0])
 		Expect(data).To(HaveKeyWithValue("failure_reason", "missing_authoritative_data"))
 	})
 

--- a/pkg/apifrontend/launcher/reinvoking_runner_test.go
+++ b/pkg/apifrontend/launcher/reinvoking_runner_test.go
@@ -95,6 +95,111 @@ func toolCallModelEvent(invocationID string) *adksession.Event {
 }
 
 var _ = Describe("reinvokingRunner (BR-SESS-013, issue #1776)", func() {
+	It("IT-AF-2365-006 (AC-6, AU-3): recovers the decision artifact without reinvoking past consent", func() {
+		ctx := context.Background()
+		sessionSvc := adksession.InMemoryService()
+		createResp, err := sessionSvc.Create(ctx, &adksession.CreateRequest{
+			AppName: "test-app", UserID: "user-1", SessionID: "sess-2365-coordinator",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		setup := adksession.NewEvent(ctx, "setup-2365-coordinator")
+		setup.Actions.StateDelta = map[string]any{
+			session.StateKeyDriverActive:           true,
+			session.StateKeyPhase3Blocked:          false,
+			session.StateKeyDecisionArtifactStatus: session.DecisionArtifactRequired,
+			session.StateKeyActiveRRID:             "rr-2365-coordinator",
+			session.StateKeyActiveSession:          "sess-2365-coordinator",
+			session.StateKeyGroundedRCAPayload: map[string]any{
+				"explanation": "The deployment is restarting after a bad configuration.",
+				"severity":    "critical",
+				"confidence":  0.94,
+			},
+			session.StateKeyDiscoveryResult: map[string]any{
+				"workflows": []any{map[string]any{
+					"workflow_id": "wf-restart",
+					"name":        "Restart deployment",
+					"description": "Restarts the deployment",
+				}},
+			},
+		}
+		Expect(sessionSvc.AppendEvent(ctx, createResp.Session, setup)).To(Succeed())
+
+		fake := &checkpointObservingRunner{
+			sessionSvc: sessionSvc,
+			appName:    "test-app",
+			responses:  []*adksession.Event{textOnlyModelEvent("inv-2365-coordinator", "I have selected the workflow.")},
+			sideEffects: map[int]map[string]any{
+				0: {session.StateKeyPhase3Blocked: true},
+			},
+		}
+		queue := &fakeQueue{}
+		bridgeCtx := launcher.WithEventBridge(ctx, queue, "task-2365-coordinator", "sess-2365-coordinator", nil)
+		rr := launcher.NewReinvokingRunnerForTest(fake, sessionSvc, "test-app", logr.Discard(), nil)
+
+		for event, runErr := range rr.Run(bridgeCtx, "user-1", "sess-2365-coordinator", genai.NewContentFromText("investigate and fix", genai.RoleUser), agent.RunConfig{}) {
+			Expect(runErr).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+		}
+
+		Expect(fake.calls).To(HaveLen(1), "recovery must not use generic reinvocation")
+		Expect(queue.events).To(HaveLen(1), "recovery must emit one structured decision artifact")
+		data := launcher.LastArtifactDataForTest(queue.events[0])
+		Expect(data).To(HaveKeyWithValue("source", "af_completion_recovery"))
+		Expect(data).To(HaveKeyWithValue("requires_user_selection", true))
+		Expect(data["options"]).To(HaveLen(1))
+
+		stored, err := sessionSvc.Get(ctx, &adksession.GetRequest{AppName: "test-app", UserID: "user-1", SessionID: "sess-2365-coordinator"})
+		Expect(err).NotTo(HaveOccurred())
+		status, err := stored.Session.State().Get(session.StateKeyDecisionArtifactStatus)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(session.DecisionArtifactRecovered))
+	})
+
+	It("IT-AF-2365-008 (AU-12, SI-4): escalates incomplete recovery instead of dismissing it", func() {
+		ctx := context.Background()
+		sessionSvc := adksession.InMemoryService()
+		createResp, err := sessionSvc.Create(ctx, &adksession.CreateRequest{
+			AppName: "test-app", UserID: "user-1", SessionID: "sess-2365-incomplete",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		setup := adksession.NewEvent(ctx, "setup-2365-incomplete")
+		setup.Actions.StateDelta = map[string]any{
+			session.StateKeyDriverActive:           true,
+			session.StateKeyPhase3Blocked:          false,
+			session.StateKeyDecisionArtifactStatus: session.DecisionArtifactRequired,
+			session.StateKeyActiveRRID:             "rr-2365-incomplete",
+			session.StateKeyActiveSession:          "sess-2365-incomplete",
+		}
+		Expect(sessionSvc.AppendEvent(ctx, createResp.Session, setup)).To(Succeed())
+
+		fake := &checkpointObservingRunner{
+			sessionSvc: sessionSvc,
+			appName:    "test-app",
+			responses:  []*adksession.Event{textOnlyModelEvent("inv-2365-incomplete", "I will submit the result.")},
+			sideEffects: map[int]map[string]any{
+				0: {session.StateKeyPhase3Blocked: true},
+			},
+		}
+		queue := &fakeQueue{}
+		bridgeCtx := launcher.WithEventBridge(ctx, queue, "task-2365-incomplete", "sess-2365-incomplete", nil)
+		var escalated string
+		rr := launcher.NewReinvokingRunnerForTest(fake, sessionSvc, "test-app", logr.Discard(), nil,
+			func(_ context.Context, rrID string) error {
+				escalated = rrID
+				return nil
+			})
+
+		for event, runErr := range rr.Run(bridgeCtx, "user-1", "sess-2365-incomplete", genai.NewContentFromText("investigate and fix", genai.RoleUser), agent.RunConfig{}) {
+			Expect(runErr).NotTo(HaveOccurred())
+			Expect(event).NotTo(BeNil())
+		}
+
+		Expect(escalated).To(Equal("rr-2365-incomplete"))
+		data := launcher.LastArtifactDataForTest(queue.events[0])
+		Expect(data).To(HaveKeyWithValue("status", "failure"))
+		Expect(data).To(HaveKeyWithValue("failure_reason", "missing_authoritative_data"))
+	})
+
 	It("UT-AF-REINV-002: Run() re-invokes when last event has no tool call (session Active, count < Max)", func() {
 		sessionSvc := adksession.InMemoryService()
 		createResp, err := sessionSvc.Create(context.Background(), &adksession.CreateRequest{

--- a/pkg/apifrontend/session/completion.go
+++ b/pkg/apifrontend/session/completion.go
@@ -1,0 +1,29 @@
+package session
+
+// CompletionObligation describes the independent presentation and execution
+// consequences of a successful workflow discovery result.
+type CompletionObligation struct {
+	PresentationRequired bool
+	ExecutionAllowed     bool
+}
+
+// DecisionObligation derives the business outcome required after workflow
+// discovery. Presentation is required for user-facing modes, while execution
+// remains controlled exclusively by the phase-3 consent state.
+func DecisionObligation(mode string, discoverySucceeded, phase3Blocked bool) CompletionObligation {
+	if !discoverySucceeded {
+		return CompletionObligation{ExecutionAllowed: !phase3Blocked}
+	}
+
+	if !ValidInteractionMode(mode) {
+		mode = InteractionModeInteractive
+	}
+	if mode == InteractionModeFullRemediationAutonomous {
+		return CompletionObligation{ExecutionAllowed: !phase3Blocked}
+	}
+
+	return CompletionObligation{
+		PresentationRequired: true,
+		ExecutionAllowed:     !phase3Blocked,
+	}
+}

--- a/pkg/apifrontend/session/completion_test.go
+++ b/pkg/apifrontend/session/completion_test.go
@@ -1,0 +1,45 @@
+package session_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+)
+
+var _ = Describe("Business-outcome completion policy (#2365)", func() {
+	It("UT-AF-2365-003 (BR-INTERACTIVE-010, AC-6): full remediation requires presentation but remains execution-blocked", func() {
+		obligation := session.DecisionObligation(session.InteractionModeFullRemediation, true, true)
+
+		Expect(obligation.PresentationRequired).To(BeTrue())
+		Expect(obligation.ExecutionAllowed).To(BeFalse())
+	})
+
+	It("UT-AF-2365-003b (BR-INTERACTIVE-010, AC-6): autonomous remediation does not activate presentation recovery", func() {
+		obligation := session.DecisionObligation(session.InteractionModeFullRemediationAutonomous, true, false)
+
+		Expect(obligation.PresentationRequired).To(BeFalse())
+		Expect(obligation.ExecutionAllowed).To(BeTrue())
+	})
+
+	It("UT-AF-2365-005 (BR-INTERACTIVE-010, AC-6): interactive discovery requires presentation without granting execution", func() {
+		obligation := session.DecisionObligation(session.InteractionModeInteractive, true, true)
+
+		Expect(obligation.PresentationRequired).To(BeTrue())
+		Expect(obligation.ExecutionAllowed).To(BeFalse())
+	})
+
+	It("UT-AF-2365-005b (SI-10): invalid mode fails safe to interactive policy", func() {
+		obligation := session.DecisionObligation("invalid", true, true)
+
+		Expect(obligation.PresentationRequired).To(BeTrue())
+		Expect(obligation.ExecutionAllowed).To(BeFalse())
+	})
+
+	It("UT-AF-2365-005c (BR-SESS-013): discovery has no presentation obligation before it succeeds", func() {
+		obligation := session.DecisionObligation(session.InteractionModeFullRemediation, false, false)
+
+		Expect(obligation.PresentationRequired).To(BeFalse())
+		Expect(obligation.ExecutionAllowed).To(BeTrue())
+	})
+})

--- a/pkg/apifrontend/session/consent.go
+++ b/pkg/apifrontend/session/consent.go
@@ -70,6 +70,13 @@ const (
 	// from a prior RemediationRequest.
 	StateKeyDiscoverWorkflowsSucceeded = "af_discover_workflows_succeeded"
 
+	// StateKeyPresentationRequired marks the narrow recovery window after
+	// discovery when the model must emit the structured decision artifact.
+	StateKeyPresentationRequired = "af_presentation_required"
+
+	// StateKeyPresentationRecoveryCount bounds corrective presentation turns.
+	StateKeyPresentationRecoveryCount = "af_presentation_recovery_count"
+
 	// StateKeyGroundedContentAvailable records whether the most recent
 	// kubernaut_investigate call produced real, groundable RCA content
 	// (#2047, main clone of #2023). phase_guard.go's harness-enforced

--- a/pkg/apifrontend/session/consent.go
+++ b/pkg/apifrontend/session/consent.go
@@ -39,6 +39,10 @@ const (
 	// af_active_rr_id key.
 	StateKeyActiveRRID = "af_active_rr_id"
 
+	// StateKeyActiveSession records the KA investigation session associated
+	// with the active driver.
+	StateKeyActiveSession = "af_active_session_id"
+
 	// StateKeyInteractionMode records the interaction_mode declared on the
 	// most recent successful kubernaut_investigate call.
 	StateKeyInteractionMode = "af_interaction_mode"
@@ -76,6 +80,19 @@ const (
 
 	// StateKeyPresentationRecoveryCount bounds corrective presentation turns.
 	StateKeyPresentationRecoveryCount = "af_presentation_recovery_count"
+
+	// StateKeyDecisionArtifactStatus records whether the business outcome
+	// coordinator still owes a decision artifact for the current discovery.
+	StateKeyDecisionArtifactStatus = "af_decision_artifact_status"
+
+	// StateKeyGroundedRCAPayload stores a gob-safe canonical RCA payload for
+	// deterministic completion recovery. StateKeyGroundedRCA remains the typed
+	// value used by the agent grounding guard.
+	StateKeyGroundedRCAPayload = "af_grounded_rca_payload"
+
+	// StateKeyDiscoveryResult stores the successful canonical discovery result
+	// for completion recovery when ADK trims older events.
+	StateKeyDiscoveryResult = "af_discovery_result"
 
 	// StateKeyGroundedContentAvailable records whether the most recent
 	// kubernaut_investigate call produced real, groundable RCA content
@@ -115,6 +132,15 @@ const (
 	// key's name implies). A Provisional-only investigate call is treated
 	// the same as one with no structured RCA at all.
 	StateKeyGroundedRCA = "af_grounded_rca"
+)
+
+// DecisionArtifactStatus values persisted in StateKeyDecisionArtifactStatus.
+const (
+	DecisionArtifactNotRequired = "not_required"
+	DecisionArtifactRequired    = "required"
+	DecisionArtifactEmitted     = "emitted"
+	DecisionArtifactRecovered   = "recovered"
+	DecisionArtifactFailed      = "failed"
 )
 
 // Interaction mode values for InteractionMode / StateKeyInteractionMode.

--- a/pkg/apifrontend/session/consent.go
+++ b/pkg/apifrontend/session/consent.go
@@ -90,6 +90,14 @@ const (
 	// value used by the agent grounding guard.
 	StateKeyGroundedRCAPayload = "af_grounded_rca_payload"
 
+	// StateKeyGroundedSummary stores the grounded narrative available when KA
+	// returns summary content without a non-provisional structured RCA.
+	StateKeyGroundedSummary = "af_grounded_summary"
+
+	// StateKeyGroundedSummaryProvisional distinguishes severity-triage fallback
+	// text from an authoritative investigation summary.
+	StateKeyGroundedSummaryProvisional = "af_grounded_summary_provisional"
+
 	// StateKeyDiscoveryResult stores the successful canonical discovery result
 	// for completion recovery when ADK trims older events.
 	StateKeyDiscoveryResult = "af_discovery_result"

--- a/pkg/apifrontend/session/reinvoke.go
+++ b/pkg/apifrontend/session/reinvoke.go
@@ -31,6 +31,10 @@ const (
 	// investigation. This prevents infinite re-invocation loops.
 	MaxReinvocations = 3
 
+	// MaxPresentationRecoveries bounds retries after discovery narration so a
+	// provider that ignores tool choice cannot spin the A2A turn indefinitely.
+	MaxPresentationRecoveries = 2
+
 	// ReinvocationMessage is the synthetic user message injected to trigger
 	// the agent to continue investigation when a premature text-only turn
 	// end is detected.
@@ -81,11 +85,50 @@ func NeedsReinvocationCtx(ctx context.Context, phase v1alpha1.SessionPhase, even
 	if !driverActive(state) {
 		return false
 	}
-	if checkpointBlocked(state) {
+	if checkpointBlocked(state) && !presentationRecoveryRequired(state) {
+		return false
+	}
+	if presentationRecoveryRequired(state) && presentationRecoveryCount(state) >= MaxPresentationRecoveries {
 		return false
 	}
 
 	return true
+}
+
+func presentationRecoveryRequired(state adksession.State) bool {
+	if state == nil {
+		return false
+	}
+	v, err := state.Get(StateKeyPresentationRequired)
+	if err != nil {
+		return false
+	}
+	required, _ := v.(bool)
+	return required
+}
+
+// PresentationRecoveryRequired reports whether discovery completed but the
+// structured presentation artifact has not yet been emitted.
+func PresentationRecoveryRequired(state adksession.State) bool {
+	return presentationRecoveryRequired(state)
+}
+
+// PresentationRecoveryCount returns the number of corrective presentation
+// turns already attempted.
+func PresentationRecoveryCount(state adksession.State) int {
+	return presentationRecoveryCount(state)
+}
+
+func presentationRecoveryCount(state adksession.State) int {
+	if state == nil {
+		return 0
+	}
+	v, err := state.Get(StateKeyPresentationRecoveryCount)
+	if err != nil {
+		return 0
+	}
+	count, _ := v.(int)
+	return count
 }
 
 // driverActive reports whether an interactive driver session (a successful

--- a/pkg/apifrontend/session/reinvoke_test.go
+++ b/pkg/apifrontend/session/reinvoke_test.go
@@ -238,15 +238,25 @@ var _ = Describe("Re-invocation Fallback", func() {
 			"a genuinely stalled mid-investigation turn (driver active, no checkpoint gate) must still be nudged")
 	})
 
-	It("UT-AF-2365-001 (SI-4): recovers after discovery even when phase 3 is blocked", func() {
+	It("UT-AF-2365-001 (SI-4): recovers after autonomous discovery", func() {
 		events := getEvents(textEvent())
 		state := newFakeState(map[string]any{
 			session.StateKeyDriverActive:              true,
-			session.StateKeyPhase3Blocked:             true,
+			session.StateKeyPhase3Blocked:             false,
 			session.StateKeyPresentationRequired:      true,
 			session.StateKeyPresentationRecoveryCount: 0,
 		})
 		Expect(session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, state, 0)).To(BeTrue())
+	})
+
+	It("UT-AF-2365-003 (AC-6): preserves the phase-3 consent checkpoint", func() {
+		events := getEvents(textEvent())
+		state := newFakeState(map[string]any{
+			session.StateKeyDriverActive:         true,
+			session.StateKeyPhase3Blocked:        true,
+			session.StateKeyPresentationRequired: false,
+		})
+		Expect(session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, state, 0)).To(BeFalse())
 	})
 
 	It("UT-AF-2365-002 (SI-4): stops after bounded presentation recovery", func() {

--- a/pkg/apifrontend/session/reinvoke_test.go
+++ b/pkg/apifrontend/session/reinvoke_test.go
@@ -238,6 +238,27 @@ var _ = Describe("Re-invocation Fallback", func() {
 			"a genuinely stalled mid-investigation turn (driver active, no checkpoint gate) must still be nudged")
 	})
 
+	It("UT-AF-2365-001 (SI-4): recovers after discovery even when phase 3 is blocked", func() {
+		events := getEvents(textEvent())
+		state := newFakeState(map[string]any{
+			session.StateKeyDriverActive:              true,
+			session.StateKeyPhase3Blocked:             true,
+			session.StateKeyPresentationRequired:      true,
+			session.StateKeyPresentationRecoveryCount: 0,
+		})
+		Expect(session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, state, 0)).To(BeTrue())
+	})
+
+	It("UT-AF-2365-002 (SI-4): stops after bounded presentation recovery", func() {
+		events := getEvents(textEvent())
+		state := newFakeState(map[string]any{
+			session.StateKeyDriverActive:              true,
+			session.StateKeyPresentationRequired:      true,
+			session.StateKeyPresentationRecoveryCount: session.MaxPresentationRecoveries,
+		})
+		Expect(session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, state, 0)).To(BeFalse())
+	})
+
 	It("UT-AF-1912-004: does NOT nudge once driverActive is cleared, even if the session phase still reads Active (#1912)", func() {
 		// Simulates the state phase_guard.go now leaves behind post-#1912-fix:
 		// a session-terminal tool (kubernaut_complete/kubernaut_cancel) has

--- a/pkg/apifrontend/session/reinvoke_test.go
+++ b/pkg/apifrontend/session/reinvoke_test.go
@@ -238,13 +238,23 @@ var _ = Describe("Re-invocation Fallback", func() {
 			"a genuinely stalled mid-investigation turn (driver active, no checkpoint gate) must still be nudged")
 	})
 
-	It("UT-AF-2365-001 (SI-4): recovers after autonomous discovery", func() {
+	It("UT-AF-2365-001 (SI-4): recovers after full-remediation discovery", func() {
 		events := getEvents(textEvent())
 		state := newFakeState(map[string]any{
 			session.StateKeyDriverActive:              true,
-			session.StateKeyPhase3Blocked:             false,
+			session.StateKeyPhase3Blocked:             true,
 			session.StateKeyPresentationRequired:      true,
 			session.StateKeyPresentationRecoveryCount: 0,
+		})
+		Expect(session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, state, 0)).To(BeTrue())
+	})
+
+	It("UT-AF-2365-004 (AC-6): does not intercept fully autonomous selection", func() {
+		events := getEvents(textEvent())
+		state := newFakeState(map[string]any{
+			session.StateKeyDriverActive:         true,
+			session.StateKeyPhase3Blocked:        false,
+			session.StateKeyPresentationRequired: false,
 		})
 		Expect(session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, state, 0)).To(BeTrue())
 	})

--- a/pkg/apifrontend/tools/af_create_rr.go
+++ b/pkg/apifrontend/tools/af_create_rr.go
@@ -40,6 +40,9 @@ type ToolDeps struct {
 	// backward-compatible: scope validation is skipped (matches Triager's
 	// own nil-safe convention above).
 	ScopeChecker scope.ScopeChecker
+	// ClusterLister names known fleet clusters for the unattributed-refusal
+	// message (#2362). Nil-safe: a nil lister preserves the legacy message.
+	ClusterLister ClusterLister
 }
 
 // maxDescriptionLen is the maximum length for RR description (truncated, not rejected).
@@ -229,7 +232,7 @@ func HandleCreateRRWithHooks(ctx context.Context, d *ToolDeps, args *CreateRRArg
 	// triage round-trip and an RR CRD create/delete cycle.
 	if managed, msg := checkRRScope(ctx, d.ScopeChecker, d.Auditor, username, scope.ResourceIdentity{
 		ClusterID: args.ClusterID, Namespace: args.Namespace, Kind: args.Kind, Name: args.Name,
-	}); !managed {
+	}, d.ClusterLister); !managed {
 		return CreateRRResult{}, fmt.Errorf("%w: %s", ErrResourceNotManaged, msg)
 	}
 

--- a/pkg/apifrontend/tools/af_create_rr_test.go
+++ b/pkg/apifrontend/tools/af_create_rr_test.go
@@ -25,6 +25,7 @@ import (
 	prom "github.com/jordigilh/kubernaut/pkg/apifrontend/prometheus"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
 	gwtypes "github.com/jordigilh/kubernaut/pkg/gateway/types"
 	"github.com/jordigilh/kubernaut/test/shared/mocks"
 )
@@ -34,6 +35,17 @@ const (
 	kubernautSystem = "kubernaut-system"
 	production      = "production"
 )
+
+// stubClusterLister is a one-method tools.ClusterLister fake for #2362 specs.
+type stubClusterLister struct{ ids []string }
+
+func (s stubClusterLister) List() []registry.ClusterInfo {
+	infos := make([]registry.ClusterInfo, 0, len(s.ids))
+	for _, id := range s.ids {
+		infos = append(infos, registry.ClusterInfo{ID: id})
+	}
+	return infos
+}
 
 type noopPromClient struct{}
 
@@ -1108,6 +1120,101 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			Expect(rec.events[0].Detail["namespace"]).To(Equal("prod"))
 			Expect(rec.events[0].Detail["kind"]).To(Equal("Deployment"))
 			Expect(rec.events[0].Detail["name"]).To(Equal("web"))
+		})
+	})
+
+	// Issue #2362: fleet-enabled + unattributed scope checks must refuse with
+	// cluster attribution guidance (AC-3 fail-closed) instead of assuming
+	// local and misreporting the resource as unmanaged.
+	Describe("ScopeChecker fleet-attribution refusal (#2362)", func() {
+		It("UT-AF-2362-001: fleet + empty cluster + local miss rejects naming known clusters, not the managed label", func() {
+			tc := newTypedFakeClient()
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:        tc,
+				ControllerNS:  kubernautSystem,
+				Triager:       defaultTestTriager("prod", "Deployment", "web"),
+				ScopeChecker:  &mocks.NeverManagedScopeChecker{},
+				ClusterLister: stubClusterLister{ids: []string{"remote-cluster"}},
+			}, &tools.CreateRRArgs{
+				Namespace: "demo-checkout", Kind: "Pod", Name: "worker-1",
+				Description: "unattributed spoke resource", APIVersion: "v1",
+			}, "carol")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, tools.ErrResourceNotManaged)).To(BeTrue(),
+				"AC-3: an unattributed scope miss must still fail closed")
+			Expect(err.Error()).To(ContainSubstring("remote-cluster"))
+			Expect(err.Error()).To(ContainSubstring("cluster_id"))
+			Expect(err.Error()).NotTo(ContainSubstring("Add label kubernaut.ai/managed=true"),
+				"the label lecture misleads when the label may already exist on a spoke")
+		})
+
+		It("UT-AF-2362-002: nil lister keeps the legacy local message byte-for-byte", func() {
+			tc := newTypedFakeClient()
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: kubernautSystem,
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
+				ScopeChecker: &mocks.NeverManagedScopeChecker{},
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "unmanaged, no fleet", APIVersion: "apps/v1",
+			}, "carol")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, tools.ErrResourceNotManaged)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("(cluster=local)"))
+			Expect(err.Error()).To(ContainSubstring("Add label kubernaut.ai/managed=true"))
+		})
+
+		It("UT-AF-2362-003: explicit cluster_id keeps the cluster-scoped message unchanged", func() {
+			tc := newTypedFakeClient()
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:        tc,
+				ControllerNS:  kubernautSystem,
+				Triager:       defaultTestTriager("prod", "Deployment", "web"),
+				ScopeChecker:  &mocks.NeverManagedScopeChecker{},
+				ClusterLister: stubClusterLister{ids: []string{"remote-cluster"}},
+			}, &tools.CreateRRArgs{
+				Namespace: "demo-checkout", Kind: "Pod", Name: "worker-1",
+				Description: "explicit remote miss", APIVersion: "v1", ClusterID: "remote-cluster",
+			}, "carol")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, tools.ErrResourceNotManaged)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("(cluster=remote-cluster)"))
+		})
+
+		It("UT-AF-2362-004: the attribution refusal still emits EventRRScopeRejected (AU-2/AU-12)", func() {
+			tc := newTypedFakeClient()
+			rec := &auditRecorder{}
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:        tc,
+				ControllerNS:  kubernautSystem,
+				Triager:       defaultTestTriager("prod", "Deployment", "web"),
+				Auditor:       rec,
+				ScopeChecker:  &mocks.NeverManagedScopeChecker{},
+				ClusterLister: stubClusterLister{ids: []string{"remote-cluster"}},
+			}, &tools.CreateRRArgs{
+				Namespace: "demo-checkout", Kind: "Pod", Name: "worker-1",
+				Description: "unattributed with auditor", APIVersion: "v1",
+			}, "carol")
+			Expect(err).To(HaveOccurred())
+			Expect(rec.events).To(HaveLen(1))
+			Expect(rec.events[0].Type).To(Equal(audit.EventRRScopeRejected))
+		})
+
+		It("UT-AF-2362-005: local hit with empty cluster proceeds despite a lister being present", func() {
+			tc := newTypedFakeClient()
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:        tc,
+				ControllerNS:  kubernautSystem,
+				Triager:       defaultTestTriager("prod", "Deployment", "web"),
+				ScopeChecker:  &mocks.AlwaysManagedScopeChecker{},
+				ClusterLister: stubClusterLister{ids: []string{"remote-cluster"}},
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "managed locally", APIVersion: "apps/v1",
+			}, "carol")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RRID).To(HavePrefix("rr-"))
 		})
 	})
 

--- a/pkg/apifrontend/tools/af_investigate_alert.go
+++ b/pkg/apifrontend/tools/af_investigate_alert.go
@@ -50,6 +50,9 @@ type InvestigateAlertConfig struct {
 	Mapper             meta.RESTMapper
 	Signaler           AlertISSignaler
 	ScopeChecker       scope.ScopeChecker
+	// ClusterLister names known fleet clusters for the unattributed-refusal
+	// message (#2362). Nil-safe: a nil lister preserves the legacy message.
+	ClusterLister ClusterLister
 }
 
 // InvestigateAlertArgs defines the LLM-supplied input for kubernaut_investigate_alert.
@@ -147,7 +150,7 @@ func HandleInvestigateAlert(
 	}
 
 	hooks, hookFired := buildAlertPreCreateISHooks(cfg.Signaler, username)
-	result, err := HandleCreateRRWithHooks(ctx, &ToolDeps{Client: cfg.Client, DynClient: cfg.DynClient, ControllerNS: cfg.ControllerNS, Triager: cfg.Triager, Auditor: cfg.Auditor, ScopeChecker: cfg.ScopeChecker}, createArgs, username, hooks)
+	result, err := HandleCreateRRWithHooks(ctx, &ToolDeps{Client: cfg.Client, DynClient: cfg.DynClient, ControllerNS: cfg.ControllerNS, Triager: cfg.Triager, Auditor: cfg.Auditor, ScopeChecker: cfg.ScopeChecker, ClusterLister: cfg.ClusterLister}, createArgs, username, hooks)
 	if err != nil {
 		return InvestigateAlertResult{}, fmt.Errorf("create RR for alert investigation: %w", err)
 	}

--- a/pkg/apifrontend/tools/af_list_events.go
+++ b/pkg/apifrontend/tools/af_list_events.go
@@ -23,6 +23,14 @@ type ListEventsArgs struct {
 	Namespace string `json:"namespace"`
 	Reason    string `json:"reason,omitempty"`
 	Kind      string `json:"involved_kind,omitempty"`
+	// ClusterID, RRID and SessionID are ambient hints the LLM propagates from
+	// fleet context and cross-phase preservation (#2364 Tier 2: fleet triage
+	// naturally scopes events per-cluster, unlike kubectl_get/list which
+	// already declare cluster_id). Tolerated here so strict ADK schema
+	// validation does not kill the turn; ignored by the handler.
+	ClusterID string `json:"cluster_id,omitempty"`
+	RRID      string `json:"rr_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // EventSummary is a compact view of a Kubernetes Event.

--- a/pkg/apifrontend/tools/ambient_fields_2364_test.go
+++ b/pkg/apifrontend/tools/ambient_fields_2364_test.go
@@ -1,0 +1,178 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// #2364: fleet-hinted turns die at ADK strict schema validation because the
+// model propagates ambient fields (cluster_id from the console fleet hint,
+// rr_id/session_id from prompt.txt's preserve-across-phases instruction) into
+// tool calls whose schemas declare none of them. Every struct below must
+// tolerate its ambient fields as ignored omitempty hints.
+var _ = Describe("ambient fleet-field tolerance (#2364)", func() {
+	It("UT-2364-001: SI-10 PresentDecisionArgs schema tolerates cluster_id/rr_id", func() {
+		schema, err := jsonschema.For[tools.PresentDecisionArgs](nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(schema.Properties).To(HaveKey("cluster_id"),
+			"fleet-hinted present_decision calls carry cluster_id -- strict schema must tolerate it (#2364)")
+		Expect(schema.Properties).To(HaveKey("rr_id"),
+			"prompt.txt instructs rr_id preservation -- present_decision must tolerate it (#2364)")
+		Expect(schema.Required).NotTo(ContainElement("cluster_id"))
+		Expect(schema.Required).NotTo(ContainElement("rr_id"))
+		Expect(schema.Required).To(ContainElement("session_id"),
+			"fields the LLM IS expected to supply must remain required")
+		Expect(schema.Required).To(ContainElement("summary"))
+		Expect(schema.Required).To(ContainElement("rca"))
+	})
+
+	It("UT-2364-002: SI-10 discover/select schemas tolerate cluster_id/session_id", func() {
+		discSchema, err := jsonschema.For[tools.DiscoverWorkflowsArgs](nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(discSchema.Properties).To(HaveKey("cluster_id"))
+		Expect(discSchema.Properties).To(HaveKey("session_id"))
+		Expect(discSchema.Required).NotTo(ContainElement("cluster_id"))
+		Expect(discSchema.Required).NotTo(ContainElement("session_id"))
+		Expect(discSchema.Required).To(ContainElement("rr_id"))
+
+		selSchema, err := jsonschema.For[tools.SelectWorkflowArgs](nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(selSchema.Properties).To(HaveKey("cluster_id"))
+		Expect(selSchema.Properties).To(HaveKey("session_id"))
+		Expect(selSchema.Required).NotTo(ContainElement("cluster_id"))
+		Expect(selSchema.Required).NotTo(ContainElement("session_id"))
+		Expect(selSchema.Required).To(ContainElement("rr_id"))
+		Expect(selSchema.Required).To(ContainElement("workflow_id"))
+	})
+
+	It("UT-2364-003: SI-10 WatchArgs schema tolerates cluster_id/session_id", func() {
+		schema, err := jsonschema.For[tools.WatchArgs](nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(schema.Properties).To(HaveKey("cluster_id"))
+		Expect(schema.Properties).To(HaveKey("session_id"))
+		Expect(schema.Required).NotTo(ContainElement("cluster_id"))
+		Expect(schema.Required).NotTo(ContainElement("session_id"))
+	})
+
+	It("UT-2364-004: SI-10 Tier-2 schemas tolerate the ambient trio", func() {
+		investSchema, err := jsonschema.For[tools.InvestigateMCPArgs](nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(investSchema.Properties).To(HaveKey("session_id"),
+			"prompt.txt preservation contaminates the most-called tool (#2364 Tier 2)")
+
+		for name, schema := range map[string]*jsonschema.Schema{
+			"InteractiveActionArgs": mustSchema[tools.InteractiveActionArgs](),
+			"CompleteNoActionArgs":  mustSchema[tools.CompleteNoActionArgs](),
+			"GetRemediationArgs":    mustSchema[tools.GetRemediationArgs](),
+			"CancelRemediationArgs": mustSchema[tools.CancelRemediationArgs](),
+			"GetAuditTrailArgs":     mustSchema[tools.GetAuditTrailArgs](),
+			"ListEventsArgs":        mustSchema[tools.ListEventsArgs](),
+		} {
+			Expect(schema.Properties).To(HaveKey("cluster_id"), "%s must tolerate fleet ambient fields", name)
+			Expect(schema.Required).NotTo(ContainElement("cluster_id"), "%s must not require ambient fields", name)
+		}
+	})
+
+	It("UT-2364-N01: SI-10 nested RCAData/TargetInfo tolerate cluster_id", func() {
+		rcaSchema, err := jsonschema.For[tools.RCAData](nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rcaSchema.Properties).To(HaveKey("cluster_id"),
+			"jsonschema-go rejects unknown NESTED properties too (infer.go) -- spoke-scoped RCA must validate")
+		Expect(rcaSchema.Required).NotTo(ContainElement("cluster_id"))
+		Expect(rcaSchema.Required).To(ContainElement("severity"))
+
+		targetSchema, err := jsonschema.For[tools.TargetInfo](nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(targetSchema.Properties).To(HaveKey("cluster_id"))
+		Expect(targetSchema.Required).NotTo(ContainElement("cluster_id"))
+		Expect(targetSchema.Required).To(ContainElement("kind"))
+	})
+
+	It("UT-2364-S01: AU-3 ambient fields omit when empty, round-trip when set", func() {
+		args := tools.PresentDecisionArgs{SessionID: "sess-1", Summary: "s"}
+		data, err := json.Marshal(args)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).NotTo(ContainSubstring("cluster_id"))
+		Expect(string(data)).NotTo(ContainSubstring("rr_id"))
+
+		withAmbient := tools.PresentDecisionArgs{
+			SessionID: "sess-1", Summary: "s",
+			ClusterID: "spoke", RRID: "ns/rr-1",
+		}
+		data2, err := json.Marshal(withAmbient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data2)).To(ContainSubstring(`"cluster_id":"spoke"`))
+		Expect(string(data2)).To(ContainSubstring(`"rr_id":"ns/rr-1"`))
+		var decoded tools.PresentDecisionArgs
+		Expect(json.Unmarshal(data2, &decoded)).To(Succeed())
+		Expect(decoded.ClusterID).To(Equal("spoke"))
+		Expect(decoded.RRID).To(Equal("ns/rr-1"))
+	})
+
+	It("UT-2364-H01: AC-6 HandlePresentDecision ignores ambient extras", func() {
+		plain := tools.HandlePresentDecision(tools.PresentDecisionArgs{
+			SessionID: "sess-1", Summary: "leak",
+			Options: []tools.WorkflowOption{{WorkflowID: "wf-1", Name: "Restart"}},
+		})
+		hinted := tools.HandlePresentDecision(tools.PresentDecisionArgs{
+			SessionID: "sess-1", Summary: "leak",
+			Options:   []tools.WorkflowOption{{WorkflowID: "wf-1", Name: "Restart"}},
+			ClusterID: "spoke", RRID: "ns/rr-1",
+		})
+		Expect(hinted.Message).To(Equal(plain.Message),
+			"ambient hints must never alter presentation -- hints only, never routing (AC-6)")
+	})
+
+	It("UT-2364-H02: AC-6 HandleDiscoverWorkflows ignores ambient extras", func() {
+		ctx := context.Background()
+		newMock := func() *ka.MockMCPClient {
+			return &ka.MockMCPClient{
+				DiscoverWorkflowsFn: func(_ context.Context, _ ka.DiscoverWorkflowsArgs) (*ka.DiscoverWorkflowsResult, error) {
+					return &ka.DiscoverWorkflowsResult{Workflows: []ka.DiscoveredWorkflow{
+						{WorkflowID: "wf-1", Name: "Restart"},
+					}}, nil
+				},
+			}
+		}
+		plain, err := tools.HandleDiscoverWorkflows(ctx, newMock(), tools.DiscoverWorkflowsArgs{RRID: "ns/rr-1"})
+		Expect(err).NotTo(HaveOccurred())
+		hinted, err := tools.HandleDiscoverWorkflows(ctx, newMock(), tools.DiscoverWorkflowsArgs{
+			RRID: "ns/rr-1", ClusterID: "spoke", SessionID: "sess-1",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hinted).To(Equal(plain))
+	})
+
+	It("UT-2364-H03: AC-6 HandleSelectWorkflow ignores ambient extras", func() {
+		ctx := context.Background()
+		newMock := func() *ka.MockMCPClient {
+			return &ka.MockMCPClient{
+				SelectWorkflowFn: func(_ context.Context, _ ka.SelectWorkflowArgs) (*ka.SelectWorkflowResult, error) {
+					return &ka.SelectWorkflowResult{Status: "selected"}, nil
+				},
+			}
+		}
+		plain, err := tools.HandleSelectWorkflow(ctx, newMock(), tools.SelectWorkflowArgs{
+			RRID: "ns/rr-1", WorkflowID: "wf-1",
+		}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		hinted, err := tools.HandleSelectWorkflow(ctx, newMock(), tools.SelectWorkflowArgs{
+			RRID: "ns/rr-1", WorkflowID: "wf-1", ClusterID: "spoke", SessionID: "sess-1",
+		}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hinted).To(Equal(plain))
+	})
+})
+
+func mustSchema[T any]() *jsonschema.Schema {
+	schema, err := jsonschema.For[T](nil)
+	Expect(err).NotTo(HaveOccurred())
+	return schema
+}

--- a/pkg/apifrontend/tools/crd_tools.go
+++ b/pkg/apifrontend/tools/crd_tools.go
@@ -105,6 +105,12 @@ type GetRemediationArgs struct {
 	Namespace string `json:"-"`
 	Name      string `json:"name,omitempty"`
 	RRID      string `json:"rr_id,omitempty"`
+	// ClusterID and SessionID are ambient hints the LLM propagates from fleet
+	// context and cross-phase preservation (#2364 Tier 2). Tolerated here so
+	// strict ADK schema validation does not kill the turn; ignored by the
+	// handler.
+	ClusterID string `json:"cluster_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // GetRemediationResult is the output of kubernaut_get_remediation.
@@ -542,6 +548,12 @@ type CancelRemediationArgs struct {
 	Namespace string `json:"-"`
 	Name      string `json:"name,omitempty"`
 	RRID      string `json:"rr_id,omitempty"`
+	// ClusterID and SessionID are ambient hints the LLM propagates from fleet
+	// context and cross-phase preservation (#2364 Tier 2). Tolerated here so
+	// strict ADK schema validation does not kill the turn; ignored by the
+	// handler.
+	ClusterID string `json:"cluster_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // CancelRemediationResult is the output of kubernaut_cancel_remediation.

--- a/pkg/apifrontend/tools/crd_tools_watch.go
+++ b/pkg/apifrontend/tools/crd_tools_watch.go
@@ -25,6 +25,12 @@ type WatchArgs struct {
 	Namespace string `json:"-"`
 	RRID      string `json:"rr_id,omitempty"`
 	Name      string `json:"name,omitempty"`
+	// ClusterID and SessionID are ambient hints the LLM propagates from fleet
+	// context and cross-phase preservation (#2364 Tier 1). Tolerated here so
+	// strict ADK schema validation does not kill the Phase 4 close-out turn;
+	// ignored by the handler.
+	ClusterID string `json:"cluster_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // WatchEvent represents a single status change event.

--- a/pkg/apifrontend/tools/ds_tools.go
+++ b/pkg/apifrontend/tools/ds_tools.go
@@ -149,6 +149,12 @@ func NewGetEffectivenessTool(client ds.Client) (tool.Tool, error) {
 type GetAuditTrailArgs struct {
 	RRID      string `json:"rr_id"`
 	EventType string `json:"event_type,omitempty"`
+	// ClusterID and SessionID are ambient hints the LLM propagates from fleet
+	// context and cross-phase preservation (#2364 Tier 2). Tolerated here so
+	// strict ADK schema validation does not kill the turn; ignored by the
+	// handler, which keys everything off RRID.
+	ClusterID string `json:"cluster_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // PhaseGroup represents an aggregated group of audit events in one lifecycle phase.

--- a/pkg/apifrontend/tools/ka_interactive.go
+++ b/pkg/apifrontend/tools/ka_interactive.go
@@ -21,6 +21,12 @@ import (
 type InteractiveActionArgs struct {
 	RRID    string `json:"rr_id"`
 	Message string `json:"message,omitempty"`
+	// ClusterID and SessionID are ambient hints the LLM propagates from fleet
+	// context and cross-phase preservation (#2364 Tier 2). Tolerated here so
+	// strict ADK schema validation does not kill the turn; ignored by the
+	// handlers, which key everything off RRID.
+	ClusterID string `json:"cluster_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // InteractiveActionResult is the shared output for interactive investigation actions.

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -219,6 +219,11 @@ type InvestigateMCPArgs struct {
 	// candidate's alert name after the user has explicitly confirmed it
 	// (DD-AF-012, #2027/#2028). Leave empty on the first call.
 	ConfirmedSignalName string `json:"confirmed_signal_name,omitempty"`
+	// SessionID is an ambient hint the LLM propagates via cross-phase
+	// preservation (#2364 Tier 2). Tolerated here so strict ADK schema
+	// validation does not kill the turn; ignored by the handler, which owns
+	// session lifecycle server-side.
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // InvestigateMCPResult is the output of the MCP investigate tool.

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -304,6 +304,9 @@ type InvestigateConfig struct {
 	// existing-rr_id (takeover) path — that RR was already scope-checked at
 	// its own creation time. Nil skips scope validation (backward compat).
 	ScopeChecker scope.ScopeChecker
+	// ClusterLister names known fleet clusters for the unattributed-refusal
+	// message (#2362). Nil-safe: a nil lister preserves the legacy message.
+	ClusterLister ClusterLister
 }
 
 // HandleInvestigationMCP starts a dedicated MCP investigation session. When a
@@ -556,7 +559,7 @@ func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args 
 	}
 
 	hooks, signaledISCRDName := buildPreCreateISHooks(cfg, identity)
-	result, err := HandleCreateRRWithHooks(ctx, &ToolDeps{Client: cfg.Client, ControllerNS: cfg.Namespace, Triager: cfg.Triager, Auditor: cfg.Auditor, ScopeChecker: cfg.ScopeChecker}, createArgs, createUser, hooks)
+	result, err := HandleCreateRRWithHooks(ctx, &ToolDeps{Client: cfg.Client, ControllerNS: cfg.Namespace, Triager: cfg.Triager, Auditor: cfg.Auditor, ScopeChecker: cfg.ScopeChecker, ClusterLister: cfg.ClusterLister}, createArgs, createUser, hooks)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("create RR for investigation: %w", err)
 	}

--- a/pkg/apifrontend/tools/ka_remediate.go
+++ b/pkg/apifrontend/tools/ka_remediate.go
@@ -140,14 +140,15 @@ func HandleRemediate(ctx context.Context, d *ToolDeps, args *RemediateArgs, user
 // NewRemediateTool creates the kubernaut_remediate tool for autonomous remediation.
 // It creates RRs without InvestigationSessions — the pipeline handles analysis
 // autonomously without user interaction.
-func NewRemediateTool(client crclient.Client, dynClient dynamic.Interface, controllerNS string, triager *severity.Triager, auditor audit.Emitter, scopeChecker scope.ScopeChecker) (tool.Tool, error) {
+func NewRemediateTool(client crclient.Client, dynClient dynamic.Interface, controllerNS string, triager *severity.Triager, auditor audit.Emitter, scopeChecker scope.ScopeChecker, clusterLister ClusterLister) (tool.Tool, error) {
 	d := &ToolDeps{
-		Client:       client,
-		DynClient:    dynClient,
-		ControllerNS: controllerNS,
-		Triager:      triager,
-		Auditor:      auditor,
-		ScopeChecker: scopeChecker,
+		Client:        client,
+		DynClient:     dynClient,
+		ControllerNS:  controllerNS,
+		Triager:       triager,
+		Auditor:       auditor,
+		ScopeChecker:  scopeChecker,
+		ClusterLister: clusterLister,
 	}
 	return functiontool.New(functiontool.Config{
 		Name: "kubernaut_remediate",

--- a/pkg/apifrontend/tools/ka_remediate_test.go
+++ b/pkg/apifrontend/tools/ka_remediate_test.go
@@ -132,7 +132,7 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 	Describe("NewRemediateTool — tool constructor (F-06)", func() {
 		It("UT-AF-1332-009: creates tool with name kubernaut_remediate", func() {
 			tc := newTypedFakeClient()
-			t, err := tools.NewRemediateTool(tc, nil, "kubernaut-system", nil, nil, nil)
+			t, err := tools.NewRemediateTool(tc, nil, "kubernaut-system", nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(t.Name()).To(Equal("kubernaut_remediate"))
 		})

--- a/pkg/apifrontend/tools/ka_tools.go
+++ b/pkg/apifrontend/tools/ka_tools.go
@@ -58,6 +58,12 @@ type DiscoverWorkflowsArgs struct {
 	RRID       string `json:"rr_id"`
 	WorkflowID string `json:"workflow_id,omitempty"`
 	Kind       string `json:"kind,omitempty"`
+	// ClusterID and SessionID are ambient hints the LLM propagates from fleet
+	// context and cross-phase preservation (#2364). Tolerated here so strict
+	// ADK schema validation does not kill the turn; ignored by the handler,
+	// which keys everything off RRID.
+	ClusterID string `json:"cluster_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // WorkflowDetail holds a workflow definition with its parameter schemas.
@@ -76,6 +82,11 @@ type TargetInfo struct {
 	Kind       string `json:"kind"`
 	Name       string `json:"name"`
 	Namespace  string `json:"namespace"`
+	// ClusterID scopes the target to a fleet cluster (#2364): strict ADK
+	// validation rejects unknown nested properties, so spoke-scoped targets
+	// must declare it. Ignored by consumers, which read cluster identity from
+	// server-side RRContext.
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // DiscoverWorkflowsResult is the output of kubernaut_discover_workflows.
@@ -260,6 +271,12 @@ type SelectWorkflowArgs struct {
 	Name       string         `json:"name,omitempty"`
 	Namespace  string         `json:"namespace,omitempty"`
 	Parameters map[string]any `json:"parameters,omitempty"`
+	// ClusterID and SessionID are ambient hints the LLM propagates from fleet
+	// context and cross-phase preservation (#2364). Tolerated here so strict
+	// ADK schema validation does not kill the turn; ignored by the handler,
+	// which keys everything off RRID.
+	ClusterID string `json:"cluster_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // SelectWorkflowResult is the output of kubernaut_select_workflow.
@@ -367,6 +384,12 @@ type RCAData struct {
 	// enforceGroundingGuard) rather than relying on the LLM to supply them.
 	ToolCallsCount int `json:"tool_calls_count,omitempty"`
 	LLMTurns       int `json:"llm_turns,omitempty"`
+	// ClusterID is an ambient hint the LLM propagates from fleet context
+	// (#2364): spoke-scoped RCA must validate. Tolerated here so strict ADK
+	// schema validation (which rejects unknown nested properties too) does not
+	// kill the turn; ignored by consumers, which read cluster identity from
+	// server-side RRContext.
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // #2110 (v1.6 clone #2111): defense-in-depth only -- production code paths
@@ -393,6 +416,14 @@ type PresentDecisionArgs struct {
 	Options        []WorkflowOption `json:"options"`
 	SearchedTarget *TargetInfo      `json:"searched_target,omitempty"`
 	SignalTarget   *TargetInfo      `json:"signal_target,omitempty"`
+	// ClusterID and RRID are ambient hints the LLM propagates from fleet
+	// context and cross-phase preservation (#2364, recurrence of the
+	// #2073/#2074 failure class). Tolerated here so strict ADK schema
+	// validation does not kill the turn; ignored by HandlePresentDecision,
+	// which keys everything off SessionID, and by the artifact path, which
+	// merges authoritative cluster identity from RRContext.
+	ClusterID string `json:"cluster_id,omitempty"`
+	RRID      string `json:"rr_id,omitempty"`
 }
 
 // WorkflowOption represents a remediation workflow choice.
@@ -447,6 +478,12 @@ type CompleteNoActionArgs struct {
 	RRID             string `json:"rr_id"`
 	Reason           string `json:"reason,omitempty"`
 	EscalationReason string `json:"escalation_reason,omitempty"`
+	// ClusterID and SessionID are ambient hints the LLM propagates from fleet
+	// context and cross-phase preservation (#2364 Tier 2). Tolerated here so
+	// strict ADK schema validation does not kill the turn; ignored by the
+	// handler, which keys everything off RRID.
+	ClusterID string `json:"cluster_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // CompleteNoActionResult is the output of kubernaut_complete_no_action.

--- a/pkg/apifrontend/tools/scope_helpers.go
+++ b/pkg/apifrontend/tools/scope_helpers.go
@@ -133,6 +133,15 @@ func knownRemoteClusterIDs(lister ClusterLister) []string {
 
 func emitScopeRejected(ctx context.Context, auditor audit.Emitter, username string, target scope.ResourceIdentity, detail map[string]string) {
 	if auditor == nil {
+		// No emitter to record the refusal -- fail LOUD rather than silent:
+		// audit traces are not optional, so an unaudited denial is logged at
+		// error level with the full refusal context. (Deliberately not a
+		// behavior change: nil-auditor nil-safe convention is pervasive
+		// across the tool layer and production always wires a real emitter;
+		// fail-closed denial itself never depends on the auditor.)
+		logr.FromContextOrDiscard(ctx).Error(nil, "scope refusal emitted without auditor -- no audit trace recorded",
+			"user", username, "namespace", target.Namespace, "kind", target.Kind,
+			"name", target.Name, "cluster", target.ClusterID, "detail", detail)
 		return
 	}
 	auditor.Emit(ctx, &audit.Event{

--- a/pkg/apifrontend/tools/scope_helpers.go
+++ b/pkg/apifrontend/tools/scope_helpers.go
@@ -3,14 +3,26 @@ package tools
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
+	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
 	sharedK8s "github.com/jordigilh/kubernaut/pkg/shared/k8s"
 	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
+
+// ClusterLister lists the IDs of known fleet clusters for scope-refusal
+// messaging when a target carries no cluster attribution (#2362). Satisfied
+// structurally by registry.ClusterRegistry (List method) with no adapter;
+// fakes implement one method. Nil-safe: a nil lister behaves as no known
+// remotes (legacy message).
+type ClusterLister interface {
+	List() []registry.ClusterInfo
+}
 
 type restMapperContextKey struct{}
 
@@ -53,7 +65,12 @@ func RESTMapperFromContext(ctx context.Context) meta.RESTMapper {
 // agent gets identical guidance whether rejected here (fail-fast) or
 // downstream by RO (temporal-drift re-check), and an EventRRScopeRejected
 // audit event is emitted (AU-3/AU-12) when auditor is non-nil.
-func checkRRScope(ctx context.Context, checker scope.ScopeChecker, auditor audit.Emitter, username string, target scope.ResourceIdentity) (managed bool, message string) {
+//
+// lister names known fleet clusters for the unattributed-refusal message
+// (#2362). Nil-safe: a nil lister (fleet disabled, single cluster) preserves
+// the legacy message byte-for-byte -- with no remotes, local is the only
+// possible cluster and there is nothing to disambiguate.
+func checkRRScope(ctx context.Context, checker scope.ScopeChecker, auditor audit.Emitter, username string, target scope.ResourceIdentity, lister ClusterLister) (managed bool, message string) {
 	if checker == nil {
 		return true, ""
 	}
@@ -73,23 +90,57 @@ func checkRRScope(ctx context.Context, checker scope.ScopeChecker, auditor audit
 		return true, ""
 	}
 
+	detail := map[string]string{
+		"namespace": target.Namespace,
+		"kind":      target.Kind,
+		"name":      target.Name,
+	}
+	if target.ClusterID == "" {
+		if ids := knownRemoteClusterIDs(lister); len(ids) > 0 {
+			detail["candidate_clusters"] = strings.Join(ids, ",")
+			message = fmt.Sprintf("Resource %s/%s/%s has no cluster attribution; cannot determine "+
+				"which of [local hub, %s] it belongs to. Specify cluster_id (e.g. from the alert's "+
+				"cluster label); not acting.", target.Namespace, target.Kind, target.Name,
+				strings.Join(ids, ", "))
+			emitScopeRejected(ctx, auditor, username, target, detail)
+			return false, message
+		}
+	}
+
 	message = fmt.Sprintf("Resource %s/%s/%s (cluster=%s) not managed by Kubernaut. "+
 		"Add label kubernaut.ai/managed=true to namespace or resource.", target.Namespace, target.Kind, target.Name, clusterCtx)
 
-	if auditor != nil {
-		auditor.Emit(ctx, &audit.Event{
-			Type:      audit.EventRRScopeRejected,
-			UserID:    username,
-			ClusterID: target.ClusterID,
-			Detail: map[string]string{
-				"namespace": target.Namespace,
-				"kind":      target.Kind,
-				"name":      target.Name,
-			},
-		})
-	}
-
+	emitScopeRejected(ctx, auditor, username, target, detail)
 	return false, message
+}
+
+// knownRemoteClusterIDs returns the sorted IDs of fleet clusters known to
+// lister, or nil when lister is nil or knows none. Sorted for deterministic
+// refusal messages.
+func knownRemoteClusterIDs(lister ClusterLister) []string {
+	if lister == nil {
+		return nil
+	}
+	var ids []string
+	for _, ci := range lister.List() {
+		if ci.ID != "" {
+			ids = append(ids, ci.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func emitScopeRejected(ctx context.Context, auditor audit.Emitter, username string, target scope.ResourceIdentity, detail map[string]string) {
+	if auditor == nil {
+		return
+	}
+	auditor.Emit(ctx, &audit.Event{
+		Type:      audit.EventRRScopeRejected,
+		UserID:    username,
+		ClusterID: target.ClusterID,
+		Detail:    detail,
+	})
 }
 
 // ResolveEffectiveNamespace returns the namespace to use for a Kubernetes API

--- a/pkg/fleet/mcpclient/parse.go
+++ b/pkg/fleet/mcpclient/parse.go
@@ -46,6 +46,51 @@ func ParseUnstructuredResponse(text string) (*unstructured.Unstructured, error) 
 	return obj, nil
 }
 
+// ParseUnstructuredListResponse parses a kube-mcp-server list response into
+// unstructured objects. List tools may return either a top-level sequence or
+// the Kubernetes-style {"items": [...]} envelope.
+func ParseUnstructuredListResponse(text string) ([]unstructured.Unstructured, error) {
+	if text == "" {
+		return nil, fmt.Errorf("empty response")
+	}
+
+	jsonData := []byte(text)
+	if !json.Valid(jsonData) {
+		converted, err := sigsyaml.YAMLToJSON(jsonData)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshaling resource list: %w", err)
+		}
+		jsonData = converted
+	}
+
+	var rawItems []json.RawMessage
+	if err := json.Unmarshal(jsonData, &rawItems); err != nil {
+		var envelope struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if envelopeErr := json.Unmarshal(jsonData, &envelope); envelopeErr != nil {
+			return nil, fmt.Errorf("unmarshaling resource list: %w", err)
+		}
+		if envelope.Items == nil {
+			return nil, fmt.Errorf("resource list response does not contain items")
+		}
+		rawItems = envelope.Items
+	}
+
+	items := make([]unstructured.Unstructured, 0, len(rawItems))
+	for i, rawItem := range rawItems {
+		var object map[string]interface{}
+		if err := json.Unmarshal(rawItem, &object); err != nil || object == nil {
+			if err == nil {
+				err = fmt.Errorf("item is null")
+			}
+			return nil, fmt.Errorf("resource list item %d is not an object: %w", i, err)
+		}
+		items = append(items, unstructured.Unstructured{Object: object})
+	}
+	return items, nil
+}
+
 // normalizeTableItems converts flat table-row maps from kube-mcp-server
 // structuredContent (--list-output=table) into proper unstructured.Unstructured
 // objects using typed setters.

--- a/pkg/fleet/mcpclient/parse_internal_test.go
+++ b/pkg/fleet/mcpclient/parse_internal_test.go
@@ -65,6 +65,43 @@ var _ = Describe("UT-FLEET-MCP-PARSE: MCP response parsing", func() {
 		})
 	})
 
+	Describe("ParseUnstructuredListResponse", func() {
+		It("UT-KA-MCP-LIST-001 [SI-10]: parses a top-level YAML sequence", func() {
+			items, err := ParseUnstructuredListResponse("- apiVersion: v1\n  kind: Pod\n  metadata:\n    name: api-server\n    namespace: production\n")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(items).To(HaveLen(1))
+			Expect(items[0].GetKind()).To(Equal("Pod"))
+			Expect(items[0].GetName()).To(Equal("api-server"))
+		})
+
+		It("UT-KA-MCP-LIST-002 [SI-10]: parses a top-level JSON array", func() {
+			items, err := ParseUnstructuredListResponse(`[{"apiVersion":"v1","kind":"Pod","metadata":{"name":"api-server"}}]`)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(items).To(HaveLen(1))
+			Expect(items[0].GetKind()).To(Equal("Pod"))
+		})
+
+		It("UT-KA-MCP-LIST-003 [SI-10]: parses an items envelope", func() {
+			items, err := ParseUnstructuredListResponse(`{"apiVersion":"v1","kind":"PodList","items":[{"apiVersion":"v1","kind":"Pod","metadata":{"name":"api-server"}}]}`)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(items).To(HaveLen(1))
+			Expect(items[0].GetName()).To(Equal("api-server"))
+		})
+
+		It("UT-KA-MCP-LIST-004 [SI-10]: preserves an empty list", func() {
+			items, err := ParseUnstructuredListResponse("[]")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(items).To(BeEmpty())
+		})
+
+		It("UT-KA-MCP-LIST-005 [SI-10]: rejects malformed or non-object list responses", func() {
+			for _, response := range []string{"not: [valid", `["not an object"]`, `{"items":"not an array"}`} {
+				_, err := ParseUnstructuredListResponse(response)
+				Expect(err).To(HaveOccurred(), response)
+			}
+		})
+	})
+
 	Describe("parseSelectorToMap", func() {
 		It("UT-FLEET-MCP-PARSE-009: parses single key=value", func() {
 			m := parseSelectorToMap("app=nginx")

--- a/pkg/gateway/adapters/owner_resolver_fleet_test.go
+++ b/pkg/gateway/adapters/owner_resolver_fleet_test.go
@@ -157,7 +157,83 @@ var _ = Describe("PrometheusAdapter — Fleet remote owner chain (P1)", func() {
 				"ParseBatch must preserve clusterID from remote alerts")
 		})
 	})
+
+	// Issue #2362: AlertManager groups by alertname by default, so `cluster`
+	// never reaches commonLabels even when the firing alert carries it --
+	// the adapter must fall back to the per-alert label instead of
+	// attributing the signal to the local hub cluster.
+	Describe("per-alert cluster label fallback (#2362)", func() {
+		It("UT-GW-2362-101 [AC-3]: Parse attributes ClusterID from per-alert labels when commonLabels lacks cluster", func() {
+			adapter := adapters.NewPrometheusAdapter(&stubOwnerResolver{
+				ownerKind: "Deployment",
+				ownerName: "nginx",
+			}, nil, logr.Discard())
+
+			signal, err := adapter.Parse(ctx, buildAlertPayloadWithPerAlertCluster("", "remote-cluster"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(signal.ClusterID).To(Equal("remote-cluster"),
+				"a per-alert cluster label must attribute the signal when grouping strips it from commonLabels")
+		})
+
+		It("UT-GW-2362-102 [AC-3]: commonLabels cluster keeps precedence over a conflicting per-alert cluster", func() {
+			adapter := adapters.NewPrometheusAdapter(&stubOwnerResolver{
+				ownerKind: "Deployment",
+				ownerName: "nginx",
+			}, nil, logr.Discard())
+
+			signal, err := adapter.Parse(ctx, buildAlertPayloadWithPerAlertCluster("hub", "remote-cluster"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(signal.ClusterID).To(Equal("hub"),
+				"group-level attribution must win over a conflicting per-alert label")
+		})
+
+		It("UT-GW-2362-103 [AC-3]: no cluster anywhere still yields empty ClusterID (local preserved)", func() {
+			adapter := adapters.NewPrometheusAdapter(&stubOwnerResolver{
+				ownerKind: "Deployment",
+				ownerName: "nginx",
+			}, nil, logr.Discard())
+
+			signal, err := adapter.Parse(ctx, buildAlertPayloadWithPerAlertCluster("", ""))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(signal.ClusterID).To(BeEmpty(),
+				"genuinely unattributed signals keep today's local semantics")
+		})
+	})
 })
+
+// buildAlertPayloadWithPerAlertCluster creates a webhook payload with
+// independent group-level (commonLabels) and per-alert cluster labels,
+// modeling an AlertManager grouped by alertname where `cluster` never
+// reaches commonLabels.
+func buildAlertPayloadWithPerAlertCluster(commonCluster, alertCluster string) []byte {
+	commonLabels := map[string]string{}
+	if commonCluster != "" {
+		commonLabels["cluster"] = commonCluster
+	}
+
+	labels := map[string]string{
+		"alertname": "HighCPU",
+		"severity":  "warning",
+		"namespace": "default",
+		"pod":       "nginx-abc",
+	}
+	if alertCluster != "" {
+		labels["cluster"] = alertCluster
+	}
+
+	payload := map[string]any{
+		"status": "firing",
+		"alerts": []map[string]any{
+			{
+				"status": "firing",
+				"labels": labels,
+			},
+		},
+		"commonLabels": commonLabels,
+	}
+	data, _ := json.Marshal(payload)
+	return data
+}
 
 // stubOwnerResolver returns fixed owner resolution results for testing.
 type stubOwnerResolver struct {

--- a/pkg/gateway/adapters/prometheus_adapter.go
+++ b/pkg/gateway/adapters/prometheus_adapter.go
@@ -245,8 +245,16 @@ func (a *PrometheusAdapter) Parse(ctx context.Context, rawData []byte) (*types.N
 	for i, alert := range webhook.Alerts {
 		resource := a.extractAlertResource(ctx, alert)
 
-		// BR-INTEGRATION-065: Extract cluster label from commonLabels (Thanos federation)
+		// BR-INTEGRATION-065: Extract cluster label from commonLabels (Thanos federation).
+		// Issue #2362: AlertManager groups by alertname by default, so `cluster`
+		// never reaches commonLabels even when the firing alert carries it --
+		// fall back to the per-alert label instead of misattributing the
+		// signal to the local hub cluster. commonLabels keeps precedence on
+		// conflict (group-level attribution wins).
 		clusterID := webhook.CommonLabels[types.ClusterLabelKey]
+		if clusterID == "" {
+			clusterID = alert.Labels[types.ClusterLabelKey]
+		}
 		resolver := a.resolverForCluster(ctx, clusterID)
 
 		fingerprint, resolvedResource, err := a.resolveAlertForParse(ctx, i, resource, clusterID, resolver)
@@ -408,8 +416,12 @@ func (a *PrometheusAdapter) parseOneAlertInBatch(
 ) (*types.NormalizedSignal, bool) {
 	resource := a.extractAlertResource(ctx, alert)
 
-	// BR-INTEGRATION-065: Extract cluster label from commonLabels (Thanos federation)
+	// BR-INTEGRATION-065: Extract cluster label from commonLabels (Thanos federation),
+	// falling back to the per-alert label when grouping strips it (#2362).
 	clusterID := webhook.CommonLabels[types.ClusterLabelKey]
+	if clusterID == "" {
+		clusterID = alert.Labels[types.ClusterLabelKey]
+	}
 	resolver := a.resolverForCluster(ctx, clusterID)
 
 	fingerprint, resolvedResource, ok := a.resolveAlertFingerprint(ctx, alertIndex, resource, clusterID, resolver)

--- a/pkg/shared/llm/openaicompat/client.go
+++ b/pkg/shared/llm/openaicompat/client.go
@@ -206,6 +206,14 @@ func buildRequestBody(model string, req Request, stream bool) map[string]any {
 	if len(req.Tools) > 0 {
 		body["tools"] = buildTools(req.Tools)
 	}
+	if req.ToolChoice != nil && req.ToolChoice.Name != "" {
+		body["tool_choice"] = map[string]any{
+			"type": "function",
+			"function": map[string]string{
+				"name": req.ToolChoice.Name,
+			},
+		}
+	}
 	if len(req.ResponseSchema) > 0 {
 		body["response_format"] = map[string]any{
 			"type":        "json_schema",

--- a/pkg/shared/llm/openaicompat/tool_choice_2365_test.go
+++ b/pkg/shared/llm/openaicompat/tool_choice_2365_test.go
@@ -1,0 +1,36 @@
+package openaicompat_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/llm/openaicompat"
+)
+
+var _ = Describe("OpenAI tool choice recovery (#2365)", func() {
+	It("UT-AF-2365-001 (SI-10, AU-3): emits a named tool choice when recovery requires presentation", func() {
+		var body map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(json.NewDecoder(r.Body).Decode(&body)).To(Succeed())
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","tool_calls":[{"id":"call-1","type":"function","function":{"name":"kubernaut_present_decision","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`))
+		}))
+		DeferCleanup(server.Close)
+
+		client := openaicompat.New("gpt-4o", server.URL, "")
+		_, err := client.Chat(context.Background(), openaicompat.Request{
+			Messages:   []openaicompat.Message{{Role: "user", Content: "present the decision"}},
+			Tools:      []openaicompat.ToolDefinition{{Name: "kubernaut_present_decision"}},
+			ToolChoice: &openaicompat.ToolChoice{Name: "kubernaut_present_decision"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(body["tool_choice"]).To(Equal(map[string]any{
+			"type":     "function",
+			"function": map[string]any{"name": "kubernaut_present_decision"},
+		}))
+	})
+})

--- a/pkg/shared/llm/openaicompat/types.go
+++ b/pkg/shared/llm/openaicompat/types.go
@@ -58,6 +58,12 @@ type ToolDefinition struct {
 	Parameters  json.RawMessage
 }
 
+// ToolChoice forces a named function call when set. A nil choice preserves
+// the provider's default automatic tool selection behavior.
+type ToolChoice struct {
+	Name string
+}
+
 // TokenUsage tracks token consumption for a single call.
 type TokenUsage struct {
 	PromptTokens     int
@@ -70,6 +76,7 @@ type Request struct {
 	Model          string
 	Messages       []Message
 	Tools          []ToolDefinition
+	ToolChoice     *ToolChoice
 	Temperature    *float64
 	TopP           *float64
 	MaxTokens      int

--- a/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
+++ b/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
@@ -109,7 +109,7 @@ func runKAToolCallE2ECaseWithAlert(targetKubeconfig string, targetClient client.
 	// Fingerprints intentionally include alertname. Keep the scenario keyword
 	// while making each run unique so a prior CI run cannot turn this creation
 	// assertion into a duplicate-signal replay.
-	uniqueAlertName := fmt.Sprintf("%s-%s", alertName, uuid.NewString())
+	uniqueAlertName := fmt.Sprintf("%s-%s", alertName, uuid.NewString()[:8])
 	payload := buildPrometheusAlertWithCluster(uniqueAlertName, "high", kaToolE2ETargetName, clusterID)
 	body := postFleetAlertUntilAccepted(urlLocalhost30080, payload)
 

--- a/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
+++ b/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
@@ -29,6 +29,8 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -86,6 +88,21 @@ func runKAToolCallE2ECaseWithAlert(targetKubeconfig string, targetClient client.
 		g.Expect(targetClient.Get(ctx, client.ObjectKey{Name: kaToolE2ETargetName, Namespace: namespace}, dep)).To(Succeed())
 		g.Expect(dep.Status.AvailableReplicas).To(BeNumerically(">=", 1))
 	}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+	if clusterID != "" {
+		By("Waiting for the marker Deployment to be readable through the real MCP Gateway")
+		mcpClient, err := newFleetMCPClient(ctx)
+		Expect(err).ToNot(HaveOccurred(), "MCP Gateway must be ready before posting the fleet alert")
+		DeferCleanup(func() { _ = mcpClient.Close() })
+
+		Eventually(func(g Gomega) {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+			g.Expect(mcpClient.Get(ctx, client.ObjectKey{Name: kaToolE2ETargetName, Namespace: namespace}, obj)).To(Succeed())
+			g.Expect(obj.GetName()).To(Equal(kaToolE2ETargetName))
+		}, 90*time.Second, 2*time.Second).Should(Succeed(),
+			"the remote marker must be visible to resources_get before Gateway owner resolution")
+	}
 
 	By(fmt.Sprintf("Sending the alert (cluster_id=%q)", clusterID))
 	payload := buildPrometheusAlertWithCluster(alertName, "high", kaToolE2ETargetName, clusterID)

--- a/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
+++ b/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
@@ -105,7 +105,11 @@ func runKAToolCallE2ECaseWithAlert(targetKubeconfig string, targetClient client.
 	}
 
 	By(fmt.Sprintf("Sending the alert (cluster_id=%q)", clusterID))
-	payload := buildPrometheusAlertWithCluster(alertName, "high", kaToolE2ETargetName, clusterID)
+	// Fingerprints intentionally include alertname. Keep the scenario keyword
+	// while making each run unique so a prior CI run cannot turn this creation
+	// assertion into a duplicate-signal replay.
+	uniqueAlertName := fmt.Sprintf("%s-%d", alertName, time.Now().UnixNano())
+	payload := buildPrometheusAlertWithCluster(uniqueAlertName, "high", kaToolE2ETargetName, clusterID)
 	body := postFleetAlertUntilAccepted(urlLocalhost30080, payload)
 
 	var response map[string]interface{}

--- a/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
+++ b/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
@@ -26,7 +26,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
@@ -63,7 +67,7 @@ const (
 // it drives is ever told which environment it's running against; KA's own
 // tool-schema advertisement (toolDefinitionsForPhase) and overlay routing
 // (executeResolved) determine that, opaquely, from clusterID alone.
-func runKAToolCallE2ECase(targetKubeconfig string, targetClient client.Client, clusterID, evidence string) {
+func runKAToolCallE2ECase(targetKubeconfig string, targetClient client.Client, clusterID, evidence string) *aianalysisv1.AIAnalysis {
 	By(fmt.Sprintf("Deploying dedicated %s marker (memLimit=%s) on the target cluster", kaToolE2ETargetName, evidence))
 	Expect(infrastructure.DeployMemoryEaterNamed(ctx, kaToolE2ETargetName, namespace,
 		targetKubeconfig, evidence, "20Mi", GinkgoWriter)).To(Succeed())
@@ -118,6 +122,7 @@ func runKAToolCallE2ECase(targetKubeconfig string, targetClient client.Client, c
 			"real investigation loop called the correct tool for this environment and reached the correct "+
 			"cluster's live object -- not a canned response and not a wrong-cluster false positive", evidence)
 	GinkgoWriter.Printf("  E2E-FLEET-017: confirmed genuine, correctly-targeted round trip (evidence=%s)\n", evidence)
+	return &ai
 }
 
 // E2E-FLEET-017 [AC-4, AC-6, SI-4]: real KA investigation calls the correct
@@ -149,5 +154,34 @@ var _ = Describe("E2E-FLEET-017 [AC-4, AC-6, SI-4]: KA real investigation calls 
 
 	It("fleet: should call resources_get via the real MCP Gateway and return genuine remote-cluster data", func() {
 		runKAToolCallE2ECase(remoteKubeconfigPath, remoteK8sClient, remoteCluster, kaToolE2ERemoteEvidence)
+	})
+
+	It("fleet: should detect remote HPA and PDB labels through the real MCP Gateway", func() {
+		By("Creating remote infrastructure whose labels must be detected by KA")
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: kaToolE2ETargetName + "-hpa", Namespace: namespace},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{APIVersion: "apps/v1", Kind: "Deployment", Name: kaToolE2ETargetName},
+				MinReplicas:    ptr.To[int32](1), MaxReplicas: 3,
+			},
+		}
+		Expect(remoteK8sClient.Create(ctx, hpa)).To(Succeed())
+		DeferCleanup(func() { _ = remoteK8sClient.Delete(context.Background(), hpa) })
+
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{Name: kaToolE2ETargetName + "-pdb", Namespace: namespace},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MinAvailable: ptr.To(intstr.FromInt(1)),
+				Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": kaToolE2ETargetName}},
+			},
+		}
+		Expect(remoteK8sClient.Create(ctx, pdb)).To(Succeed())
+		DeferCleanup(func() { _ = remoteK8sClient.Delete(context.Background(), pdb) })
+
+		ai := runKAToolCallE2ECase(remoteKubeconfigPath, remoteK8sClient, remoteCluster, kaToolE2ERemoteEvidence)
+		Expect(ai.Status.PostRCAContext).NotTo(BeNil(), "ADR-056: remote investigation must persist post-RCA context")
+		Expect(ai.Status.PostRCAContext.DetectedLabels).NotTo(BeNil(), "BR-INTEGRATION-1489: remote detected labels must be persisted")
+		Expect(ai.Status.PostRCAContext.DetectedLabels.HPAEnabled).To(BeTrue(), "AC-4/AC-6: HPA label must come from the remote cluster")
+		Expect(ai.Status.PostRCAContext.DetectedLabels.PDBProtected).To(BeTrue(), "AC-4/AC-6: PDB label must come from the remote cluster")
 	})
 })

--- a/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
+++ b/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
@@ -71,22 +71,22 @@ const (
 // tool-schema advertisement (toolDefinitionsForPhase) and overlay routing
 // (executeResolved) determine that, opaquely, from clusterID alone.
 func runKAToolCallE2ECase(targetKubeconfig string, targetClient client.Client, clusterID, evidence string) {
-	runKAToolCallE2ECaseWithAlert(targetKubeconfig, targetClient, clusterID, evidence, kaToolE2EKeyword)
+	runKAToolCallE2ECaseWithAlert(targetKubeconfig, targetClient, clusterID, evidence, kaToolE2EKeyword, kaToolE2ETargetName)
 }
 
-func runKAToolCallE2ECaseWithAlert(targetKubeconfig string, targetClient client.Client, clusterID, evidence, alertName string) *aianalysisv1.AIAnalysis {
-	By(fmt.Sprintf("Deploying dedicated %s marker (memLimit=%s) on the target cluster", kaToolE2ETargetName, evidence))
-	Expect(infrastructure.DeployMemoryEaterNamed(ctx, kaToolE2ETargetName, namespace,
+func runKAToolCallE2ECaseWithAlert(targetKubeconfig string, targetClient client.Client, clusterID, evidence, alertName, targetName string) *aianalysisv1.AIAnalysis {
+	By(fmt.Sprintf("Deploying dedicated %s marker (memLimit=%s) on the target cluster", targetName, evidence))
+	Expect(infrastructure.DeployMemoryEaterNamed(ctx, targetName, namespace,
 		targetKubeconfig, evidence, "20Mi", GinkgoWriter)).To(Succeed())
 	DeferCleanup(func() {
-		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: kaToolE2ETargetName, Namespace: namespace}}
+		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: targetName, Namespace: namespace}}
 		_ = targetClient.Delete(context.Background(), dep)
 	})
 
 	By("Waiting for the marker Deployment to become Available")
 	Eventually(func(g Gomega) {
 		dep := &appsv1.Deployment{}
-		g.Expect(targetClient.Get(ctx, client.ObjectKey{Name: kaToolE2ETargetName, Namespace: namespace}, dep)).To(Succeed())
+		g.Expect(targetClient.Get(ctx, client.ObjectKey{Name: targetName, Namespace: namespace}, dep)).To(Succeed())
 		g.Expect(dep.Status.AvailableReplicas).To(BeNumerically(">=", 1))
 	}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
@@ -99,18 +99,16 @@ func runKAToolCallE2ECaseWithAlert(targetKubeconfig string, targetClient client.
 		Eventually(func(g Gomega) {
 			obj := &unstructured.Unstructured{}
 			obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
-			g.Expect(mcpClient.Get(ctx, client.ObjectKey{Name: kaToolE2ETargetName, Namespace: namespace}, obj)).To(Succeed())
-			g.Expect(obj.GetName()).To(Equal(kaToolE2ETargetName))
+			g.Expect(mcpClient.Get(ctx, client.ObjectKey{Name: targetName, Namespace: namespace}, obj)).To(Succeed())
+			g.Expect(obj.GetName()).To(Equal(targetName))
 		}, 90*time.Second, 2*time.Second).Should(Succeed(),
 			"the remote marker must be visible to resources_get before Gateway owner resolution")
 	}
 
 	By(fmt.Sprintf("Sending the alert (cluster_id=%q)", clusterID))
-	// Fingerprints intentionally include alertname. Keep the scenario keyword
-	// while making each run unique so a prior CI run cannot turn this creation
-	// assertion into a duplicate-signal replay.
-	uniqueAlertName := fmt.Sprintf("%s-%s", alertName, uuid.NewString()[:8])
-	payload := buildPrometheusAlertWithCluster(uniqueAlertName, "high", kaToolE2ETargetName, clusterID)
+	// Fingerprints use the target identity, not alertname. The caller supplies a
+	// unique target when multiple cases use the same remote cluster.
+	payload := buildPrometheusAlertWithCluster(alertName, "high", targetName, clusterID)
 	body := postFleetAlertUntilAccepted(urlLocalhost30080, payload)
 
 	var response map[string]interface{}
@@ -183,11 +181,12 @@ var _ = Describe("E2E-FLEET-017 [AC-4, AC-6, SI-4]: KA real investigation calls 
 	})
 
 	It("fleet: should detect remote HPA and PDB labels through the real MCP Gateway", func() {
+		targetName := fmt.Sprintf("%s-%s", kaToolE2ETargetName, uuid.NewString()[:8])
 		By("Creating remote infrastructure whose labels must be detected by KA")
 		hpa := &autoscalingv2.HorizontalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{Name: kaToolE2ETargetName + "-hpa", Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: targetName + "-hpa", Namespace: namespace},
 			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{APIVersion: "apps/v1", Kind: "Deployment", Name: kaToolE2ETargetName},
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{APIVersion: "apps/v1", Kind: "Deployment", Name: targetName},
 				MinReplicas:    ptr.To[int32](1), MaxReplicas: 3,
 			},
 		}
@@ -195,18 +194,16 @@ var _ = Describe("E2E-FLEET-017 [AC-4, AC-6, SI-4]: KA real investigation calls 
 		DeferCleanup(func() { _ = remoteK8sClient.Delete(context.Background(), hpa) })
 
 		pdb := &policyv1.PodDisruptionBudget{
-			ObjectMeta: metav1.ObjectMeta{Name: kaToolE2ETargetName + "-pdb", Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: targetName + "-pdb", Namespace: namespace},
 			Spec: policyv1.PodDisruptionBudgetSpec{
 				MinAvailable: ptr.To(intstr.FromInt(1)),
-				Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": kaToolE2ETargetName}},
+				Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": targetName}},
 			},
 		}
 		Expect(remoteK8sClient.Create(ctx, pdb)).To(Succeed())
 		DeferCleanup(func() { _ = remoteK8sClient.Delete(context.Background(), pdb) })
 
-		// Keep this signal distinct from E2E-FLEET-017's preceding fleet case;
-		// otherwise Gateway deduplication rejects it before KA can inspect labels.
-		ai := runKAToolCallE2ECaseWithAlert(remoteKubeconfigPath, remoteK8sClient, remoteCluster, kaToolE2ERemoteEvidence, kaToolE2EKeyword+"-labels")
+		ai := runKAToolCallE2ECaseWithAlert(remoteKubeconfigPath, remoteK8sClient, remoteCluster, kaToolE2ERemoteEvidence, kaToolE2EKeyword+"-labels", targetName)
 		Expect(ai.Status.PostRCAContext).NotTo(BeNil(), "ADR-056: remote investigation must persist post-RCA context")
 		Expect(ai.Status.PostRCAContext.DetectedLabels).NotTo(BeNil(), "BR-INTEGRATION-1489: remote detected labels must be persisted")
 		Expect(ai.Status.PostRCAContext.DetectedLabels.HPAEnabled).To(BeTrue(), "AC-4/AC-6: HPA label must come from the remote cluster")

--- a/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
+++ b/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -108,7 +109,7 @@ func runKAToolCallE2ECaseWithAlert(targetKubeconfig string, targetClient client.
 	// Fingerprints intentionally include alertname. Keep the scenario keyword
 	// while making each run unique so a prior CI run cannot turn this creation
 	// assertion into a duplicate-signal replay.
-	uniqueAlertName := fmt.Sprintf("%s-%d", alertName, time.Now().UnixNano())
+	uniqueAlertName := fmt.Sprintf("%s-%s", alertName, uuid.NewString())
 	payload := buildPrometheusAlertWithCluster(uniqueAlertName, "high", kaToolE2ETargetName, clusterID)
 	body := postFleetAlertUntilAccepted(urlLocalhost30080, payload)
 

--- a/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
+++ b/test/e2e/fleet/17_ka_real_fleet_investigation_test.go
@@ -67,7 +67,11 @@ const (
 // it drives is ever told which environment it's running against; KA's own
 // tool-schema advertisement (toolDefinitionsForPhase) and overlay routing
 // (executeResolved) determine that, opaquely, from clusterID alone.
-func runKAToolCallE2ECase(targetKubeconfig string, targetClient client.Client, clusterID, evidence string) *aianalysisv1.AIAnalysis {
+func runKAToolCallE2ECase(targetKubeconfig string, targetClient client.Client, clusterID, evidence string) {
+	runKAToolCallE2ECaseWithAlert(targetKubeconfig, targetClient, clusterID, evidence, kaToolE2EKeyword)
+}
+
+func runKAToolCallE2ECaseWithAlert(targetKubeconfig string, targetClient client.Client, clusterID, evidence, alertName string) *aianalysisv1.AIAnalysis {
 	By(fmt.Sprintf("Deploying dedicated %s marker (memLimit=%s) on the target cluster", kaToolE2ETargetName, evidence))
 	Expect(infrastructure.DeployMemoryEaterNamed(ctx, kaToolE2ETargetName, namespace,
 		targetKubeconfig, evidence, "20Mi", GinkgoWriter)).To(Succeed())
@@ -84,7 +88,7 @@ func runKAToolCallE2ECase(targetKubeconfig string, targetClient client.Client, c
 	}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
 	By(fmt.Sprintf("Sending the alert (cluster_id=%q)", clusterID))
-	payload := buildPrometheusAlertWithCluster(kaToolE2EKeyword, "high", kaToolE2ETargetName, clusterID)
+	payload := buildPrometheusAlertWithCluster(alertName, "high", kaToolE2ETargetName, clusterID)
 	body := postFleetAlertUntilAccepted(urlLocalhost30080, payload)
 
 	var response map[string]interface{}
@@ -178,7 +182,9 @@ var _ = Describe("E2E-FLEET-017 [AC-4, AC-6, SI-4]: KA real investigation calls 
 		Expect(remoteK8sClient.Create(ctx, pdb)).To(Succeed())
 		DeferCleanup(func() { _ = remoteK8sClient.Delete(context.Background(), pdb) })
 
-		ai := runKAToolCallE2ECase(remoteKubeconfigPath, remoteK8sClient, remoteCluster, kaToolE2ERemoteEvidence)
+		// Keep this signal distinct from E2E-FLEET-017's preceding fleet case;
+		// otherwise Gateway deduplication rejects it before KA can inspect labels.
+		ai := runKAToolCallE2ECaseWithAlert(remoteKubeconfigPath, remoteK8sClient, remoteCluster, kaToolE2ERemoteEvidence, kaToolE2EKeyword+"-labels")
 		Expect(ai.Status.PostRCAContext).NotTo(BeNil(), "ADR-056: remote investigation must persist post-RCA context")
 		Expect(ai.Status.PostRCAContext.DetectedLabels).NotTo(BeNil(), "BR-INTEGRATION-1489: remote detected labels must be persisted")
 		Expect(ai.Status.PostRCAContext.DetectedLabels.HPAEnabled).To(BeTrue(), "AC-4/AC-6: HPA label must come from the remote cluster")

--- a/test/e2e/fleet/23_af_consent_parity_test.go
+++ b/test/e2e/fleet/23_af_consent_parity_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fleet
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	workflowexecutionv1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
+	"github.com/jordigilh/kubernaut/test/infrastructure"
+)
+
+// These journeys deliberately mirror E2E-FP-1899-001/002 and
+// E2E-FP-1853-002, but run against the fleet-enabled AF/KA/RO stack. They
+// prove the consent and completion contracts are not accidentally dependent on
+// fullpipeline's single-cluster deployment.
+var _ = Describe("AF Fleet Consent and Completion Parity", Label("fleet", "af", "a2a", "consent", "issue-2365"), func() {
+	It("E2E-FLEET-2365-001 (AC-6, AU-3, SI-10, ASVS 5.1): preserves phase-1/2 consent through discovery and execution", NodeTimeout(10*time.Minute), func(_ SpecContext) {
+		targetNS := fpRemediateNS["consent-phase2"]
+		Expect(targetNS).NotTo(BeEmpty())
+		fleetDeployConsentTarget(targetNS)
+
+		task := fleetSendTurn("fleet-cg2-1", "create and investigate then sneak workflow discovery")
+		rrName := fleetWaitForRR(targetNS)
+		fleetAssertNoWorkflowExecution(rrName)
+
+		fleetSendTurnWithTask("fleet-cg2-2", task.ID, "ctx-fleet-cg2-1", "confirm discovery of workflows")
+		fleetSendTurnWithTask("fleet-cg2-3", task.ID, "ctx-fleet-cg2-1", "select the discovered workflow")
+		fleetSendTurnWithTask("fleet-cg2-4", task.ID, "ctx-fleet-cg2-1", "watch this remediation now")
+		fleetWaitForWorkflowExecution(rrName)
+	})
+
+	It("E2E-FLEET-2365-002 (AC-6, AU-3, SI-10, ASVS 5.1): preserves phase-2/3 consent after authorized discovery", NodeTimeout(10*time.Minute), func(_ SpecContext) {
+		targetNS := fpRemediateNS["consent-phase3"]
+		Expect(targetNS).NotTo(BeEmpty())
+		fleetDeployConsentTarget(targetNS)
+
+		task := fleetSendTurn("fleet-cg3-1", "create and investigate then sneak workflow selection")
+		rrName := fleetWaitForRR(targetNS)
+		fleetAssertNoWorkflowExecution(rrName)
+
+		fleetSendTurnWithTask("fleet-cg3-2", task.ID, "ctx-fleet-cg3-1", "select the discovered workflow")
+		fleetSendTurnWithTask("fleet-cg3-3", task.ID, "ctx-fleet-cg3-1", "watch this remediation now")
+		fleetWaitForWorkflowExecution(rrName)
+	})
+
+	It("E2E-FLEET-2365-003 (AC-6, AU-3, SI-10, ASVS 5.1): preserves autonomous discover-select-watch chaining", NodeTimeout(10*time.Minute), func(_ SpecContext) {
+		targetNS := fpRemediateNS["full-interactive"]
+		Expect(targetNS).NotTo(BeEmpty())
+		fleetDeployConsentTarget(targetNS)
+
+		fleetSendTurn("fleet-autonomous-2365", "investigate and fix remediation for deployment memory-eater")
+		rrName := fleetWaitForRR(targetNS)
+		fleetWaitForWorkflowExecution(rrName)
+	})
+})
+
+func fleetSendTurn(id, text string) afA2ATaskResult {
+	return fleetSendTurnWithBody(afA2ATasksSend(id, text), 180*time.Second)
+}
+
+func fleetSendTurnWithTask(id, taskID, contextID, text string) afA2ATaskResult {
+	return fleetSendTurnWithBody(afA2ATasksSendWithTask(id, taskID, contextID, text), 180*time.Second)
+}
+
+func fleetSendTurnWithBody(body string, timeout time.Duration) afA2ATaskResult {
+	resp, err := afA2AInvokeWithTimeout(body, timeout)
+	Expect(err).NotTo(HaveOccurred())
+	defer func() { _ = resp.Body.Close() }()
+	Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	rpc, err := afParseRPC(resp)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(rpc.Error).To(BeNil())
+	task, err := afExtractTask(rpc.Result)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(task.ID).NotTo(BeEmpty())
+	return task
+}
+
+func fleetDeployConsentTarget(targetNS string) {
+	Expect(infrastructure.DeployMemoryEaterNamed(ctx, "memory-eater", targetNS, kubeconfigPath, "64Mi", "20Mi", GinkgoWriter)).To(Succeed())
+	DeferCleanup(func() {
+		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "memory-eater", Namespace: targetNS}}
+		_ = k8sClient.Delete(context.Background(), dep)
+	})
+}
+
+func fleetWaitForRR(targetNS string) string {
+	var rrName string
+	Eventually(func() bool {
+		list := &remediationv1.RemediationRequestList{}
+		if err := apiReader.List(ctx, list, client.InNamespace(namespace)); err != nil {
+			return false
+		}
+		for _, rr := range list.Items {
+			if rr.Spec.TargetResource.Namespace == targetNS && rr.Spec.TargetResource.Name == "memory-eater" {
+				rrName = rr.Name
+				return true
+			}
+		}
+		return false
+	}, 90*time.Second, 2*time.Second).Should(BeTrue(), "fleet consent RR should be created for %s", targetNS)
+	return rrName
+}
+
+func fleetAssertNoWorkflowExecution(rrName string) {
+	Consistently(func() int {
+		list := &workflowexecutionv1.WorkflowExecutionList{}
+		if err := apiReader.List(ctx, list, client.InNamespace(namespace)); err != nil {
+			return 0
+		}
+		count := 0
+		for _, we := range list.Items {
+			if we.Spec.RemediationRequestRef.Name == rrName {
+				count++
+			}
+		}
+		return count
+	}, 10*time.Second, 1*time.Second).Should(Equal(0), "same-turn consent violation must not create a WorkflowExecution for %s", rrName)
+}
+
+func fleetWaitForWorkflowExecution(rrName string) {
+	Eventually(func() bool {
+		list := &workflowexecutionv1.WorkflowExecutionList{}
+		if err := apiReader.List(ctx, list, client.InNamespace(namespace)); err != nil {
+			return false
+		}
+		for _, we := range list.Items {
+			if we.Spec.RemediationRequestRef.Name != rrName {
+				continue
+			}
+			if string(we.Status.Phase) == "Failed" {
+				Fail(fmt.Sprintf("fleet WorkflowExecution %s failed", we.Name))
+			}
+			return string(we.Status.Phase) == "Completed"
+		}
+		return false
+	}, 5*time.Minute, 3*time.Second).Should(BeTrue(), "fleet WorkflowExecution for %s should complete", rrName)
+}

--- a/test/e2e/fleet/23_af_consent_parity_test.go
+++ b/test/e2e/fleet/23_af_consent_parity_test.go
@@ -82,8 +82,8 @@ func fleetSendTurn(id, text string) afA2ATaskResult {
 	return fleetSendTurnWithBody(afA2ATasksSend(id, text), 180*time.Second)
 }
 
-func fleetSendTurnWithTask(id, taskID, contextID, text string) afA2ATaskResult {
-	return fleetSendTurnWithBody(afA2ATasksSendWithTask(id, taskID, contextID, text), 180*time.Second)
+func fleetSendTurnWithTask(id, taskID, contextID, text string) {
+	fleetSendTurnWithBody(afA2ATasksSendWithTask(id, taskID, contextID, text), 180*time.Second)
 }
 
 func fleetSendTurnWithBody(body string, timeout time.Duration) afA2ATaskResult {
@@ -152,10 +152,10 @@ func fleetWaitForWorkflowExecution(rrName string) {
 			if we.Spec.RemediationRequestRef.Name != rrName {
 				continue
 			}
-			if string(we.Status.Phase) == "Failed" {
+			if we.Status.Phase == "Failed" {
 				Fail(fmt.Sprintf("fleet WorkflowExecution %s failed", we.Name))
 			}
-			return string(we.Status.Phase) == "Completed"
+			return we.Status.Phase == "Completed"
 		}
 		return false
 	}, 5*time.Minute, 3*time.Second).Should(BeTrue(), "fleet WorkflowExecution for %s should complete", rrName)

--- a/test/e2e/fleet/suite_test.go
+++ b/test/e2e/fleet/suite_test.go
@@ -199,13 +199,11 @@ const fmcSyncTimeout = 45 * time.Second
 
 // postFleetAlertUntilAccepted posts a Prometheus alert payload to the Gateway and
 // retries while the response status is not one of acceptableStatus (defaults to
-// 201 Created or 202 Accepted). A replay can legitimately return either code:
-// 201 means the request reached the create path, while 202 is the duplicate
-// path. See fmcSyncTimeout for why the retry window must exceed FMC's sync
-// interval.
+// 201 Created). See fmcSyncTimeout for why the retry window must exceed FMC's
+// sync interval.
 func postFleetAlertUntilAccepted(gatewayURL string, payload []byte, acceptableStatus ...int) []byte {
 	if len(acceptableStatus) == 0 {
-		acceptableStatus = []int{http.StatusCreated, http.StatusAccepted}
+		acceptableStatus = []int{http.StatusCreated}
 	}
 	var respBody []byte
 	Eventually(func(g Gomega) {

--- a/test/e2e/fleet/suite_test.go
+++ b/test/e2e/fleet/suite_test.go
@@ -199,11 +199,13 @@ const fmcSyncTimeout = 45 * time.Second
 
 // postFleetAlertUntilAccepted posts a Prometheus alert payload to the Gateway and
 // retries while the response status is not one of acceptableStatus (defaults to
-// 201 Created). See fmcSyncTimeout for why the retry window must exceed FMC's
-// sync interval.
+// 201 Created or 202 Accepted). A replay can legitimately return either code:
+// 201 means the request reached the create path, while 202 is the duplicate
+// path. See fmcSyncTimeout for why the retry window must exceed FMC's sync
+// interval.
 func postFleetAlertUntilAccepted(gatewayURL string, payload []byte, acceptableStatus ...int) []byte {
 	if len(acceptableStatus) == 0 {
-		acceptableStatus = []int{http.StatusCreated}
+		acceptableStatus = []int{http.StatusCreated, http.StatusAccepted}
 	}
 	var respBody []byte
 	Eventually(func(g Gomega) {

--- a/test/infrastructure/fleet_demo_helm.go
+++ b/test/infrastructure/fleet_demo_helm.go
@@ -242,6 +242,18 @@ func buildFleetDemoHelmArgs(kubeconfigPath, chartPath, namespace string, fleetOp
 		// uses it for browser-JWT JWKS validation (same host:port, unlike
 		// the FP suite's separate DEX-on-5556 case).
 		"--set", "networkPolicies.idp.port=8443",
+		// AF alert tools (list_alerts/get_alert_details/kubernaut_investigate_alert)
+		// only register when the chart renders severityTriage.enabled=true with
+		// a prometheusURL, which requires monitoring.prometheus.enabled=true.
+		// Without these, AF runs triage-disabled and Console reports alert
+		// querying as unconfigured -- even though the fleet monitoring stack
+		// below is already running. Matches the manual values printed by
+		// SetupFleetCoreInfrastructureWithGateway. Thanos Querier (not plain
+		// Prometheus) so alerts are fleet-wide (hub+spoke, ADR-068).
+		"--set", "monitoring.prometheus.enabled=true",
+		"--set", "monitoring.prometheus.url=http://thanos-querier-svc." + monitoringNamespace + ".svc.cluster.local:9090",
+		"--set", "monitoring.alertManager.enabled=true",
+		"--set", "monitoring.alertManager.url=http://alertmanager-svc." + monitoringNamespace + ".svc.cluster.local:9093",
 		"--set-file", "signalprocessing.policies.content=" + spPolicyFile,
 		"--set-file", "aianalysis.policies.content=" + aaPolicyFile,
 	}

--- a/test/infrastructure/fleet_demo_helm.go
+++ b/test/infrastructure/fleet_demo_helm.go
@@ -474,10 +474,17 @@ func InstallFleetDemoHelmChart(ctx context.Context, kubeconfigPath, remoteKubeco
 		_, _ = fmt.Fprintln(writer, "  Console to investigate. Re-run with -autonomous to see it happen on its own.")
 	}
 	_, _ = fmt.Fprintln(writer, "\n  To run a kubernaut-demo-scenarios scenario in fleet mode (hub+spoke split")
-	_, _ = fmt.Fprintln(writer, "  instead of single-cluster), export these, then pass --fleet to run.sh:")
+	_, _ = fmt.Fprintln(writer, "  instead of single-cluster), export these, then run the scenario:")
 	_, _ = fmt.Fprintf(writer, "    export HUB_KUBECONFIG=%s\n", kubeconfigPath)
 	_, _ = fmt.Fprintf(writer, "    export SPOKE_KUBECONFIG=%s\n", remoteKubeconfigPath)
-	_, _ = fmt.Fprintln(writer, "    ./scenarios/<name>/run.sh --fleet")
+	if opts.Autonomous {
+		_, _ = fmt.Fprintln(writer, "    ./scenarios/<name>/run.sh --fleet")
+		_, _ = fmt.Fprintln(writer, "  (Gateway enabled: Kubernaut detects and remediates automatically.)")
+	} else {
+		_, _ = fmt.Fprintln(writer, "    ./scenarios/<name>/run.sh --fleet --alert-only")
+		_, _ = fmt.Fprintln(writer, "  (--alert-only fires the alert and stops: investigate it yourself in")
+		_, _ = fmt.Fprintln(writer, "  Console. Drop --alert-only with -autonomous for full auto-remediation.)")
+	}
 	_, _ = fmt.Fprintln(writer, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
 	return nil

--- a/test/infrastructure/fleet_demo_helm.go
+++ b/test/infrastructure/fleet_demo_helm.go
@@ -489,6 +489,9 @@ func InstallFleetDemoHelmChart(ctx context.Context, kubeconfigPath, remoteKubeco
 	_, _ = fmt.Fprintln(writer, "  instead of single-cluster), export these, then run the scenario:")
 	_, _ = fmt.Fprintf(writer, "    export HUB_KUBECONFIG=%s\n", kubeconfigPath)
 	_, _ = fmt.Fprintf(writer, "    export SPOKE_KUBECONFIG=%s\n", remoteKubeconfigPath)
+	_, _ = fmt.Fprintln(writer, "\n  Clone the demo scenarios repo:")
+	_, _ = fmt.Fprintln(writer, "    git clone https://github.com/kubernaut/kubernaut-demo-scenarios.git")
+	_, _ = fmt.Fprintln(writer, "    cd kubernaut-demo-scenarios https://github.com/kubernaut/kubernaut-demo-scenarios.git")
 	if opts.Autonomous {
 		_, _ = fmt.Fprintln(writer, "    ./scenarios/<name>/run.sh --fleet")
 		_, _ = fmt.Fprintln(writer, "  (Gateway enabled: Kubernaut detects and remediates automatically.)")

--- a/test/infrastructure/fleet_demo_helm_test.go
+++ b/test/infrastructure/fleet_demo_helm_test.go
@@ -226,6 +226,16 @@ var _ = Describe("buildFleetDemoHelmArgs", func() {
 		}
 	})
 
+	It("UT-INFRA-FLEETDEMO-046: wires AF alert tools to the fleet monitoring stack (Thanos Querier + Alertmanager)", func() {
+		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, baseOpts, "/tmp/sp.rego", "/tmp/aa.rego")
+		Expect(args).To(ContainElements(
+			"--set", "monitoring.prometheus.enabled=true",
+			"--set", "monitoring.prometheus.url=http://thanos-querier-svc.monitoring.svc.cluster.local:9090",
+			"--set", "monitoring.alertManager.enabled=true",
+			"--set", "monitoring.alertManager.url=http://alertmanager-svc.monitoring.svc.cluster.local:9093",
+		))
+	})
+
 	It("UT-INFRA-FLEETDEMO-017: points APIFrontend/Console OIDC at Keycloak, not DEX", func() {
 		args := buildFleetDemoHelmArgs("/tmp/kubeconfig", "charts/kubernaut", "kubernaut-system", baseFleetOpts, baseOpts, "/tmp/sp.rego", "/tmp/aa.rego")
 		Expect(args).To(ContainElements(

--- a/test/integration/kubernautagent/investigator/fleet_enrichment_prefetch_it_test.go
+++ b/test/integration/kubernautagent/investigator/fleet_enrichment_prefetch_it_test.go
@@ -18,6 +18,7 @@ package investigator_test
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-logr/logr"
 
@@ -35,6 +36,44 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
+
+type labelDetectorGetTool struct{}
+
+func (labelDetectorGetTool) Name() string                { return "resources_get" }
+func (labelDetectorGetTool) Description() string         { return "remote label detector get" }
+func (labelDetectorGetTool) Parameters() json.RawMessage { return json.RawMessage(`{}`) }
+func (labelDetectorGetTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var request map[string]string
+	Expect(json.Unmarshal(args, &request)).To(Succeed())
+	if request["kind"] == "Namespace" {
+		return `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"remote-ns"}}`, nil
+	}
+	return `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"remote-target","namespace":"remote-ns","labels":{"app":"remote-target"}}}`, nil
+}
+
+type labelDetectorListTool struct{}
+
+func (labelDetectorListTool) Name() string                { return "resources_list" }
+func (labelDetectorListTool) Description() string         { return "remote label detector list" }
+func (labelDetectorListTool) Parameters() json.RawMessage { return json.RawMessage(`{}`) }
+func (labelDetectorListTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var request map[string]string
+	Expect(json.Unmarshal(args, &request)).To(Succeed())
+	switch request["kind"] {
+	case "HorizontalPodAutoscaler":
+		return `{"apiVersion":"autoscaling/v2","kind":"HorizontalPodAutoscalerList","items":[{"spec":{"scaleTargetRef":{"kind":"Deployment","name":"remote-target"}}}]}`, nil
+	case "PodDisruptionBudget":
+		return `{"apiVersion":"policy/v1","kind":"PodDisruptionBudgetList","items":[{"spec":{"selector":{"matchLabels":{"app":"remote-target"}}}}]}`, nil
+	case "NetworkPolicy":
+		return `{"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicyList","items":[]}`, nil
+	case "ResourceQuota":
+		return `{"apiVersion":"v1","kind":"ResourceQuotaList","items":[]}`, nil
+	case "PersistentVolumeClaim":
+		return `{"apiVersion":"v1","kind":"PersistentVolumeClaimList","items":[]}`, nil
+	default:
+		return `{"items":[]}`, nil
+	}
+}
 
 // Issue #2343: Investigate()'s automatic pre-fetch enrichment step
 // (resolveEnrichmentCached -> Enricher.Enrich) always resolved owner-chain/
@@ -163,6 +202,51 @@ var _ = Describe("Fleet-aware enrichment pre-fetch (BR-INTEGRATION-1489, Issue #
 			ev := completedEvents[0]
 			Expect(ev.Data["root_owner_name"]).To(Equal("hub-local-target"),
 				"a hub-local investigation (no ClusterID, no overlay) must still resolve via the hub K8sClient")
+		})
+	})
+
+	Describe("IT-KA-FLEET-2345 [AC-4, AC-6, SI-10]: detected labels use the fleet overlay", func() {
+		It("detects remote HPA and PDB labels through production-style enricher routing", func() {
+			hubK8s := &k8sFixtureClient{ownerChain: []enrichment.OwnerChainEntry{
+				{Kind: "Deployment", Name: "hub-should-not-appear", Namespace: "production"},
+			}}
+			hubDetector := enrichment.NewLabelDetector(nil, newItTestMapper(), invLogger)
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{
+				"resources_get":  labelDetectorGetTool{},
+				"resources_list": labelDetectorListTool{},
+			}}
+			mockClient := &mockLLMClient{responses: minimalInvestigationResponses()}
+
+			enricher := enrichment.NewEnricher(hubK8s, suiteDSAdapter, auditStore, invLogger).
+				WithK8sResolver(func(ctx context.Context) enrichment.K8sClient {
+					return custom.ResolveK8sClient(ctx, hubK8s, invLogger)
+				}).
+				WithLabelDetectorResolver(func(ctx context.Context) *enrichment.LabelDetector {
+					return custom.ResolveLabelDetector(ctx, hubDetector, newItTestMapper(), invLogger)
+				})
+
+			builder, berr := prompt.NewBuilder()
+			Expect(berr).NotTo(HaveOccurred())
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: parser.NewResultParser(), Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: registry.New(),
+				FleetOverlayResolver: spy,
+			})
+
+			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "remote-target", Namespace: "remote-ns", ResourceKind: "Deployment", ResourceName: "remote-target",
+				ClusterID: "remote-east", RemediationID: "rem-2345-001",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.DetectedLabels).NotTo(BeNil())
+			Expect(result.DetectedLabels["hpaEnabled"]).To(BeTrue(), "AC-4: HPA evidence must come from the target cluster")
+			Expect(result.DetectedLabels["pdbProtected"]).To(BeTrue(), "AC-4: PDB evidence must come from the target cluster")
+			failed, ok := result.DetectedLabels["failedDetections"].([]string)
+			if ok {
+				Expect(failed).NotTo(ContainElement("hpaEnabled"), "SI-10: valid remote list responses must not be treated as detection failures")
+				Expect(failed).NotTo(ContainElement("pdbProtected"), "SI-10: valid remote list responses must not be treated as detection failures")
+			}
 		})
 	})
 })

--- a/test/services/mock-llm/scenarios/scenario_ka_fleet_investigation.go
+++ b/test/services/mock-llm/scenarios/scenario_ka_fleet_investigation.go
@@ -17,6 +17,7 @@ package scenarios
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -106,19 +107,30 @@ const (
 // resources_get (overlay, fleet-only) once the transparency fix ships, and
 // the overlay's cluster-scoped tool is the correct one to call for that
 // investigation.
-func kaToolCallForAvailability(available []string) (toolName string, args map[string]interface{}, expectedEvidence string, ok bool) {
+var kaToolE2ETargetNamePattern = regexp.MustCompile(`(?i)ka-tool-e2e-target(?:-[a-z0-9]{8})?`)
+
+func kaToolE2ETargetNameFromContext(ctx *DetectionContext) string {
+	if ctx != nil {
+		if targetName := kaToolE2ETargetNamePattern.FindString(ctx.Content + " " + ctx.AllText); targetName != "" {
+			return targetName
+		}
+	}
+	return kaToolE2ETargetName
+}
+
+func kaToolCallForAvailability(available []string, targetName string) (toolName string, args map[string]interface{}, expectedEvidence string, ok bool) {
 	switch {
 	case slices.Contains(available, kaToolE2EFleetToolName):
 		return kaToolE2EFleetToolName, map[string]interface{}{
 			"kind":       "Deployment",
 			"apiVersion": "apps/v1",
-			"name":       kaToolE2ETargetName,
+			"name":       targetName,
 			"namespace":  kaToolE2ETargetNamespace,
 		}, kaToolE2ERemoteEvidence, true
 	case slices.Contains(available, kaToolE2ELocalToolName):
 		return kaToolE2ELocalToolName, map[string]interface{}{
 			"kind":      "Deployment",
-			"name":      kaToolE2ETargetName,
+			"name":      targetName,
 			"namespace": kaToolE2ETargetNamespace,
 		}, kaToolE2ELocalEvidence, true
 	default:
@@ -185,7 +197,8 @@ func (s *kaToolCallE2EScenario) ConfigForContext(ctx *DetectionContext) MockScen
 	if ctx != nil {
 		available = ctx.AvailableTools
 	}
-	toolName, args, expectedEvidence, ok := kaToolCallForAvailability(available)
+	targetName := kaToolE2ETargetNameFromContext(ctx)
+	toolName, args, expectedEvidence, ok := kaToolCallForAvailability(available, targetName)
 	if !ok {
 		cfg.RootCause = fmt.Sprintf(
 			"neither %q nor %q was offered in the tool schema -- fleet overlay wiring or local tool registration is broken",
@@ -214,11 +227,11 @@ func (s *kaToolCallE2EScenario) ConfigForContext(ctx *DetectionContext) MockScen
 	if ctx != nil && strings.Contains(ctx.AllText, strings.ToLower(expectedEvidence)) {
 		cfg.RootCause = fmt.Sprintf(
 			"Verified %s via %s: found expected evidence %q from a genuine, correctly-targeted cluster round trip",
-			kaToolE2ETargetName, toolName, expectedEvidence)
+			targetName, toolName, expectedEvidence)
 	} else {
 		cfg.RootCause = fmt.Sprintf(
 			"%s call for %s did not return the expected evidence %q -- tool call missing, failed, or reached the wrong cluster",
-			toolName, kaToolE2ETargetName, expectedEvidence)
+			toolName, targetName, expectedEvidence)
 	}
 	return cfg
 }


### PR DESCRIPTION
Closes #2345
Closes #2358
Closes #2360
Closes #2362
Closes #2364
Closes #2365

## Fix 1: wire AF alert tools to the fleet monitoring stack (#2358)

Demo provisioning never set `monitoring.prometheus.*`, so the chart rendered
`severityTriage.enabled=false`, AF built no `PromClient`, and Console reported
alert querying as unconfigured. Sets `monitoring.prometheus.enabled/url`
(Thanos Querier) and `monitoring.alertManager.enabled/url`;
`UT-INFRA-FLEETDEMO-046` pins all four `--set` values. Verified live via
`helm upgrade --reuse-values` + AF restart.

## Fix 2: scenario run.sh hint distinguishes interactive vs autonomous (#2360)

Hint branched on `opts.Autonomous`: `--fleet --alert-only` for Console-first,
bare `--fleet` for autonomous. Presentation-only.

## Fix 3: optional setup-fleet-demo-infra flags no longer split the recipe

`$(if ...)` lines ended with `\ ` inside the conditional, breaking shell
continuation whenever set. Backslash moved outside; verified via `make -n`.

## Fix 4: cluster attribution across GW + AF (#2362)

- Gateway adapter falls back to the per-alert `cluster` label when AlertManager
  grouping strips it from `commonLabels` (common keeps precedence);
  `UT-GW-2362-101..103`.
- AF refuses fleet-unattributed scope checks naming known clusters instead of
  misreporting "not managed" (`UT-AF-2362-001..005`); nil lister, explicit
  cluster, and local-hit paths unchanged; audit preserved. Narrow
  `ClusterLister` interface threaded through ToolDeps/configs.

## Fix 5: route fleet LabelDetector enrichment to the target cluster (#2345)

Fleet investigations previously constructed `LabelDetector` once with the hub
Kubernetes client. Related-resource detection (HPA, PDB, NetworkPolicy,
ResourceQuota, PVC/CDI, and StorageClass) therefore queried the hub and could
report missing or incorrect infrastructure labels for healthy spoke resources.

- Added per-request LabelDetector resolution matching the existing fleet
  Enricher/Kubernetes-client routing.
- Added remote `resources_list` support with namespace and label-selector
  handling.
- Routed all list-backed detection and storage lookups through the remote
  overlay without falling back to the hub for fleet requests.
- Added `IT-KA-FLEET-2345` production-style coverage asserting remote HPA/PDB
  business outcomes and no detection failures.
- Added `E2E-FLEET-2345` real hub/spoke coverage asserting labels in
  `AIAnalysis.Status.PostRCAContext.DetectedLabels`.
- Added `docs/tests/2345/TEST_PLAN.md` mapping BR-INTEGRATION-1489 to FedRAMP
  AC-4/AC-6/SI-10 and OWASP ASVS 5.1.x/5.5.2.
- Preserved local/non-Kubernetes startup behavior: Kubernetes infrastructure is
  optional so future non-Kubernetes remediation targets can still start without
  a Kubernetes client.

Validation: targeted enrichment/custom/agent tests, `go build ./...`, and
 targeted golangci-lint pass. The new integration/E2E suites compile; execution
requires envtest assets and a real fleet environment. Local IT execution is
currently blocked because `/usr/local/kubebuilder/bin/etcd` is unavailable.

## Fix 6: tolerate ambient fleet fields in AF tool schemas (#2364)

Fleet-hinted interactive turns can propagate `cluster_id`, `rr_id`, and
`session_id` across tool calls. ADK v2 strict schemas rejected undeclared fields,
causing `kubernaut_present_decision` failures and circuit-breaker termination
before the structured decision artifact was emitted.

- Added ignored `omitempty` ambient fields across Tier 1/Tier 2 lifecycle tool schemas, including nested RCA and target structs.
- Updated the agent prompt to preserve context without copying undeclared fields into tool calls.
- Added Ginkgo unit and real ADK functiontool integration coverage mapped to SI-10, AU-3, AC-6, ASVS 5.1/5.5.2, and fleet selection behavior.
- Added `docs/tests/2364/TEST_PLAN.md`.

## Fix 7: business-outcome completion and decision recovery (#2365)

AF previously treated ADK/A2A turn completion as business-lifecycle completion.
When the model narrated after successful workflow discovery without calling
`kubernaut_present_decision`, the stream closed without a structured decision
artifact and the RR could remain in `Analyzing`.

- Added the accepted architecture in `DD-AF-014`.
- Added a typed completion-obligation policy separating presentation from execution authorization.
- Added canonical discovery normalization, including empty direct responses.
- Added deterministic, provenance-marked recovery from authoritative RCA summaries and workflow discovery results.
- Preserved phase-3 consent and autonomous discover/select/watch chaining.
- Added truthful incomplete-data artifacts and bounded operator escalation only outside an active consent boundary.
- Added unit and production-path integration coverage mapped to AC-6, SI-10, AU-3, AU-12, SI-4, ASVS 5.1, and ASVS 5.5.2.
- Added `docs/tests/2365/IMPLEMENTATION_PLAN.md`.

Validation: `make test`, `make test-unit-apifrontend`, `make lint`, `make vet`, and `go build ./...` pass. Live full-pipeline E2E validation is documented as environment-gated; the generated dossier for run `34011480864` was used to correct the consent-boundary escalation regression.