### PR TITLE
fix(interactive): retry transient MCP startup failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ COMMA := ,
 # macOS: sysctl -n hw.ncpu
 # Fallback to 4 if detection fails
 TEST_PROCS ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+# FullPipeline specs share one MCP test identity; avoid cross-worker rate-limit bursts.
+FULLPIPELINE_TEST_PROCS ?= 1
 TEST_TIMEOUT_UNIT ?= 8m
 TEST_TIMEOUT_INTEGRATION ?= 15m
 TEST_TIMEOUT_E2E ?= 18m
@@ -929,7 +931,7 @@ test-e2e-fullpipeline: ginkgo ensure-coverage-dirs ## Run full pipeline E2E test
 	@echo "   All Kubernaut services in a single Kind cluster"
 	@echo "   Event → Gateway → RO → SP → AA → KA → WE(Job) → EM → Notification"
 	@echo "════════════════════════════════════════════════════════════════════════"
-	@$(GINKGO) -v --race --timeout=50m --procs=$(TEST_PROCS) ./test/e2e/fullpipeline/...
+	@$(GINKGO) -v --race --timeout=50m --procs=$(FULLPIPELINE_TEST_PROCS) ./test/e2e/fullpipeline/...
 	@echo "✅ Full Pipeline E2E tests completed!"
 
 # Fleet E2E: Full pipeline + EAIGW + K8s MCP Server (loopback pattern)

--- a/pkg/apifrontend/ka/mcp_sdk_client.go
+++ b/pkg/apifrontend/ka/mcp_sdk_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -253,7 +254,7 @@ func (c *SDKMCPClient) StartInvestigation(ctx context.Context, args StartInvesti
 	// minutes; the caller controls cleanup via Closer(). We still use ctx
 	// for the initial Connect and SetLoggingLevel calls (which must complete
 	// within the request deadline), but the session itself lives beyond ctx.
-	session, err := connectInvestigationSession(streamClient, c.endpoint, c.streamHTTPClient) //nolint:contextcheck // connectInvestigationSession intentionally connects over a detached background context (see its doc comment / StartInvestigation)
+	session, err := connectInvestigationSession(ctx, streamClient, c.endpoint, c.streamHTTPClient)
 	if err != nil {
 		close(doneCh)
 		close(eventCh)
@@ -335,26 +336,64 @@ func (c *SDKMCPClient) newInvestigationStreamClient(args StartInvestigationArgs,
 	})
 }
 
