### PR TITLE
release: prepare v1.6.0-rc10

### DIFF
--- a/charts/kubernaut/Chart.yaml
+++ b/charts/kubernaut/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubernaut
 description: Kubernaut - Autonomous Kubernetes Remediation Platform
 type: application
-version: 1.6.0-rc9
-appVersion: "1.6.0-rc9"
+version: 1.6.0
+appVersion: "1.6.0"
 home: https://github.com/jordigilh/kubernaut
 sources:
   - https://github.com/jordigilh/kubernaut

--- a/charts/kubernaut/README.md
+++ b/charts/kubernaut/README.md
@@ -820,13 +820,13 @@ the chart version:
 ```bash
 helm upgrade kubernaut charts/kubernaut \
   --namespace kubernaut-system \
-  --set global.image.tag=1.6.0-rc9 \
+  --set global.image.tag=1.6.0-rc10 \
   ...
 ```
 
 The fleet demo entry point wires this directly: `setup-fleet-demo-infra
--image-tag 1.6.0-rc9 ...` (equivalently `make setup-fleet-demo-infra
-IMAGE_TAG=1.6.0-rc9 ...`). When the flag is omitted, no `--set` is emitted and
+-image-tag 1.6.0-rc10 ...` (equivalently `make setup-fleet-demo-infra
+IMAGE_TAG=1.6.0-rc10 ...`). When the flag is omitted, no `--set` is emitted and
 every service falls back to `.Chart.AppVersion`. Note the `console` container
 itself is versioned independently (`console.image.repository:tag`) and is
 intentionally not part of the `global.image.tag` train.


### PR DESCRIPTION
## Summary
- restore Chart.yaml version/appVersion to the 1.6.0 source-of-truth values
- update chart documentation examples to the v1.6.0-rc10 image tag

## Validation
- `make sync-version`
- `go build ./...`
- `make lint`
- `go test ./... -run=^$ -timeout=30s`
- `helm lint` with required policy values

Full `make test` was attempted but exceeded the local five-minute limit during gateway coverage finalization.