### PR TITLE
test(infrastructure): deploy operator and restore fleet KSM monitoring

### DIFF
--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -681,9 +681,19 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, r
 		return nil, remoteKubeconfigPath, fmt.Errorf("alertmanager install failed: %w", err)
 	}
 
+	// Prometheus Operator on BOTH clusters, before each cluster's Prometheus
+	// resource. The fleet demo uses one operator-managed installation path for
+	// hub and spoke so ServiceMonitor/Probe/PodMonitor/PrometheusRule behavior
+	// is identical on both clusters and matches the production monitoring API.
+	if err := InstallPrometheusOperator(ctx, kubeconfigPath, writer); err != nil {
+		return nil, remoteKubeconfigPath, fmt.Errorf("hub Prometheus Operator install failed: %w", err)
+	}
+	if err := InstallPrometheusOperator(ctx, remoteKubeconfigPath, writer); err != nil {
+		return nil, remoteKubeconfigPath, fmt.Errorf("spoke Prometheus Operator install failed: %w", err)
+	}
+
 	// kube-state-metrics on BOTH clusters, before each cluster's Prometheus
-	// (whose generated scrape config already targets it by Service name --
-	// see DeployKubeStateMetrics's doc comment). Without this, AF's
+	// resource. Without this, AF's
 	// monitoring-backed tools that depend on pod/deployment/node object-
 	// state metrics (as opposed to cAdvisor's container-resource metrics)
 	// come back empty -- confirmed via manual QE run on fleet-e2e-remote's
@@ -695,35 +705,17 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, r
 		return nil, remoteKubeconfigPath, fmt.Errorf("spoke kube-state-metrics install failed: %w", err)
 	}
 
-	// Demo alerting rules (with a STATIC cluster label baked into each rule,
-	// not left to Thanos's external_labels -- see DeployDemoAlertingRules's
-	// doc comment for why) must exist before Prometheus starts, since its
-	// Deployment mounts the ConfigMap they create.
-	if err := DeployDemoAlertingRules(ctx, monitoringNamespace, kubeconfigPath, "hub", writer); err != nil {
-		return nil, remoteKubeconfigPath, fmt.Errorf("hub demo alerting rules install failed: %w", err)
-	}
-	// "remote-cluster", not "spoke": matches the MCPServerRegistration/MCPRoute
-	// identity resource tools already use for this same physical cluster
-	// (test/e2e/fleet's canonical fixture, confirmed 2026-08-30) -- using a
-	// different string here for the SAME cluster would leave AF's alert
-	// cluster_id and its resource-tool cluster_id permanently unable to
-	// cross-reference each other for one physical cluster.
-	if err := DeployDemoAlertingRules(ctx, monitoringNamespace, remoteKubeconfigPath, "remote-cluster", writer); err != nil {
-		return nil, remoteKubeconfigPath, fmt.Errorf("spoke demo alerting rules install failed: %w", err)
-	}
-
 	hubAlertManagerTarget := fmt.Sprintf("alertmanager-svc.%s.svc.cluster.local:9093", monitoringNamespace)