-// connectInvestigationSession connects streamClient over a detached
-// background context (see StartInvestigation) and sets the KA logging level
-// for the resulting session.
-func connectInvestigationSession(streamClient *mcp.Client, endpoint string, httpClient *http.Client) (*mcp.ClientSession, error) {
+const (
+	maxInvestigationConnectAttempts = 3
+	investigationConnectRetryDelay  = 100 * time.Millisecond
+)
+
+// connectInvestigationSession connects streamClient and sets the KA logging
+// level. Transient 429 responses are retried because interactive MCP traffic
+// can briefly exhaust a per-user token bucket.
+func connectInvestigationSession(ctx context.Context, streamClient *mcp.Client, endpoint string, httpClient *http.Client) (*mcp.ClientSession, error) {
+	var lastErr error
+	for attempt := 1; attempt <= maxInvestigationConnectAttempts; attempt++ {
+		session, err := connectInvestigationSessionOnce(ctx, streamClient, endpoint, httpClient)
+		if err == nil {
+			return session, nil
+		}
+		lastErr = err
+		if !isRetryableMCPStartupError(err) || attempt == maxInvestigationConnectAttempts {
+			break
+		}
+
+		timer := time.NewTimer(investigationConnectRetryDelay * time.Duration(attempt))
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return nil, lastErr
+}
+
+func connectInvestigationSessionOnce(ctx context.Context, streamClient *mcp.Client, endpoint string, httpClient *http.Client) (*mcp.ClientSession, error) {
 	transport := &mcp.StreamableClientTransport{
 		Endpoint:   endpoint,
 		HTTPClient: httpClient,
 	}
 
-	session, err := streamClient.Connect(context.Background(), transport, nil)
+	session, err := streamClient.Connect(ctx, transport, nil)
 	if err != nil {
 		return nil, fmt.Errorf("MCP connect for investigation: %w", err)
 	}
 
-	if err := session.SetLoggingLevel(context.Background(), &mcp.SetLoggingLevelParams{Level: "info"}); err != nil {
+	if err := session.SetLoggingLevel(ctx, &mcp.SetLoggingLevelParams{Level: "info"}); err != nil {
 		_ = session.Close()
 		return nil, fmt.Errorf("set logging level: %w", err)
 	}
 
 	return session, nil
+}
+
+func isRetryableMCPStartupError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errText := strings.ToLower(err.Error())
+	return strings.Contains(errText, "429") || strings.Contains(errText, "too many requests")
 }
 
 // callStartInvestigation invokes kubernaut_investigate with action=start on

--- a/pkg/apifrontend/ka/mcp_sdk_client.go
+++ b/pkg/apifrontend/ka/mcp_sdk_client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/security"
+	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
 )
 
 // SDKMCPClient implements MCPClient using the MCP Go SDK's StreamableClientTransport.
@@ -338,8 +339,14 @@ func (c *SDKMCPClient) newInvestigationStreamClient(args StartInvestigationArgs,
 
 const (
 	maxInvestigationConnectAttempts = 3
-	investigationConnectRetryDelay  = 100 * time.Millisecond
 )
+
+var investigationConnectBackoff = backoff.Config{
+	BasePeriod:    100 * time.Millisecond,
+	MaxPeriod:     1 * time.Second,
+	Multiplier:    2.0,
+	JitterPercent: 20,
+}
 
 // connectInvestigationSession connects streamClient and sets the KA logging
 // level. Transient 429 responses are retried because interactive MCP traffic
@@ -356,7 +363,7 @@ func connectInvestigationSession(ctx context.Context, streamClient *mcp.Client, 
 			break
 		}
 
-		timer := time.NewTimer(investigationConnectRetryDelay * time.Duration(attempt))
+		timer := time.NewTimer(investigationConnectBackoff.Calculate(int32(attempt)))
 		select {
 		case <-ctx.Done():
 			if !timer.Stop() {

--- a/pkg/apifrontend/ka/mcp_sdk_client_test.go
+++ b/pkg/apifrontend/ka/mcp_sdk_client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
@@ -560,6 +561,47 @@ var _ = Describe("SDKMCPClient.StartInvestigation (CHAR-AF-1532)", func() {
 		Expect(capturedArgs).NotTo(HaveKey("session_id"), "session_id omitted from args when not provided")
 
 		result.Closer()
+	})
+
+	It("UT-AF-2373-001: retries transient MCP 429 during investigation startup", func() {
+		server := mcp.NewServer(&mcp.Implementation{Name: "ka-mock", Version: "test"}, nil)
+		mcp.AddTool(server, &mcp.Tool{Name: "kubernaut_investigate"}, func(_ context.Context, _ *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: `{"session_id":"sess-2373","status":"started"}`}}}, nil, nil
+		})
+		httpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server { return server }, nil)
+		var requests atomic.Int32
+		mux := http.NewServeMux()
+		mux.Handle("/mcp", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if requests.Add(1) == 1 {
+				http.Error(w, "too many requests", http.StatusTooManyRequests)
+				return
+			}
+			fakeAuthMiddleware(httpHandler).ServeHTTP(w, r)
+		}))
+		ts = httptest.NewServer(mux)
+		client = ka.NewSDKMCPClient(ts.URL+"/mcp", &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}, nil, logr.Discard())
+
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "alice@example.com", RawToken: "token-for-alice@example.com"})
+		result, err := client.StartInvestigation(ctx, ka.StartInvestigationArgs{RRID: "rr-2373"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.SessionID).To(Equal("sess-2373"))
+		Expect(requests.Load()).To(BeNumerically(">", 1))
+		result.Closer()
+	})
+
+	It("UT-AF-2373-002: returns the startup error when MCP 429 persists", func() {
+		var requests atomic.Int32
+		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requests.Add(1)
+			http.Error(w, "too many requests", http.StatusTooManyRequests)
+		}))
+		client = ka.NewSDKMCPClient(ts.URL+"/mcp", &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}, nil, logr.Discard())
+
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "alice@example.com", RawToken: "token-for-alice@example.com"})
+		_, err := client.StartInvestigation(ctx, ka.StartInvestigationArgs{RRID: "rr-2373-exhausted"})
+		Expect(err).To(HaveOccurred())
+		Expect(strings.ToLower(err.Error())).To(ContainSubstring("too many requests"))
+		Expect(requests.Load()).To(BeNumerically(">=", 3))
 	})
 
 	It("CHAR-AF-1532-012: passes session_id through to args when provided (#1452)", func() {


### PR DESCRIPTION
## Summary

- Retry transient MCP `429 Too Many Requests` responses during interactive investigation startup.
- Use the request context for bounded startup connection and logging-level setup retries.
- Default FullPipeline E2E execution to one Ginkgo process to avoid shared `e2e-user-sre` token-bucket bursts.
- Add regression coverage for retry success and retry exhaustion.

Fixes #2373

## RCA

Run `34164976498` showed API Frontend starting an interactive investigation while the corresponding KA `AgentSession` remained pending. The run contained concurrent MCP rate-limit responses. FullPipeline already used the configured rate-limit ceiling, so increasing it further was not viable; serializing the shared-identity E2E workload removes the test-side contention.

## Validation

- `go test ./pkg/apifrontend/ka -count=1`
- `go test ./internal/kubernautagent/...`
- `go build ./pkg/apifrontend/... ./internal/kubernautagent/...`
- `go vet ./pkg/apifrontend/ka ./internal/kubernautagent/...`
- `make -n test-e2e-fullpipeline FULLPIPELINE_TEST_PROCS=1`

Full FullPipeline E2E was not run locally because it requires the complete Kind environment.

## Notes

The unrelated untracked `scripts/ci/download-amd64-images.sh` remains intentionally uncommitted.
