### PR TITLE
fix(fleet-demo): reissue stale Keycloak TLS certificate

### DIFF
--- a/test/infrastructure/keycloak_certmanager.go
+++ b/test/infrastructure/keycloak_certmanager.go
@@ -17,12 +17,15 @@ limitations under the License.
 package infrastructure
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -93,6 +96,9 @@ func ensureKeycloakCertManagerIssuer(ctx context.Context, kubeconfigPath, namesp
 
 	caCert, caKey, err := loadChartCAFromAuthwebhookTLS(ctx, kubeconfigPath, namespace)
 	if err != nil {
+		return err
+	}
+	if err := removeStaleKeycloakTLSSecret(ctx, kubeconfigPath, keycloakNamespace, caCert, writer); err != nil {
 		return err
 	}
 	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw})
@@ -189,4 +195,53 @@ spec:
 	}
 
 	return fmt.Errorf("failed to create keycloak-tls Issuer/Certificate after %d attempts: %w", maxRetries, lastErr)
+}
+
+// removeStaleKeycloakTLSSecret removes only the generated leaf Secret when it
+// was issued by an older chart CA. cert-manager considers an unexpired Secret
+// ready even after its CA issuer Secret changes, so applying the Certificate
+// alone does not reliably trigger reissuance on demo reruns.
+func removeStaleKeycloakTLSSecret(ctx context.Context, kubeconfigPath, namespace string, caCert *x509.Certificate, writer io.Writer) error {
+	getCmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath,
+		"get", "secret", "keycloak-tls", "-n", namespace, "--ignore-not-found",
+		"-o", `jsonpath={.data.tls\.crt}`)
+	encodedCert, err := getCmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to inspect existing keycloak-tls Secret: %w", err)
+	}
+	if len(bytes.TrimSpace(encodedCert)) == 0 {
+		return nil
+	}
+
+	certPEM, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(encodedCert)))
+	if err != nil {
+		return fmt.Errorf("failed to decode existing keycloak-tls certificate: %w", err)
+	}
+	matches, err := certificateSignedByCA(certPEM, caCert)
+	if err != nil {
+		return fmt.Errorf("failed to validate existing keycloak-tls certificate: %w", err)
+	}
+	if matches {
+		return nil
+	}
+
+	deleteCmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath,
+		"delete", "secret", "keycloak-tls", "-n", namespace, "--ignore-not-found")
+	if output, err := deleteCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to remove stale keycloak-tls Secret: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	_, _ = fmt.Fprintln(writer, "  ♻️  Removed stale keycloak-tls Secret; cert-manager will reissue it from the current chart CA")
+	return nil
+}
+
+func certificateSignedByCA(certPEM []byte, caCert *x509.Certificate) (bool, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return false, fmt.Errorf("certificate PEM block not found")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false, err
+	}
+	return cert.CheckSignatureFrom(caCert) == nil, nil
 }

--- a/test/infrastructure/keycloak_certmanager_test.go
+++ b/test/infrastructure/keycloak_certmanager_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("certificateSignedByCA", func() {
+	It("UT-INFRA-FLEETDEMO-047: accepts a leaf signed by the current CA", func() {
+		ca, leafPEM, setupErr := testCertificateChain()
+
+		Expect(setupErr).NotTo(HaveOccurred())
+		matches, err := certificateSignedByCA(leafPEM, ca)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matches).To(BeTrue())
+	})
+
+	It("UT-INFRA-FLEETDEMO-048: rejects a leaf signed by an obsolete CA", func() {
+		currentCA, _, currentCAErr := testCertificateChain()
+		obsoleteCA, leafPEM, obsoleteCAErr := testCertificateChain()
+
+		Expect(currentCAErr).NotTo(HaveOccurred())
+		Expect(obsoleteCAErr).NotTo(HaveOccurred())
+		matches, err := certificateSignedByCA(leafPEM, currentCA)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matches).To(BeFalse())
+		Expect(obsoleteCA).NotTo(BeNil())
+	})
+
+	It("UT-INFRA-FLEETDEMO-049: rejects malformed certificate PEM", func() {
+		ca, _, setupErr := testCertificateChain()
+
+		Expect(setupErr).NotTo(HaveOccurred())
+		matches, err := certificateSignedByCA([]byte("not-a-certificate"), ca)
+
+		Expect(err).To(MatchError("certificate PEM block not found"))
+		Expect(matches).To(BeFalse())
+	})
+})
+
+func testCertificateChain() (*x509.Certificate, []byte, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	now := time.Now()
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	ca, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "keycloak"},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, ca, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ca, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER}), nil
+}

--- a/test/infrastructure/keycloak_e2e.go
+++ b/test/infrastructure/keycloak_e2e.go
@@ -472,6 +472,7 @@ func waitForKeycloakReady(ctx context.Context, kubeconfigPath string, hostPort i
 
 	realmURL := fmt.Sprintf("https://localhost:%d/realms/kubernaut-fleet", hostPort)
 	deadline := time.Now().Add(150 * time.Second)
+	var lastErr error
 	for time.Now().Before(deadline) {
 		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, realmURL, http.NoBody)
 		if reqErr != nil {
@@ -487,14 +488,19 @@ func waitForKeycloakReady(ctx context.Context, kubeconfigPath string, hostPort i
 		// common case while Keycloak is still starting) -- dereferencing it
 		// unconditionally panics here. Branch on err first (SA5011/errcheck).
 		if err != nil {
+			lastErr = err
 			_, _ = fmt.Fprintln(writer, "  Keycloak not yet reachable, waiting:", err)
 		} else {
+			lastErr = fmt.Errorf("received HTTP status %d", resp.StatusCode)
 			_, _ = fmt.Fprintln(writer, "resp.StatusCode:", resp.StatusCode, "waiting for Keycloak kubernaut-fleet realm to be reachable...")
 			_ = resp.Body.Close()
 		}
 		time.Sleep(3 * time.Second)
 	}
 
+	if lastErr != nil {
+		return fmt.Errorf("keycloak kubernaut-fleet realm not responsive after 150 seconds: %w", lastErr)
+	}
 	return fmt.Errorf("keycloak kubernaut-fleet realm not responsive after 150 seconds")
 }
 


### PR DESCRIPTION
## Summary

- Detect and remove a demo `keycloak-tls` leaf Secret signed by an obsolete chart CA before applying the cert-manager Certificate.
- Preserve existing behavior when the leaf is signed by the current CA.
- Include the last TLS or HTTP failure in the Keycloak readiness timeout.
- Add Ginkgo regression coverage for matching, obsolete, and malformed certificates.

Closes #2371

## Validation

- `go build ./...`
- `go test ./test/infrastructure`
- `go test ./test/infrastructure -run TestInfrastructure -ginkgo.focus=certificateSignedByCA -count=1`
- `go vet ./test/infrastructure`
- `golangci-lint run --timeout=5m ./test/infrastructure/...`

`go test ./...` reached unrelated spike suites but cannot complete in this environment because `/usr/local/kubebuilder/bin/etcd`, `/tmp/kube-mcp-server`, and the MCP service at `127.0.0.1:18080` are unavailable. Repository-wide `golangci-lint` and `make lint-test-patterns` also report pre-existing issues outside the changed package.