-	if err := DeployPrometheusWithThanosSidecar(ctx, monitoringNamespace, kubeconfigPath, "hub", hubAlertManagerTarget, writer); err != nil {
-		return nil, remoteKubeconfigPath, fmt.Errorf("hub prometheus+thanos-sidecar install failed: %w", err)
+	if err := DeployManagedPrometheusWithThanosSidecar(ctx, monitoringNamespace, kubeconfigPath, "hub", hubAlertManagerTarget, writer); err != nil {
+		return nil, remoteKubeconfigPath, fmt.Errorf("hub managed prometheus+thanos install failed: %w", err)
 	}
 
 	spokeAlertManagerTarget, err := HubNodeBridgeIPAndPort(ctx, clusterName, AlertManagerNodePort)
 	if err != nil {
 		return nil, remoteKubeconfigPath, fmt.Errorf("failed to resolve hub AlertManager bridge address for spoke: %w", err)
 	}
-	// "remote-cluster", not "spoke" -- see DeployDemoAlertingRules call above.
-	if err := DeployPrometheusWithThanosSidecar(ctx, monitoringNamespace, remoteKubeconfigPath, "remote-cluster", spokeAlertManagerTarget, writer); err != nil {
-		return nil, remoteKubeconfigPath, fmt.Errorf("spoke prometheus+thanos-sidecar install failed: %w", err)
+	if err := DeployManagedPrometheusWithThanosSidecar(ctx, monitoringNamespace, remoteKubeconfigPath, "remote-cluster", spokeAlertManagerTarget, writer); err != nil {
+		return nil, remoteKubeconfigPath, fmt.Errorf("spoke managed prometheus+thanos install failed: %w", err)
 	}
 
 	spokeSidecarStoreAddr, err := BridgeSpokeThanosSidecar(ctx, kubeconfigPath, monitoringNamespace, remoteKubeconfigPath, monitoringNamespace, remoteClusterName, writer)
@@ -767,7 +759,7 @@ func SetupFleetCoreInfrastructureWithGateway(ctx context.Context, clusterName, r
 	_, _ = fmt.Fprintln(writer, "      own static `labels:` block -- Thanos does NOT propagate")
 	_, _ = fmt.Fprintln(writer, "      external_labels to fired alert instances (thanos-io/thanos#7327), so AF's")
 	_, _ = fmt.Fprintln(writer, "      cluster_id filter will silently drop any alert missing it. See")
-	_, _ = fmt.Fprintln(writer, "      DeployDemoAlertingRules's doc comment (thanos_e2e.go) for details.")
+	_, _ = fmt.Fprintln(writer, "      the fleet monitoring manifest and scenario PrometheusRules for details.")
 	if opts.LLMCredentialsFile == "" {
 		_, _ = fmt.Fprintln(writer, "\n  ⚠️  llm-credentials-primary currently holds a MOCK key --")
 		_, _ = fmt.Fprintln(writer, "      kubectl apply your real LLM credentials Secret before")

--- a/test/infrastructure/prometheus_operator.go
+++ b/test/infrastructure/prometheus_operator.go
@@ -1,0 +1,293 @@
+package infrastructure
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// The chart installs the Prometheus Operator and its CRDs without requiring
+	// client-side annotation storage for the large CRD definitions.
+	prometheusOperatorHelmChart   = "prometheus-community/kube-prometheus-stack"
+	prometheusOperatorHelmVersion = "88.1.5"
+	prometheusOperatorNamespace   = "prometheus-operator"
+	managedPrometheusName         = "fleet-spoke"
+	managedPrometheusStatefulSet  = "prometheus-fleet-spoke"
+)
+
+// InstallPrometheusOperator installs the CRDs and controller used by the fleet
+// demo monitoring clusters. Both hub and spoke use this same path.
+func InstallPrometheusOperator(ctx context.Context, kubeconfigPath string, writer io.Writer) error {
+	_, _ = fmt.Fprintf(writer, "  Installing Prometheus Operator in namespace %s...\n", prometheusOperatorNamespace)
+	if err := runHelmUpgradeInstall(ctx, kubeconfigPath, writer, "prometheus-operator",
+		prometheusOperatorHelmChart, prometheusOperatorNamespace,
+		"--version", prometheusOperatorHelmVersion,
+		"--set", "prometheusOperator.fullnameOverride=prometheus-operator",
+		"--set", "defaultRules.create=false",
+		"--set", "alertmanager.enabled=false",
+		"--set", "grafana.enabled=false",
+		"--set", "kubeStateMetrics.enabled=false",
+		"--set", "nodeExporter.enabled=false",
+		"--set", "prometheus.enabled=false",
+	); err != nil {
+		return fmt.Errorf("prometheus operator Helm install failed: %w", err)
+	}
+	if err := waitForDeployment(ctx, "prometheus-operator", prometheusOperatorNamespace, kubeconfigPath, 180*time.Second, writer); err != nil {
+		return fmt.Errorf("prometheus operator rollout failed: %w", err)
+	}
+	_, _ = fmt.Fprintln(writer, "  Prometheus Operator ready")
+	return nil
+}
+
+// DeployManagedPrometheusWithThanosSidecar installs the common fleet demo
+// Prometheus path. Scenario monitoring is expressed through ServiceMonitor,
+// PodMonitor, Probe, and PrometheusRule resources; only infrastructure-owned
+// kubelet scraping remains an additional scrape config.
+func DeployManagedPrometheusWithThanosSidecar(ctx context.Context, namespace, kubeconfigPath, clusterLabel, alertManagerTarget string, writer io.Writer) error {
+	manifest, err := buildManagedPrometheusManifestChecked(namespace, clusterLabel, alertManagerTarget)
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(writer, "  Deploying operator-managed Prometheus+Thanos (cluster=%s) in namespace %s...\n", clusterLabel, namespace)
+	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, manifest); err != nil {
+		return fmt.Errorf("managed Prometheus manifest apply failed: %w", err)
+	}
+	if err := waitForResource(ctx, kubeconfigPath, "statefulset", managedPrometheusStatefulSet, namespace, 180*time.Second); err != nil {
+		return fmt.Errorf("managed Prometheus StatefulSet was not created: %w", err)
+	}
+	if err := runKubectl(ctx, kubeconfigPath, writer, "rollout", "status",
+		"statefulset/"+managedPrometheusStatefulSet, "-n", namespace, "--timeout=180s"); err != nil {
+		return fmt.Errorf("managed Prometheus rollout failed: %w", err)
+	}
+	_, _ = fmt.Fprintf(writer, "  operator-managed Prometheus+Thanos ready (cluster=%s, NodePort %d)\n", clusterLabel, PrometheusNodePort)
+	return nil
+}
+
+//nolint:unparam // tests exercise namespace substitution in the shared manifest builder.
+func buildManagedPrometheusManifest(namespace, clusterLabel, alertManagerTarget string) string {
+	manifest, err := buildManagedPrometheusManifestChecked(namespace, clusterLabel, alertManagerTarget)
+	if err != nil {
+		return ""
+	}
+	return manifest
+}
+
+func buildManagedPrometheusManifestChecked(namespace, clusterLabel, alertManagerTarget string) (string, error) {
+	host, portText, err := net.SplitHostPort(alertManagerTarget)
+	if err != nil {
+		return "", fmt.Errorf("invalid Alertmanager bridge address %q: %w", alertManagerTarget, err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port < 1 || port > 65535 {
+		return "", fmt.Errorf("invalid Alertmanager bridge address %q: invalid port", alertManagerTarget)
+	}
+
+	alertManagerName := "alertmanager-remote"
+	alertManagerPortName := "web"
+	alertManagerBridge := fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-remote
+  namespace: %s
+spec:
+  ports:
+  - name: web
+    port: 9093
+    targetPort: 9093
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: alertmanager-remote
+  namespace: %s
+subsets:
+- addresses:
+  - ip: %s
+  ports:
+  - name: web
+    port: %d
+`, namespace, namespace, host, port)
+	if net.ParseIP(host) == nil {
+		alertManagerName = strings.Split(host, ".")[0]
+		alertManagerPortName = "http"
+		alertManagerBridge = ""
+	}
+
+	return fmt.Sprintf(`---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: %[1]s
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "nodes/proxy", "nodes/metrics", "pods", "services", "endpoints", "namespaces"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: %[1]s
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-additional-scrape-configs
+  namespace: %[1]s
+stringData:
+  additional-scrape-configs.yaml: |
+    - job_name: kubelet-cadvisor
+      scrape_interval: 10s
+      kubernetes_sd_configs:
+      - role: node
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+        target_label: __address__
+        replacement: ${1}:10250
+      - target_label: __metrics_path__
+        replacement: /metrics/cadvisor
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'container_(cpu_usage_seconds_total|memory_working_set_bytes|memory_usage_bytes|spec_memory_limit_bytes)'
+        action: keep
+---
+%[2]s
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-svc
+  namespace: %[1]s
+spec:
+  type: NodePort
+  selector:
+    app: prometheus
+  ports:
+  - name: http
+    port: 9090
+    targetPort: 9090
+    nodePort: %[3]d
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: %[1]s
+  labels:
+    app: kube-state-metrics
+spec:
+  selector:
+    app: kube-state-metrics
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-state-metrics
+  namespace: %[1]s
+spec:
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  endpoints:
+  - port: http-metrics
+    interval: 15s
+    honorLabels: true
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: demo-alerts
+  namespace: %[1]s
+spec:
+  groups:
+  - name: demo-app
+    rules:
+    - alert: KubePodCrashLooping
+      expr: |
+        max_over_time(
+          kube_pod_container_status_waiting_reason{
+            namespace="demo-checkout",
+            reason="CrashLoopBackOff"
+          }[2m]
+        ) > 0
+      for: 30s
+      labels:
+        severity: critical
+        cluster: %[4]s
+      annotations:
+        summary: 'Container {{ $labels.container }} in pod {{ $labels.pod }} is restarting repeatedly ({{ $value | humanize }} restarts in 5m).'
+        description: 'A container in namespace {{ $labels.namespace }} is failing to reach a stable running state. Elevated restart rate may indicate service degradation.'
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: %[5]s
+  namespace: %[1]s
+spec:
+  image: %[6]s
+  replicas: 1
+  serviceAccountName: prometheus
+  podMetadata:
+    labels:
+      app: prometheus
+  externalLabels:
+    cluster: %[4]s
+  scrapeInterval: 15s
+  evaluationInterval: 15s
+  retention: 6h
+  storage:
+    emptyDir: {}
+  serviceMonitorSelector: {}
+  serviceMonitorNamespaceSelector: {}
+  podMonitorSelector: {}
+  podMonitorNamespaceSelector: {}
+  probeSelector: {}
+  probeNamespaceSelector: {}
+  ruleSelector: {}
+  ruleNamespaceSelector: {}
+  additionalScrapeConfigs:
+    name: prometheus-additional-scrape-configs
+    key: additional-scrape-configs.yaml
+  alerting:
+    alertmanagers:
+    - name: %[7]s
+      namespace: %[1]s
+      port: %[9]s
+  thanos:
+    image: %[8]s
+`, namespace, alertManagerBridge, PrometheusNodePort, clusterLabel, managedPrometheusName, PrometheusImage, alertManagerName, ThanosImage, alertManagerPortName), nil
+}

--- a/test/infrastructure/prometheus_operator_test.go
+++ b/test/infrastructure/prometheus_operator_test.go
@@ -1,0 +1,219 @@
+package infrastructure
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+var _ = Describe("fleet spoke Prometheus Operator manifests", func() {
+	It("UT-INFRA-FLEETDEMO-OPERATOR-001: pins the operator Helm chart", func() {
+		Expect(prometheusOperatorHelmChart).To(Equal("prometheus-community/kube-prometheus-stack"))
+		Expect(prometheusOperatorHelmVersion).To(Equal("88.1.5"))
+		Expect(prometheusOperatorNamespace).To(Equal("prometheus-operator"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-OPERATOR-002: uses an operator-only chart configuration", func() {
+		Expect(prometheusOperatorHelmChart).To(Equal("prometheus-community/kube-prometheus-stack"))
+		Expect(prometheusOperatorNamespace).To(Equal("prometheus-operator"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-PROMETHEUS-001: selects monitoring CRDs across namespaces", func() {
+		manifest := buildManagedPrometheusManifest("monitoring", "remote-cluster", "10.0.0.2:30193")
+
+		Expect(manifest).To(ContainSubstring("kind: Prometheus\n"))
+		Expect(manifest).To(ContainSubstring("name: fleet-spoke\n"))
+		Expect(manifest).To(ContainSubstring("serviceMonitorSelector: {}"))
+		Expect(manifest).To(ContainSubstring("serviceMonitorNamespaceSelector: {}"))
+		Expect(manifest).To(ContainSubstring("podMonitorSelector: {}"))
+		Expect(manifest).To(ContainSubstring("podMonitorNamespaceSelector: {}"))
+		Expect(manifest).To(ContainSubstring("probeSelector: {}"))
+		Expect(manifest).To(ContainSubstring("probeNamespaceSelector: {}"))
+		Expect(manifest).To(ContainSubstring("ruleSelector: {}"))
+		Expect(manifest).To(ContainSubstring("ruleNamespaceSelector: {}"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-PROMETHEUS-002: preserves fleet identity and Thanos configuration", func() {
+		manifest := buildManagedPrometheusManifest("monitoring", "remote-cluster", "10.0.0.2:30193")
+
+		Expect(manifest).To(ContainSubstring("cluster: remote-cluster"))
+		Expect(manifest).To(ContainSubstring("image: " + ThanosImage))
+		Expect(manifest).To(ContainSubstring("name: prometheus-svc"))
+		Expect(manifest).To(ContainSubstring("nodePort: 30190"))
+		Expect(manifest).To(ContainSubstring("app: prometheus"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-PROMETHEUS-003: routes alerts through the hub bridge", func() {
+		manifest := buildManagedPrometheusManifest("monitoring", "remote-cluster", "10.0.0.2:30193")
+
+		Expect(manifest).To(ContainSubstring("name: alertmanager-remote"))
+		Expect(manifest).To(ContainSubstring("ip: 10.0.0.2"))
+		Expect(manifest).To(ContainSubstring("port: 30193"))
+		Expect(manifest).To(ContainSubstring("port: web"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-PROMETHEUS-003b: uses the existing hub Alertmanager Service", func() {
+		manifest := buildManagedPrometheusManifest("monitoring", "hub", "alertmanager-svc.monitoring.svc.cluster.local:9093")
+
+		Expect(manifest).To(ContainSubstring("name: alertmanager-svc"))
+		Expect(manifest).To(ContainSubstring("port: http"))
+		Expect(manifest).NotTo(ContainSubstring("name: alertmanager-remote"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-PROMETHEUS-004: installs baseline kube-state-metrics discovery", func() {
+		manifest := buildManagedPrometheusManifest("monitoring", "remote-cluster", "10.0.0.2:30193")
+
+		Expect(manifest).To(ContainSubstring("name: kube-state-metrics"))
+		Expect(manifest).To(ContainSubstring("kind: ServiceMonitor"))
+		Expect(manifest).To(ContainSubstring("port: http-metrics"))
+	})
+
+	It("UT-INFRA-2380-001 [SI-4, ASVS-4.0.3-V4.1.1]: preserves native KSM labels", func() {
+		manifest := buildManagedPrometheusManifest("monitoring", "remote-cluster", "10.0.0.2:30193")
+		serviceMonitor := findManifestDocument(manifest, "ServiceMonitor", "kube-state-metrics")
+
+		endpoints, found, err := unstructured.NestedSlice(serviceMonitor.Object, "spec", "endpoints")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(endpoints).NotTo(BeEmpty())
+
+		endpoint, ok := endpoints[0].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		honorLabels, found, err := unstructured.NestedBool(endpoint, "honorLabels")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(honorLabels).To(BeTrue(), "KSM namespace/pod labels must not be renamed to exported_*")
+	})
+
+	It("UT-INFRA-2380-002 [SI-4]: enables fleet scenario KSM metric families", func() {
+		manifest := buildKubeStateMetricsManifest("monitoring")
+		deployment := findManifestDocument(manifest, "Deployment", "kube-state-metrics")
+		containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(containers).NotTo(BeEmpty())
+
+		container, ok := containers[0].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		args, found, err := unstructured.NestedStringSlice(container, "args")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(args).To(ContainElement("--resources=pods,deployments,replicasets,statefulsets,daemonsets,nodes,horizontalpodautoscalers,persistentvolumeclaims,poddisruptionbudgets"))
+	})
+
+	It("UT-INFRA-2380-003 [AC-6, ASVS-4.0.3-V4.1.3]: grants KSM required read-only access", func() {
+		manifest := buildKubeStateMetricsManifest("monitoring")
+		clusterRole := findManifestDocument(manifest, "ClusterRole", "kube-state-metrics")
+		rules, found, err := unstructured.NestedSlice(clusterRole.Object, "rules")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+
+		expectReadOnlyRule := func(apiGroup, resource string) {
+			GinkgoHelper()
+			for _, rawRule := range rules {
+				rule, ok := rawRule.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				groups, _, _ := unstructured.NestedStringSlice(rule, "apiGroups")
+				resources, _, _ := unstructured.NestedStringSlice(rule, "resources")
+				if !containsString(groups, apiGroup) || !containsString(resources, resource) {
+					continue
+				}
+				verbs, _, _ := unstructured.NestedStringSlice(rule, "verbs")
+				Expect(verbs).To(ConsistOf("list", "watch"))
+				Expect(verbs).NotTo(ContainElement("create"))
+				Expect(verbs).NotTo(ContainElement("delete"))
+				return
+			}
+			Fail(fmt.Sprintf("missing read-only RBAC rule for apiGroup=%q resource=%q", apiGroup, resource))
+		}
+
+		expectReadOnlyRule("", "persistentvolumeclaims")
+		expectReadOnlyRule("autoscaling", "horizontalpodautoscalers")
+		expectReadOnlyRule("policy", "poddisruptionbudgets")
+	})
+
+	It("UT-INFRA-FLEETDEMO-PROMETHEUS-005: keeps the baseline crashloop rule as a PrometheusRule", func() {
+		manifest := buildManagedPrometheusManifest("monitoring", "remote-cluster", "10.0.0.2:30193")
+
+		Expect(manifest).To(ContainSubstring("kind: PrometheusRule"))
+		Expect(manifest).To(ContainSubstring("name: demo-alerts"))
+		Expect(manifest).To(ContainSubstring("cluster: remote-cluster"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-PROMETHEUS-006: rejects an invalid Alertmanager bridge address", func() {
+		_, err := buildManagedPrometheusManifestChecked("monitoring", "remote-cluster", "not-an-address")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Alertmanager bridge address"))
+	})
+
+	It("UT-INFRA-FLEETDEMO-PROMETHEUS-007: keeps infrastructure scrape configuration separate from scenario CRDs", func() {
+		manifest := buildManagedPrometheusManifest("monitoring", "remote-cluster", "10.0.0.2:30193")
+
+		Expect(manifest).To(ContainSubstring("name: prometheus-additional-scrape-configs"))
+		Expect(manifest).To(ContainSubstring("job_name: kubelet-cadvisor"))
+		Expect(strings.Count(manifest, "kind: ServiceMonitor")).To(Equal(1))
+	})
+
+	It("UT-INFRA-FLEETDEMO-PROMETHEUS-008: renders valid multi-document YAML", func() {
+		manifest := buildManagedPrometheusManifest("monitoring", "remote-cluster", "10.0.0.2:30193")
+		decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 4096)
+		documents := 0
+
+		for {
+			var document map[string]interface{}
+			err := decoder.Decode(&document)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			Expect(err).NotTo(HaveOccurred())
+			if document != nil {
+				documents++
+			}
+		}
+
+		Expect(documents).To(BeNumerically(">=", 8))
+	})
+})
+
+func findManifestDocument(manifest, kind, name string) unstructured.Unstructured {
+	decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 4096)
+	for {
+		var document map[string]interface{}
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		Expect(err).NotTo(HaveOccurred())
+		if document == nil {
+			continue
+		}
+		if document["kind"] == kind {
+			metadata, found, metadataErr := unstructured.NestedMap(document, "metadata")
+			Expect(metadataErr).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			if metadata["name"] == name {
+				return unstructured.Unstructured{Object: document}
+			}
+		}
+	}
+	Fail(fmt.Sprintf("manifest document not found: kind=%q name=%q", kind, name))
+	return unstructured.Unstructured{}
+}
+
+func containsString(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/test/infrastructure/thanos_e2e.go
+++ b/test/infrastructure/thanos_e2e.go
@@ -47,7 +47,7 @@ import (
 // through Thanos Querier's /api/v1/alerts until upstream fixes it.
 //
 // WORKAROUND (confirmed live 2026-08-30, reproduced with a real firing
-// alert -- see DeployDemoAlertingRules): don't rely on external_labels for
+// alert): don't rely on external_labels for
 // alert-instance cluster attribution at all. Bake `cluster: <name>` into
 // each cluster's alerting rule as a STATIC rule label instead (alongside
 // e.g. `severity: critical`) -- a rule's own static labels ARE attached to
@@ -87,10 +87,6 @@ const (
 	// port, identical in both clusters (container-internal, no collision
 	// risk since each cluster is its own network namespace).
 	ThanosSidecarGRPCPort = 10901
-	// thanosSidecarHTTPPort is the sidecar's own HTTP port (unused by
-	// Querier, which talks gRPC only; kept for completeness/debugging).
-	thanosSidecarHTTPPort = 10902
-
 	// thanosSidecarRemoteNodePort exposes the SPOKE cluster's Thanos
 	// sidecar gRPC port for the hub-side Service+Endpoints bridge (same
 	// DD-TEST-013 pattern as remoteKubeMCPServerNodePort).
@@ -119,249 +115,31 @@ const (
 	monitoringNamespace = "monitoring"
 )
 
-// DeployPrometheusWithThanosSidecar deploys a minimal Prometheus (kubelet-
-// cadvisor scrape only -- no synthetic Ginkgo-test alerting-rule fixtures,
-// unlike DeployPrometheus) plus a Thanos sidecar container in the same pod,
-// sharing an emptyDir TSDB volume. clusterLabel becomes the Prometheus
-// external_labels.cluster value Thanos uses to distinguish this cluster's
-// series/alerts once federated through the Querier. alertManagerTarget is a
-// raw host:port Prometheus dials directly for its alerting sink -- a
-// same-cluster Service DNS name for the hub, or the hub's node-bridge
-// IP:NodePort for the spoke (which has no in-cluster route to the hub's
-// AlertManager Service).
-//
-// Mounts a "rules" volume from a "prometheus-rules" ConfigMap at
-// /etc/prometheus/rules (rule_files: /etc/prometheus/rules/*.yml) --
-// DeployDemoAlertingRules creates that ConfigMap and MUST be called first
-// for each cluster, or this Deployment's pod will stick in
-// ContainerCreating waiting on a ConfigMap that doesn't exist yet.
-func DeployPrometheusWithThanosSidecar(ctx context.Context, namespace, kubeconfigPath, clusterLabel, alertManagerTarget string, writer io.Writer) error {
-	_, _ = fmt.Fprintf(writer, "  📊 Deploying Prometheus+Thanos-sidecar (cluster=%s) in namespace %s...\n", clusterLabel, namespace)
-
-	manifest := fmt.Sprintf(`---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: prometheus
-  namespace: %[1]s
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: prometheus
-rules:
-- apiGroups: [""]
-  resources: ["nodes", "nodes/proxy", "nodes/metrics", "pods", "services", "endpoints"]
-  verbs: ["get", "list", "watch"]
-- nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
-  verbs: ["get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: prometheus
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: prometheus
-subjects:
-- kind: ServiceAccount
-  name: prometheus
-  namespace: %[1]s
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: prometheus-config
-  namespace: %[1]s
-data:
-  prometheus.yml: |
-    global:
-      scrape_interval: 15s
-      evaluation_interval: 15s
-      external_labels:
-        cluster: %[3]s
-    rule_files:
-    - /etc/prometheus/rules/*.yml
-    scrape_configs:
-    - job_name: 'kubelet-cadvisor'
-      scrape_interval: 10s
-      kubernetes_sd_configs:
-      - role: node
-      scheme: https
-      tls_config:
-        insecure_skip_verify: true
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      relabel_configs:
-      - action: labelmap
-        regex: __meta_kubernetes_node_label_(.+)
-      - source_labels: [__meta_kubernetes_node_address_InternalIP]
-        target_label: __address__
-        replacement: ${1}:10250
-      - target_label: __metrics_path__
-        replacement: /metrics/cadvisor
-      metric_relabel_configs:
-      - source_labels: [__name__]
-        regex: 'container_(cpu_usage_seconds_total|memory_working_set_bytes|memory_usage_bytes|spec_memory_limit_bytes)'
-        action: keep
-    - job_name: 'kube-state-metrics'
-      scrape_interval: 15s
-      static_configs:
-      - targets: ['kube-state-metrics.%[1]s.svc.cluster.local:8080']
-    alerting:
-      alertmanagers:
-      - static_configs:
-        - targets: ['%[4]s']
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: prometheus
-  namespace: %[1]s
-  labels:
-    app: prometheus
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: prometheus
-  template:
-    metadata:
-      labels:
-        app: prometheus
-    spec:
-      serviceAccountName: prometheus
-      containers:
-      - name: prometheus
-        image: %[2]s
-        args:
-        - "--config.file=/etc/prometheus/prometheus.yml"
-        - "--storage.tsdb.path=/prometheus"
-        - "--storage.tsdb.retention.time=6h"
-        - "--web.enable-lifecycle"
-        - "--web.listen-address=:9090"
-        ports:
-        - containerPort: 9090
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: 9090
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /-/healthy
-            port: 9090
-          initialDelaySeconds: 10
-          periodSeconds: 10
-        volumeMounts:
-        - name: config
-          mountPath: /etc/prometheus
-        - name: tsdb-data
-          mountPath: /prometheus
-        - name: rules
-          mountPath: /etc/prometheus/rules
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "100m"
-          limits:
-            memory: "512Mi"
-            cpu: "500m"
-      - name: thanos-sidecar
-        image: %[5]s
-        args:
-        - "sidecar"
-        - "--tsdb.path=/prometheus"
-        - "--prometheus.url=http://localhost:9090"
-        - "--grpc-address=0.0.0.0:%[6]d"
-        - "--http-address=0.0.0.0:%[7]d"
-        ports:
-        - containerPort: %[6]d
-          name: grpc
-        - containerPort: %[7]d
-          name: sidecar-http
-        volumeMounts:
-        - name: tsdb-data
-          mountPath: /prometheus
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "50m"
-          limits:
-            memory: "256Mi"
-            cpu: "250m"
-      volumes:
-      - name: config
-        configMap:
-          name: prometheus-config
-      - name: tsdb-data
-        emptyDir: {}
-      - name: rules
-        configMap:
-          name: prometheus-rules
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: prometheus-svc
-  namespace: %[1]s
-spec:
-  type: NodePort
-  selector:
-    app: prometheus
-  ports:
-  - name: http
-    port: 9090
-    targetPort: 9090
-    nodePort: %[8]d
-    protocol: TCP
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: thanos-sidecar-grpc
-  namespace: %[1]s
-  labels:
-    app: prometheus
-spec:
-  selector:
-    app: prometheus
-  ports:
-  - name: grpc
-    port: %[6]d
-    targetPort: %[6]d
-    protocol: TCP
-`, namespace, PrometheusImage, clusterLabel, alertManagerTarget, ThanosImage, ThanosSidecarGRPCPort, thanosSidecarHTTPPort, PrometheusNodePort)
-
-	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, manifest); err != nil {
-		return fmt.Errorf("failed to deploy Prometheus+Thanos-sidecar: %w", err)
-	}
-
-	_, _ = fmt.Fprintln(writer, "    Waiting for Prometheus+Thanos-sidecar...")
-	if err := waitForDeployment(ctx, "prometheus", namespace, kubeconfigPath, 120*time.Second, writer); err != nil {
-		return fmt.Errorf("prometheus+thanos-sidecar rollout failed: %w", err)
-	}
-	_, _ = fmt.Fprintf(writer, "  ✅ Prometheus+Thanos-sidecar ready (cluster=%s, NodePort %d)\n", clusterLabel, PrometheusNodePort)
-	return nil
-}
-
 // DeployKubeStateMetrics deploys kube-state-metrics into the given cluster,
 // exposing Kubernetes object-state metrics (pod/deployment/replicaset/
 // statefulset/daemonset/node phase, replica counts, etc.) that cAdvisor's
-// container-resource metrics don't cover. DeployPrometheusWithThanosSidecar's
-// generated config already scrapes this Service by name
-// ("kube-state-metrics.<namespace>.svc.cluster.local:8080"), so call this
-// BEFORE (or alongside) that function for each cluster -- Prometheus will
-// otherwise just log scrape failures until this exists, matching manual QE
-// setup confirmed 2026-08-30 (fleet-e2e-remote's spoke cluster) that
-// exposed AF's monitoring-backed tools as returning empty pod/deployment
-// data without it.
+// container-resource metrics don't cover. The fleet demo's operator-managed
+// Prometheus discovers this Service through its baseline ServiceMonitor, so
+// call this before the Prometheus resource is reconciled.
 func DeployKubeStateMetrics(ctx context.Context, namespace, kubeconfigPath string, writer io.Writer) error {
 	_, _ = fmt.Fprintf(writer, "  📈 Deploying kube-state-metrics in namespace %s...\n", namespace)
 
-	manifest := fmt.Sprintf(`---
+	manifest := buildKubeStateMetricsManifest(namespace)
+
+	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, manifest); err != nil {
+		return fmt.Errorf("failed to deploy kube-state-metrics: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "    Waiting for kube-state-metrics...")
+	if err := waitForDeployment(ctx, "kube-state-metrics", namespace, kubeconfigPath, 60*time.Second, writer); err != nil {
+		return fmt.Errorf("kube-state-metrics rollout failed: %w", err)
+	}
+	_, _ = fmt.Fprintln(writer, "  ✅ kube-state-metrics ready")
+	return nil
+}
+
+func buildKubeStateMetricsManifest(namespace string) string {
+	return fmt.Sprintf(`---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -374,10 +152,16 @@ metadata:
   name: kube-state-metrics
 rules:
 - apiGroups: [""]
-  resources: ["pods", "nodes", "namespaces"]
+  resources: ["pods", "nodes", "namespaces", "persistentvolumeclaims"]
   verbs: ["list", "watch"]
 - apiGroups: ["apps"]
   resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["list", "watch"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
   verbs: ["list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -415,7 +199,7 @@ spec:
       - name: kube-state-metrics
         image: %[2]s
         args:
-        - "--resources=pods,deployments,replicasets,statefulsets,daemonsets,nodes"
+        - "--resources=pods,deployments,replicasets,statefulsets,daemonsets,nodes,horizontalpodautoscalers,persistentvolumeclaims,poddisruptionbudgets"
         ports:
         - containerPort: 8080
           name: http-metrics
@@ -443,82 +227,6 @@ spec:
     port: 8080
     targetPort: 8080
 `, namespace, KubeStateMetricsImage)
-
-	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, manifest); err != nil {
-		return fmt.Errorf("failed to deploy kube-state-metrics: %w", err)
-	}
-
-	_, _ = fmt.Fprintln(writer, "    Waiting for kube-state-metrics...")
-	if err := waitForDeployment(ctx, "kube-state-metrics", namespace, kubeconfigPath, 60*time.Second, writer); err != nil {
-		return fmt.Errorf("kube-state-metrics rollout failed: %w", err)
-	}
-	_, _ = fmt.Fprintln(writer, "  ✅ kube-state-metrics ready")
-	return nil
-}
-
-// DeployDemoAlertingRules creates the "prometheus-rules" ConfigMap that
-// DeployPrometheusWithThanosSidecar mounts at /etc/prometheus/rules. MUST be
-// called before that function for the same cluster (the Deployment it
-// creates references this ConfigMap by name).
-//
-// The rule's cluster attribution is baked in as a STATIC rule label
-// (labels.cluster below), not left to Thanos's external_labels -- Thanos
-// Querier only merges external_labels into a rule's own definition
-// (/api/v1/rules[].labels), NOT into the fired alert instances nested
-// underneath it or returned by the flat /api/v1/alerts endpoint AF actually
-// queries (pkg/apifrontend/prometheus.Client.GetAlerts). That gap is a
-// confirmed, open upstream limitation (thanos-io/thanos#7327) reproduced
-// live 2026-08-30: an alert firing on the spoke came back from Thanos
-// Querier's /api/v1/alerts with zero "cluster" label, so AF's cluster_id
-// filter (af_alerts.go's fleetClusterLabelKey) silently excluded it from
-// every cluster-scoped query. A rule's own static labels, by contrast, ARE
-// attached to every alert instance it fires -- confirmed by this same rule's
-// pre-existing "severity: critical" label showing up correctly -- so that's
-// the layer this needs to be set at, not the Prometheus/Thanos federation
-// layer.
-//
-// Deploys the same KubePodCrashLooping rule to both hub and spoke
-// regardless of where the demo-checkout namespace/workload actually lives
-// (spoke only, as of 2026-08-30): the PromQL selector simply returns no
-// series and the rule stays inactive on a cluster without a matching
-// namespace, so this is harmless and makes the demo scenario portable to
-// either cluster without further code changes.
-func DeployDemoAlertingRules(ctx context.Context, namespace, kubeconfigPath, clusterLabel string, writer io.Writer) error {
-	_, _ = fmt.Fprintf(writer, "  🔔 Deploying demo alerting rules (cluster=%s) in namespace %s...\n", clusterLabel, namespace)
-
-	manifest := fmt.Sprintf(`---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: prometheus-rules
-  namespace: %[1]s
-data:
-  demo-app-alerts.yml: |
-    groups:
-    - name: demo-app
-      rules:
-      - alert: KubePodCrashLooping
-        expr: |
-          max_over_time(
-            kube_pod_container_status_waiting_reason{
-              namespace="demo-checkout",
-              reason="CrashLoopBackOff"
-            }[2m]
-          ) > 0
-        for: 30s
-        labels:
-          severity: critical
-          cluster: %[2]s
-        annotations:
-          summary: 'Container {{ $labels.container }} in pod {{ $labels.pod }} is restarting repeatedly ({{ $value | humanize }} restarts in 5m).'
-          description: 'A container in namespace {{ $labels.namespace }} is failing to reach a stable running state. Elevated restart rate may indicate service degradation.'
-`, namespace, clusterLabel)
-
-	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, manifest); err != nil {
-		return fmt.Errorf("failed to deploy demo alerting rules: %w", err)
-	}
-	_, _ = fmt.Fprintln(writer, "  ✅ demo alerting rules ready")
-	return nil
 }
 
 // exposeThanosSidecarNodePort creates a fixed-NodePort Service in the given


### PR DESCRIPTION
## Scope
This PR combines the fleet monitoring prerequisite from issue #2377 with the follow-up fixes from issue #2380.

### Issue #2377
- install Prometheus Operator CRDs/controller on hub and spoke
- deploy the fleet Prometheus through Operator-managed resources
- enable ServiceMonitor/PrometheusRule discovery across namespaces

### Issue #2380
- set `ServiceMonitor.spec.endpoints[].honorLabels: true` so native KSM labels remain `namespace`/`pod`
- enable HPA, PVC, and PDB metric resources with matching read-only RBAC

## Validation
- `go build ./...`
- `go test ./test/infrastructure -run TestInfrastructure -count=1`
- `golangci-lint run --timeout=5m ./test/infrastructure/...`
- live hub/spoke Kind triage: Prometheus KSM targets healthy, native labels preserved, PVC/PDB metrics observed, create/delete denied for KSM ServiceAccount

`make test` was attempted but repository coverage aggregation failed outside this change because `cmd/gateway/coverage_unit_gateway.out` was missing.

Closes #2377
Closes #2380