### PR TITLE
feat(workflowexecution): retain failed execution resources

### DIFF
--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -590,6 +590,8 @@ workflowexecution:
                 namespace: ""
         execution:
             cooldownPeriod: 1m
+            failedExecutionRetentionSeconds: 600
+            retainFailedExecutions: false
     debug:
         pprofEnabled: false
     fleet:

--- a/charts/kubernaut/templates/workflowexecution/workflowexecution.yaml
+++ b/charts/kubernaut/templates/workflowexecution/workflowexecution.yaml
@@ -209,6 +209,8 @@ controller:
 execution:
   namespace: {{ include "kubernaut.workflowNamespace" . }}
   cooldownPeriod: {{ $v.config.execution.cooldownPeriod }}
+  retainFailedExecutions: {{ $v.config.execution.retainFailedExecutions | default false }}
+  failedExecutionRetentionSeconds: {{ $v.config.execution.failedExecutionRetentionSeconds | default 600 }}
 datastorage:
   url: "{{ include "kubernaut.datastorage.url" . }}"
   healthUrl: "{{ include "kubernaut.datastorage.healthUrl" . }}"

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -2005,6 +2005,18 @@
                   ],
                   "default": "1m",
                   "description": "Cooldown between workflow executions"
+                },
+                "retainFailedExecutions": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Retain failed execution resources for bounded diagnosis"
+                },
+                "failedExecutionRetentionSeconds": {
+                  "type": "integer",
+                  "default": 600,
+                  "minimum": 0,
+                  "maximum": 604800,
+                  "description": "Maximum failed execution resource retention period in seconds"
                 }
               }
             },

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -379,8 +379,9 @@ remediationorchestrator:
 
 # -- WorkflowExecution controller
 # DD-PLATFORM-006 DA14: workflowNamespace ("kubernaut-workflows") / replicas (1)
-# / logging.level ("INFO") / config.execution.cooldownPeriod ("1m") all have
-# non-zero schema defaults -- omitted here, override only what you need.
+# / logging.level ("INFO") / config.execution.cooldownPeriod ("1m") /
+# config.execution.failedExecutionRetentionSeconds (600) all have schema
+# defaults -- omitted here, override only what you need.
 workflowexecution:
   # -- config.execution.cooldownPeriod has a non-zero schema default ("1m",
   # DD-PLATFORM-006 DA14) -- omitted here. config.tekton/config.ansible are

--- a/cmd/workflowexecution/main.go
+++ b/cmd/workflowexecution/main.go
@@ -132,6 +132,8 @@ func setupWorkflowExecutionConfig(configPath string, atomicLevel zaplog.AtomicLe
 	setupLog.Info("WorkflowExecution controller configuration",
 		"executionNamespace", cfg.Execution.Namespace,
 		"cooldownPeriod", cfg.Execution.CooldownPeriod,
+		"retainFailedExecutions", cfg.Execution.RetainFailedExecutions,
+		"failedExecutionRetention", cfg.Execution.FailedExecutionRetention(),
 		"metricsAddr", cfg.Controller.MetricsAddr,
 		"healthProbeAddr", cfg.Controller.HealthProbeAddr,
 		"dataStorageURL", cfg.DataStorage.URL,
@@ -275,14 +277,16 @@ func run() int {
 	// directly from WorkflowExecution.Spec.WorkflowRef's CRD-embedded
 	// execution snapshot instead of a DataStorage round-trip.
 	reconciler := workflowexecution.NewReconciler(mgr, workflowexecution.ReconcilerOptions{
-		ExecutionNamespace: cfg.Execution.Namespace,
-		CooldownPeriod:     cfg.Execution.CooldownPeriod,
-		Metrics:            weMetrics,
-		StatusManager:      statusManager,
-		AuditStore:         auditStore,
-		PhaseManager:       phaseManager,
-		AuditManager:       auditManager,
-		ExecutorRegistry:   executorRegistry,
+		ExecutionNamespace:       cfg.Execution.Namespace,
+		CooldownPeriod:           cfg.Execution.CooldownPeriod,
+		RetainFailedExecutions:   cfg.Execution.RetainFailedExecutions,
+		FailedExecutionRetention: cfg.Execution.FailedExecutionRetention(),
+		Metrics:                  weMetrics,
+		StatusManager:            statusManager,
+		AuditStore:               auditStore,
+		PhaseManager:             phaseManager,
+		AuditManager:             auditManager,
+		ExecutorRegistry:         executorRegistry,
 	})
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkflowExecution")

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -695,6 +695,8 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `config.ansible.tokenSecretRef.name` | string | Secret name | `` | Yes |
 | `config.ansible.tokenSecretRef.namespace` | string | Namespace of the Secret (empty = release namespace) | `""` | No |
 | `config.execution.cooldownPeriod` | string | Cooldown between workflow executions | `"1m"` | No |
+| `config.execution.failedExecutionRetentionSeconds` | integer | Maximum failed execution resource retention period in seconds | `600` | No |
+| `config.execution.retainFailedExecutions` | boolean | Retain failed execution resources for bounded diagnosis | `false` | No |
 | `config.tekton.enabled` | boolean | true or omit = auto-discover CRDs; false = disable Tekton engine | `` | No |
 | `containerSecurityContext` | object | Kubernetes securityContext (pod or container level) | `` | No |
 | `debug.pprofEnabled` | boolean | Enables the /debug/pprof/* endpoints (net/http/pprof) on the service's health listener, or a dedicated :6060 pprof listener for controller-runtime-managed services. Defaults to false -- an operator must explicitly opt in. | `false` | No |

--- a/docs/tests/2392/IMPLEMENTATION_PLAN.md
+++ b/docs/tests/2392/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,279 @@
+# Implementation Plan: Failed Workflow Execution Resource Retention
+
+> Implementation plan for issue #2392.
+
+**Plan Identifier**: IP-2392-v1
+**Feature**: Retain failed workflow execution resources for bounded post-failure diagnosis across Job, Tekton, and Ansible/AWX engines.
+**Created**: 2026-09-12
+**Author**: Kubernaut maintainers
+**Status**: Implementation complete for the current code scope; CI integration/E2E validation pending
+**Branch**: `feat/2392-failed-execution-retention`
+**Issue**: [#2392](https://github.com/jordigilh/kubernaut/issues/2392)
+
+## 1. Business Requirements and Controls
+
+This change is backed by:
+
+- `BR-WE-014`: execution resources are created, observed, and cleaned up through the WorkflowExecution execution backend.
+- `BR-WE-015`: Ansible/AWX execution is a supported WorkflowExecution backend and must preserve its backend-specific lifecycle guarantees.
+- `BR-WE-019`: Job execution resource failures and retry information remain observable.
+- `BR-WORKFLOW-008`: execution failures must be actionable and observable without leaking dependency values.
+- `BR-AUDIT-005`: execution lifecycle evidence must remain reconstructable from the WorkflowExecution and execution-resource metadata.
+
+Applicable control objectives:
+
+- **FedRAMP AU-11**: failed execution evidence is retained for a bounded, configurable period.
+- **FedRAMP AU-9**: retained resources remain protected by existing namespace, ownership, and gateway boundaries.
+- **FedRAMP AC-6**: retries may replace only a terminal retained resource owned by the prior WorkflowExecution; active resources and unrelated owners are never deleted.
+- **FedRAMP AU-3**: retained resources carry sufficient non-secret execution identity metadata for reconstruction.
+- **OWASP ASVS V4.1.1/V4.1.3**: resource ownership and least-privilege authorization remain enforced during retention and replacement.
+- **OWASP ASVS V5.1.x**: retention configuration is parsed and validated, including positive bounded durations.
+- **OWASP ASVS V7.1.1/V7.2.1**: retention, replacement, and cleanup decisions are observable without logging credentials or workflow output.
+
+## 2. Outcome
+
+When enabled, a failed WorkflowExecution remains diagnosable for the configured retention period. The retained resource is removed automatically after that period, or earlier when a new execution for the same target safely replaces the old terminal resource. Successful executions retain the current cleanup behavior.
+
+The public configuration is generic rather than engine-specific:
+
+```yaml
+execution:
+  retainFailedExecutions: false
+  failedExecutionRetentionSeconds: 600
+```
+
+The existing defaults remain unchanged when the feature is disabled.
+
+## 3. Preflight Findings
+
+The relevant production paths are:
+
+- `pkg/workflowexecution/config/config.go`: `ExecutionConfig` is the existing YAML configuration seam.
+- `cmd/workflowexecution/main.go`: loads config, constructs the executor registry, and passes `ReconcilerOptions`.
+- `internal/controller/workflowexecution/workflowexecution_lifecycle.go`: owns cooldown cleanup and deletion finalization.
+- `pkg/workflowexecution/executor/executor.go`: shared `Executor` strategy interface.
+- `pkg/workflowexecution/executor/job.go`: creates Jobs with a hard-coded `TTLSecondsAfterFinished: 600` and deletes owned Jobs during cleanup.
+- `pkg/workflowexecution/executor/tekton.go`: creates and deletes owned PipelineRuns; no backend TTL is configured here.
+- `pkg/workflowexecution/executor/ansible.go`: cancels AWX jobs and deletes ephemeral credentials during cleanup.
+- `internal/controller/workflowexecution/workflowexecution_collision.go`: Job-only terminal collision replacement exists; Tekton currently treats an existing PipelineRun as a collision.
+- `charts/kubernaut/templates/workflowexecution/workflowexecution.yaml` and `charts/kubernaut/values.yaml`: Helm configuration wiring and defaults.
+- Existing `DD-WE-004` behavior treats failures during workflow execution as non-retryable (`wasExecutionFailure=true`) and routes them to manual intervention. Retention must not create an automatic retry path.
+
+Baseline validation on this branch passed:
+
+```text
+go test ./pkg/workflowexecution/...
+go test ./internal/controller/workflowexecution/...
+go test ./cmd/workflowexecution/...
+```
+
+## 4. Spikes and Decisions
+
+### Spike 1: Retention versus deterministic execution locks
+
+**Question**: Can a failed resource remain available for diagnosis without permanently blocking a later execution for the same target?
+
+**Finding**: Yes, but retention crosses two Kubernetes lifecycles. A WorkflowExecution is controller-owned by its RemediationRequest, so an RR terminal/deletion cascade can put the WFE into deletion while the execution resource is still being retained. The WorkflowExecution finalizer must remain until retention expires or replacement completes. A new execution may replace an expired or terminal retained resource, but never an active or differently-owned resource.
+
+**Decision**: Use option 1. Retain the original terminal resource until a separately authorized/new execution attempt or configured expiry, whichever comes first. Reuse the deterministic name and perform an ownership-checked terminal replacement before creating the new resource. Retention must not bypass `DD-WE-004`'s no-automatic-retry rule.
+
+### Spike 2: Kubernetes Job TTL interaction
+
+**Question**: Is changing executor cleanup sufficient for Job retention?
+
+**Finding**: No. `Job.Spec.TTLSecondsAfterFinished` currently prunes the Job and its pods independently of WorkflowExecution finalization. The TTL countdown begins from Job completion, while the WFE retention timer begins when Kubernaut observes and records failure, so equal values can prune diagnostics early. The current Job builder always sets a hard-coded 600-second TTL at creation, before the controller knows whether the execution will fail.
+
+**Decision**: When failed-execution retention is enabled, omit `TTLSecondsAfterFinished` for Jobs and make the WorkflowExecution controller the cleanup authority for both terminal outcomes. This avoids early diagnostic deletion caused by two clocks starting at different times. Successful Jobs remain subject to existing cooldown cleanup; failed Jobs are removed at the retention deadline. The default-off path preserves the existing 600-second Job TTL.
+
+### Spike 3: Tekton and Ansible semantics
+
+**Question**: Can the same policy cover non-Job engines without pretending they are Kubernetes Jobs?
+
+**Finding**: Yes, but the policy must be expressed in terms of the execution resource. Tekton retention is controlled by delaying PipelineRun cleanup, subject to any cluster-level Tekton pruner. AWX retention is controlled by not cancelling the failed AWX job, subject to AWX/AAP retention policy. AWX ephemeral credential deletion is independent and must continue immediately.
+
+**Decision**: Keep the policy and timer in the shared controller; retain/delete behavior remains engine-specific inside each executor.
+
+### Spike 4: Existing collision handling
+
+**Question**: Can existing collision paths safely replace a retained failed resource?
+
+**Finding**: Job has a terminal collision path, but it currently constructs a cleanup WFE without the existing owner identity, which is incompatible with the Job cleanup ownership check. Tekton has no equivalent terminal replacement path. Ansible launch IDs are external AWX identifiers and do not use the same deterministic Kubernetes collision path. This is a required implementation gap, not a reason to add a second resource naming scheme.
+
+**Decision**: Introduce a shared terminal-resource replacement capability or an equivalent executor operation that receives the verified existing owner identity. Extend Job and Tekton symmetrically. Ansible launch IDs are external AWX identifiers and do not use the same deterministic Kubernetes resource collision path.
+
+### Spike 5: AWX credential lifetime
+
+**Question**: Can failed AWX jobs be retained without retaining credentials created for them?
+
+**Finding**: Not with the current `AnsibleExecutor.Cleanup` boundary. `Cleanup` deletes ephemeral credentials and then cancels the AWX job. Delaying the whole method would keep credentials alive for the retention interval; skipping it would leak them.
+
+**Decision**: Split credential cleanup from execution-resource cancellation. Credential cleanup must run as soon as a terminal AWX failure is observed, while cancellation remains governed by the shared retention policy. User-requested WFE deletion must still cancel active AWX jobs.
+
+### Spike 6: Executor API shape
+
+**Question**: Can the controller trigger AWX-only credential cleanup without weakening the shared executor contract?
+
+**Finding**: The existing `Executor` interface is shared by Job, Tekton, and Ansible, and its `Cleanup` method means execution-resource deletion/cancellation. Making `Cleanup` retention-aware would force every backend to understand AWX credential semantics and would delay credential removal.
+
+**Decision**: Add a narrow optional capability for ephemeral-resource cleanup. The controller invokes it after a terminal AWX failure when implemented; Job and Tekton do not implement it. The existing `Cleanup` method remains the deletion/finalizer operation and keeps active-job cancellation behavior.
+
+### Spike 7: Terminal replacement authorization
+
+**Question**: Can deterministic-name replacement be made safe without creating an automatic retry path?
+
+**Finding**: Job replacement currently checks only whether the deterministic Job is terminal, then constructs a cleanup WFE without the original label owner (`workflowexecution_collision.go:84-89`). Cleanup refuses deletion because the synthetic WFE has an empty name. Tekton collision handling currently classifies a differently-owned PipelineRun as deduplicated and has no terminal replacement path. Gateway terminal phases allow a new RR, but `DD-WE-004` still requires execution failures to remain non-automatic/manual unless a new execution is explicitly authorized.
+
+**Decision**: Before replacement, read and validate the existing resource owner label, fetch the owner WFE, require the owner WFE to be terminal, and delete only that exact owner resource. Pass the verified owner identity to cleanup or delete directly. Extend this symmetrically to Job and Tekton. The path is reached only from creation of a new authorized WFE and does not alter retry/gating decisions.
+
+## 5. Scope
+
+### In scope
+
+- Add validated generic retention fields to `ExecutionConfig`.
+- Wire configuration through Helm, startup logging, executor creation, and `ReconcilerOptions`.
+- Delay failed-resource cleanup and WFE finalizer removal for the configured bounded period.
+- Retain failed Job/Pod diagnostics, Tekton PipelineRun/TaskRun diagnostics, and AWX job output where supported.
+- Preserve prompt, independent AWX ephemeral credential cleanup.
+- Add ownership-safe terminal replacement for retrying a target with a retained failed resource.
+- Add unit, integration, and engine-journey tests tied to the controls above.
+- Add operator-facing configuration documentation.
+
+### Out of scope
+
+- Retaining successful execution resources.
+- Retaining arbitrary workflow logs outside the backend resource lifecycle.
+- Changing execution-resource names or weakening deterministic locking.
+- Adding new RBAC permissions beyond the existing Job/PipelineRun access.
+- Changing AWX job retention policy outside Kubernaut’s cancellation behavior.
+- Guaranteeing retention against an independently configured Tekton pruner or AWX/AAP cleanup policy.
+
+## 6. Risks and Mitigations
+
+| ID | Risk | Mitigation | Tests |
+|---|---|---|---|
+| R1 | Retained resource blocks a valid retry | Replace only verified terminal resources owned by the prior WFE; keep active resources locked | `UT-WE-2392-RET-003`, `IT-WE-2392-004`, `E2E-WE-2392-001` |
+| R2 | Kubernetes TTL deletes failed Job diagnostics early | Disable the Job TTL only when retention is enabled and use controller-owned expiry | `UT-WE-2392-JOB-001`, `IT-WE-2392-JOB-002`, `IT-WE-2392-002` |
+| R3 | Unrelated resource is deleted during replacement | Require matching execution-owner label and terminal status | `UT-WE-2392-RET-004`, `IT-WE-2392-005` |
+| R4 | AWX credentials remain after retaining the job | Keep credential cleanup independent from job cancellation | `UT-WE-2392-AWX-002`, `IT-WE-2392-006` |
+| R5 | Invalid or unbounded retention configuration causes resource leaks | Validate positive duration and preserve secure default-off behavior | `UT-WE-2392-CFG-001`, `UT-WE-2392-CFG-002` |
+| R6 | Retention behavior differs by engine | Test the shared lifecycle and each executor’s resource-specific operation | `IT-WE-2392-001`, `IT-WE-2392-002`, `IT-WE-2392-003`, `IT-WE-2392-006` |
+| R7 | Diagnostic metadata leaks secrets | Assert labels, events, and logs contain identity/reason only, not Secret values or workflow output | `UT-WE-2392-OBS-001`, `IT-WE-2392-007` |
+| R8 | RR deletion cascades into WFE deletion before retention expires | Keep the WFE finalizer until expiry/replacement and test deletion while the parent is terminating | `UT-WE-2392-RET-005`, `IT-WE-2392-008` |
+| R9 | External Tekton/AWX pruning defeats retention | Document the guarantee boundary and treat missing external resources as safe terminal state | `UT-WE-2392-EXT-001`, `IT-WE-2392-009` |
+| R10 | Retention delays AWX credential cleanup | Invoke the optional ephemeral-resource cleanup capability at terminal failure and assert credentials are absent while the AWX job remains | `UT-WE-2392-AWX-003`, `IT-WE-2392-010` |
+| R11 | Retention accidentally enables automatic retry after execution failure | Preserve `wasExecutionFailure` / manual-intervention semantics; only an explicitly authorized new WFE may replace a retained resource | `UT-WE-2392-RETRY-001`, `IT-WE-2392-012`, `E2E-WE-2392-004` |
+
+## 7. Wiring Manifest
+
+| Component | Production entry point | Wiring location | IT proof |
+|---|---|---|---|
+| Retention configuration | WorkflowExecution startup | `cmd/workflowexecution/main.go`, `pkg/workflowexecution/config/config.go` | `IT-WE-2392-001` |
+| Shared retention lifecycle | Terminal and deletion reconciliation | `internal/controller/workflowexecution/workflowexecution_lifecycle.go` | `IT-WE-2392-002` |
+| Job retention and replacement | Job executor dispatch | `pkg/workflowexecution/executor/job.go`, `internal/controller/workflowexecution/workflowexecution_collision.go` | `IT-WE-2392-004` |
+| Tekton retention and replacement | Tekton executor dispatch | `pkg/workflowexecution/executor/tekton.go`, collision handling | `IT-WE-2392-005` |
+| Ansible retention and credential cleanup | Ansible executor dispatch | `pkg/workflowexecution/executor/ansible.go` | `IT-WE-2392-006` |
+| Helm configuration | WorkflowExecution ConfigMap rendering | `charts/kubernaut/values.yaml`, `templates/workflowexecution/workflowexecution.yaml` | `IT-WE-2392-003` |
+
+## 8. TDD Sequence
+
+### RED
+
+Write failing Ginkgo/Gomega tests before implementation:
+
+1. Configuration defaults to retention disabled and parses a positive bounded duration.
+2. Invalid zero/negative retention values fail validation when retention is enabled.
+3. Job creation omits the TTL only when retention is enabled and preserves the existing 600-second TTL when disabled.
+4. Shared terminal reconciliation retains failed resources during the window and cleans them at expiry.
+5. Deletion finalization does not remove a failed retained resource before expiry.
+6. Successful resources are cleaned at the existing cooldown boundary.
+7. Job replacement removes only a verified terminal resource owned by the prior WFE and only for a separately authorized/new execution.
+8. Tekton replacement has the same terminal ownership guarantees.
+9. Active and differently-owned resources remain untouched.
+10. Ansible retention skips AWX cancellation while deleting ephemeral credentials immediately after failure through the optional capability.
+11. Retention and replacement logs/events contain no credential or workflow-output values.
+12. Helm renders the generic settings into the WorkflowExecution ConfigMap and production startup consumes them.
+13. Execution failures remain non-retryable unless a separate authorized execution is created.
+
+Every test must identify its BR/control objective. No standard `testing.T`, `Skip`, `XIt`, or `PIt` tests are permitted.
+
+### GREEN
+
+1. Add `retainFailedExecutions` and `failedExecutionRetentionSeconds` to `ExecutionConfig` with secure defaults and validation.
+2. Pass a shared retention policy into the reconciler and required executor creation path.
+3. Make terminal and deletion reconciliation defer failed-resource cleanup until expiry.
+4. Make Job TTL conditional: preserve the default-off TTL and use controller-owned expiry when retention is enabled.
+5. Add ownership-safe terminal replacement for Job and Tekton resources.
+6. Add the optional ephemeral-resource cleanup capability and split AWX credential cleanup from conditionally suppressed job cancellation.
+7. Wire Helm values, `values.schema.json`, generated documentation, and startup logging.
+
+Run CHECKPOINT W immediately after GREEN. Every wiring-manifest row must have a production caller and a passing integration test.
+
+### REFACTOR
+
+- Centralize terminal-retention eligibility and expiry calculations.
+- Remove duplicated owner/terminal checks across Job and Tekton replacement paths.
+- Make retention logs and events structured and secret-safe.
+- Preserve the existing executor interface unless a narrowly scoped replacement capability is required.
+
+## 9. Test Pyramid and Control Matrix
+
+The pyramid invariant is mandatory: unit tests prove retention and ownership logic, integration tests prove production wiring and engine dispatch, and E2E tests prove the operator-visible remediation journey.
+
+| Control / outcome | Unit | Integration | E2E |
+|---|---|---|---|
+| AU-11 bounded failed-resource retention | `UT-WE-2392-CFG-001`, `UT-WE-2392-RET-001` | `IT-WE-2392-002` | `E2E-WE-2392-001` |
+| AU-9 protected retained evidence | `UT-WE-2392-RET-004`, `UT-WE-2392-OBS-001` | `IT-WE-2392-007` | `E2E-WE-2392-001`, `E2E-WE-2392-002` |
+| AC-6 ownership and least privilege | `UT-WE-2392-RET-003` | `IT-WE-2392-004`, `IT-WE-2392-005` | `E2E-WE-2392-001` |
+| AU-3 reconstructable execution identity | `UT-WE-2392-OBS-001` | `IT-WE-2392-002` | `E2E-WE-2392-001` |
+| ASVS V4.1.1/V4.1.3 ownership enforcement | `UT-WE-2392-RET-004` | `IT-WE-2392-004`, `IT-WE-2392-005` | `E2E-WE-2392-002` |
+| ASVS V5.1.x configuration validation | `UT-WE-2392-CFG-001`, `UT-WE-2392-CFG-002` | `IT-WE-2392-001`, `IT-WE-2392-003` | N/A; configuration wiring is proven at IT tier |
+| ASVS V7.1.1/V7.2.1 safe observability | `UT-WE-2392-OBS-001` | `IT-WE-2392-007` | `E2E-WE-2392-001` |
+| Ansible credentials remain ephemeral | `UT-WE-2392-AWX-002` | `IT-WE-2392-006` | `E2E-WE-2392-003` |
+
+## 10. Success Criteria
+
+- `go build ./...` passes.
+- `golangci-lint run --timeout=5m` introduces no new findings.
+- All affected Ginkgo unit and integration tests pass.
+- Job, Tekton, and Ansible failed-resource behavior is proven through production dispatch paths.
+- Successful cleanup and existing ownership protections regressions are absent.
+- The configured retention duration is bounded and default-off.
+- A separately authorized new execution can replace only the prior terminal retained resource and never an active or unrelated resource.
+- FedRAMP and OWASP ASVS control objectives in Section 9 have passing tests at the listed tiers.
+
+## 11. Reassessment Findings
+
+The second preflight pass changed the risk assessment:
+
+- Retention must cover both terminal reconciliation and deletion reconciliation because WFE deletion is normally cascaded from the RR owner.
+- The current Job terminal replacement helper has an owner-identity handoff defect that must be fixed before option 1 can work safely.
+- Existing `DD-WE-004` semantics prohibit automatic retry after an execution failure; retention must not weaken that safety boundary.
+- Tekton and AWX retention are best-effort against external pruners and retention policies; the acceptance criteria must not promise stronger guarantees.
+- AWX credential cleanup cannot remain coupled to delayed execution-resource cleanup.
+- Job TTL cannot simply equal the WFE retention duration because the two clocks start at different observations.
+- Helm wiring requires updates to the JSON schema and generated documentation in addition to the ConfigMap template.
+
+Spike resolutions:
+
+- **Job TTL**: conditional behavior. Retention-enabled Jobs have no Kubernetes TTL and are expired by the WFE controller; the default-off path preserves the existing 600-second TTL.
+- **AWX credentials**: an optional one-method ephemeral-resource cleanup capability leaves the shared `Executor.Cleanup` contract unchanged.
+- **Replacement**: owner-WFE validation plus terminal-state verification will be used for both Job and Tekton. The existing Job owner handoff defect is localized and testable.
+- **Retry semantics**: replacement is limited to a separately authorized/new WFE and does not change no-automatic-retry behavior for execution failures.
+
+These findings are sufficiently resolved to proceed to implementation. The RED tests encode the configuration, Job TTL, lifecycle, AWX credential, and terminal PipelineRun boundaries. They remain implementation risks to be validated by the integration tests listed above.
+
+## 12. Confidence
+
+**Preflight confidence: 91%.**
+
+Justification: focused spikes resolved the main design uncertainties and the RED/GREEN implementation now covers configuration, Job TTL behavior, controller retention/finalization timing, AWX credential separation, and owner-checked terminal PipelineRun replacement. Remaining risk is integration-level: controller timer/finalizer interactions, remote-client behavior, and Tekton API replacement semantics require dedicated integration coverage. Confidence remains above the 90% implementation gate.
+
+## 13. Current Implementation Checkpoint
+
+- Configuration defaults and validation are implemented and wired through startup logging, Helm, schema, and generated values documentation.
+- Retention-enabled Job resources omit Kubernetes TTL; default-off Jobs preserve the existing 600-second TTL.
+- Failed WFE terminal reconciliation and deletion finalization defer execution-resource cleanup until retention expiry.
+- AWX ephemeral credentials can be cleaned independently while a failed AWX job remains retained.
+- Job collision cleanup now requires an identified owner; Tekton replacement requires an owner WFE in terminal failure state.
+- Targeted Go tests, formatting, diff checks, and changed-package lint pass.
+- Local `make test-integration-workflowexecution` reached EnvTest CRD bootstrap and controller startup but exceeded the local timeout during suite startup/cleanup; no feature assertion ran. Full integration and end-to-end validation are delegated to CI.

--- a/internal/controller/workflowexecution/workflowexecution_collision.go
+++ b/internal/controller/workflowexecution/workflowexecution_collision.go
@@ -25,11 +25,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -81,9 +83,16 @@ func (r *WorkflowExecutionReconciler) handleJobAlreadyExists(
 	logger.Info("Stale completed Job detected, cleaning up before retry (Issue #374)",
 		"resource", resourceName)
 
+	ownerName := r.getOriginalWFEFromJob(ctx, resourceName)
+	if ownerName == "" {
+		logger.Info("Terminal Job has no WorkflowExecution owner; refusing replacement", "resource", resourceName)
+		return nil, false, false, ""
+	}
 	cleanupWFE := &workflowexecutionv1alpha1.WorkflowExecution{
+		ObjectMeta: metav1.ObjectMeta{Name: ownerName},
 		Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
 			TargetResource: wfe.Spec.TargetResource,
+			ClusterID:      wfe.Spec.ClusterID,
 		},
 	}
 	if cleanErr := jobExec.Cleanup(ctx, cleanupWFE, r.ExecutionNamespace); cleanErr != nil {
@@ -173,6 +182,16 @@ func (r *WorkflowExecutionReconciler) HandleAlreadyExists(ctx context.Context, w
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	if r.RetainFailedExecutions {
+		result, replaced, replaceErr := r.replaceFailedPipelineRun(ctx, wfe, resourceName, existingPR, logger)
+		if replaceErr != nil {
+			return ctrl.Result{}, replaceErr
+		}
+		if replaced {
+			return result, nil
+		}
+	}
+
 	// Issue #190: Another WFE created this PipelineRun — classify as Deduplicated
 	// when the original WFE can be identified from labels.
 	originalWFE := existingPR.Labels["kubernaut.ai/workflow-execution"]
@@ -190,4 +209,54 @@ func (r *WorkflowExecutionReconciler) HandleAlreadyExists(ctx context.Context, w
 	markErr := r.MarkFailedWithReason(ctx, wfe, "Unknown",
 		fmt.Sprintf("PipelineRun '%s' already exists for target resource (owner label missing)", resourceName))
 	return ctrl.Result{}, markErr
+}
+
+func (r *WorkflowExecutionReconciler) replaceFailedPipelineRun(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution, resourceName string, existingPR *tektonv1.PipelineRun, logger logr.Logger) (ctrl.Result, bool, error) {
+	if !pipelineRunFailed(existingPR) {
+		return ctrl.Result{}, false, nil
+	}
+	ownerName := existingPR.Labels["kubernaut.ai/workflow-execution"]
+	ownerNamespace := existingPR.Labels["kubernaut.ai/source-namespace"]
+	if ownerName == "" || ownerNamespace == "" {
+		return ctrl.Result{}, false, nil
+	}
+	var ownerWFE workflowexecutionv1alpha1.WorkflowExecution
+	if err := r.Get(ctx, client.ObjectKey{Name: ownerName, Namespace: ownerNamespace}, &ownerWFE); err != nil {
+		return ctrl.Result{}, false, fmt.Errorf("get owner WorkflowExecution %s/%s: %w", ownerNamespace, ownerName, err)
+	}
+	if ownerWFE.Status.Phase != workflowexecutionv1alpha1.PhaseFailed {
+		return ctrl.Result{}, false, nil
+	}
+
+	logger.Info("Replacing terminal retained PipelineRun", "name", resourceName, "owner", ownerNamespace+"/"+ownerName)
+	if deleteErr := r.Delete(ctx, existingPR); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+		return ctrl.Result{}, false, fmt.Errorf("delete terminal retained PipelineRun: %w", deleteErr)
+	}
+	if r.ExecutorRegistry == nil {
+		return ctrl.Result{}, false, fmt.Errorf("executor registry is required to replace terminal retained PipelineRun")
+	}
+	exec, execErr := r.ExecutorRegistry.Get(wfe.Spec.WorkflowRef.ExecutionEngine)
+	if execErr != nil {
+		return ctrl.Result{}, false, fmt.Errorf("get executor for terminal PipelineRun replacement: %w", execErr)
+	}
+	if _, createErr := exec.Create(ctx, wfe, r.ExecutionNamespace, weexecutor.CreateOptions{
+		Dependencies:           convertWorkflowDependencies(wfe.Spec.WorkflowRef.Dependencies),
+		DeclaredParameterNames: wfe.Spec.WorkflowRef.DeclaredParameterNames,
+		RetainFailedExecutions: r.RetainFailedExecutions,
+	}); createErr != nil {
+		if apierrors.IsAlreadyExists(createErr) {
+			return ctrl.Result{RequeueAfter: time.Second}, true, nil
+		}
+		return ctrl.Result{}, false, fmt.Errorf("create replacement PipelineRun: %w", createErr)
+	}
+	return ctrl.Result{RequeueAfter: 10 * time.Second}, true, nil
+}
+
+func pipelineRunFailed(pr *tektonv1.PipelineRun) bool {
+	for _, condition := range pr.Status.Conditions {
+		if condition.Type == apis.ConditionSucceeded && condition.Status == corev1.ConditionFalse {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/controller/workflowexecution/workflowexecution_controller.go
+++ b/internal/controller/workflowexecution/workflowexecution_controller.go
@@ -143,6 +143,13 @@ type WorkflowExecutionReconciler struct {
 	// Default: 5 minutes
 	CooldownPeriod time.Duration
 
+	// RetainFailedExecutions keeps failed execution resources available for
+	// bounded diagnosis (BR-WE-019, FedRAMP AU-11).
+	RetainFailedExecutions bool
+
+	// FailedExecutionRetention is the bounded failed-resource retention period.
+	FailedExecutionRetention time.Duration
+
 	// AuditStore for writing audit events (BR-WE-005, ADR-032)
 	// Uses pkg/audit buffered store via Data Storage Service
 	// Optional: nil disables audit (graceful degradation)
@@ -172,14 +179,16 @@ type WorkflowExecutionReconciler struct {
 // WorkflowExecution reconciler. Fields extracted from ctrl.Manager (Client,
 // APIReader, Scheme, Recorder) are populated automatically by NewReconciler.
 type ReconcilerOptions struct {
-	ExecutionNamespace string
-	CooldownPeriod     time.Duration
-	Metrics            *metrics.Metrics
-	StatusManager      *status.Manager
-	AuditStore         audit.AuditStore
-	PhaseManager       *wephase.Manager
-	AuditManager       *weaudit.Manager
-	ExecutorRegistry   *weexecutor.Registry
+	ExecutionNamespace       string
+	CooldownPeriod           time.Duration
+	RetainFailedExecutions   bool
+	FailedExecutionRetention time.Duration
+	Metrics                  *metrics.Metrics
+	StatusManager            *status.Manager
+	AuditStore               audit.AuditStore
+	PhaseManager             *wephase.Manager
+	AuditManager             *weaudit.Manager
+	ExecutorRegistry         *weexecutor.Registry
 }
 
 // NewReconciler creates a WorkflowExecutionReconciler, extracting
@@ -188,18 +197,20 @@ type ReconcilerOptions struct {
 // site from ~13 fields to 2 (mgr + opts).
 func NewReconciler(mgr ctrl.Manager, opts ReconcilerOptions) *WorkflowExecutionReconciler {
 	return &WorkflowExecutionReconciler{
-		Client:             mgr.GetClient(),
-		APIReader:          mgr.GetAPIReader(),
-		Scheme:             mgr.GetScheme(),
-		Recorder:           mgr.GetEventRecorderFor("workflowexecution-controller"),
-		Metrics:            opts.Metrics,
-		StatusManager:      opts.StatusManager,
-		ExecutionNamespace: opts.ExecutionNamespace,
-		CooldownPeriod:     opts.CooldownPeriod,
-		AuditStore:         opts.AuditStore,
-		PhaseManager:       opts.PhaseManager,
-		AuditManager:       opts.AuditManager,
-		ExecutorRegistry:   opts.ExecutorRegistry,
+		Client:                   mgr.GetClient(),
+		APIReader:                mgr.GetAPIReader(),
+		Scheme:                   mgr.GetScheme(),
+		Recorder:                 mgr.GetEventRecorderFor("workflowexecution-controller"),
+		Metrics:                  opts.Metrics,
+		StatusManager:            opts.StatusManager,
+		ExecutionNamespace:       opts.ExecutionNamespace,
+		CooldownPeriod:           opts.CooldownPeriod,
+		RetainFailedExecutions:   opts.RetainFailedExecutions,
+		FailedExecutionRetention: opts.FailedExecutionRetention,
+		AuditStore:               opts.AuditStore,
+		PhaseManager:             opts.PhaseManager,
+		AuditManager:             opts.AuditManager,
+		ExecutorRegistry:         opts.ExecutorRegistry,
 	}
 }
 

--- a/internal/controller/workflowexecution/workflowexecution_lifecycle.go
+++ b/internal/controller/workflowexecution/workflowexecution_lifecycle.go
@@ -111,6 +111,7 @@ func (r *WorkflowExecutionReconciler) handleRunningExecutionResult(ctx context.C
 
 	case workflowexecutionv1alpha1.PhaseFailed:
 		logger.Info("Execution failed", "engine", wfe.Spec.WorkflowRef.ExecutionEngine, "reason", result.Reason)
+		r.cleanupEphemeralExecutionResources(ctx, wfe, logger)
 		pr := r.fetchTektonPipelineRunForMark(ctx, wfe)
 		res, err := r.MarkFailed(ctx, wfe, pr, result.Summary)
 		return res, err, true
@@ -122,6 +123,23 @@ func (r *WorkflowExecutionReconciler) handleRunningExecutionResult(ctx context.C
 			weconditions.ReasonExecutionStarted,
 			fmt.Sprintf("Execution running (%s: %s)", wfe.Spec.WorkflowRef.ExecutionEngine, result.Reason))
 		return ctrl.Result{}, nil, false
+	}
+}
+
+func (r *WorkflowExecutionReconciler) cleanupEphemeralExecutionResources(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution, logger logr.Logger) {
+	if r.ExecutorRegistry == nil {
+		return
+	}
+	exec, err := r.ExecutorRegistry.Get(wfe.Spec.WorkflowRef.ExecutionEngine)
+	if err != nil || exec == nil {
+		return
+	}
+	cleaner, ok := exec.(weexecutor.EphemeralResourceCleaner)
+	if !ok {
+		return
+	}
+	if err := cleaner.CleanupEphemeralResources(ctx, wfe, r.ExecutionNamespace); err != nil {
+		logger.Error(err, "Failed to cleanup ephemeral execution resources after terminal failure", "engine", exec.Engine())
 	}
 }
 
@@ -167,6 +185,14 @@ func (r *WorkflowExecutionReconciler) ReconcileTerminal(ctx context.Context, wfe
 		wfe.Status.CompletionTime = &now
 	}
 
+	if remaining, retain := r.failedExecutionRetentionRemaining(wfe); retain && remaining > 0 {
+		logger.V(1).Info("Retaining failed execution resource",
+			"remaining", remaining,
+			"targetResource", wfe.Spec.TargetResource,
+		)
+		return ctrl.Result{RequeueAfter: remaining}, nil
+	}
+
 	// Get cooldown period (use default if not set)
 	cooldown := r.CooldownPeriod
 	if cooldown == 0 {
@@ -197,6 +223,28 @@ func (r *WorkflowExecutionReconciler) ReconcileTerminal(ctx context.Context, wfe
 		fmt.Sprintf("Lock released for %s after cooldown", wfe.Spec.TargetResource))
 
 	return ctrl.Result{}, nil
+}
+
+// failedExecutionRetentionRemaining reports whether a failed WFE is within the
+// configured retention window and how long remains (BR-WE-019, AU-11).
+func (r *WorkflowExecutionReconciler) failedExecutionRetentionRemaining(wfe *workflowexecutionv1alpha1.WorkflowExecution) (time.Duration, bool) {
+	if !r.RetainFailedExecutions || r.FailedExecutionRetention <= 0 || wfe.Status.Phase != workflowexecutionv1alpha1.PhaseFailed {
+		return 0, false
+	}
+	var anchor time.Time
+	switch {
+	case wfe.Status.CompletionTime != nil:
+		anchor = wfe.Status.CompletionTime.Time
+	case !wfe.DeletionTimestamp.IsZero():
+		anchor = wfe.DeletionTimestamp.Time
+	default:
+		return 0, false
+	}
+	remaining := r.FailedExecutionRetention - time.Since(anchor)
+	if remaining <= 0 {
+		return 0, true
+	}
+	return remaining, true
 }
 
 // releaseExecutionLock deletes the execution resource to release the
@@ -363,6 +411,10 @@ func (r *WorkflowExecutionReconciler) ReconcileDelete(ctx context.Context, wfe *
 	// Check if finalizer is present
 	if !controllerutil.ContainsFinalizer(wfe, FinalizerName) {
 		return ctrl.Result{}, nil
+	}
+	if remaining, retain := r.failedExecutionRetentionRemaining(wfe); retain && remaining > 0 {
+		logger.V(1).Info("Deferring failed execution finalization until retention expires", "remaining", remaining)
+		return ctrl.Result{RequeueAfter: remaining}, nil
 	}
 
 	// ========================================

--- a/internal/controller/workflowexecution/workflowexecution_pending.go
+++ b/internal/controller/workflowexecution/workflowexecution_pending.go
@@ -68,6 +68,7 @@ func (r *WorkflowExecutionReconciler) resolveSchemaMetadata(_ context.Context, w
 	opts := weexecutor.CreateOptions{
 		Dependencies:           convertWorkflowDependencies(ref.Dependencies),
 		DeclaredParameterNames: ref.DeclaredParameterNames,
+		RetainFailedExecutions: r.RetainFailedExecutions,
 	}
 	return nil, opts, nil
 }

--- a/internal/controller/workflowexecution/workflowexecution_pending_test.go
+++ b/internal/controller/workflowexecution/workflowexecution_pending_test.go
@@ -45,7 +45,7 @@ var _ = Describe("resolveSchemaMetadata (Issue #1661 Change 11e)", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		r = &WorkflowExecutionReconciler{}
+		r = &WorkflowExecutionReconciler{RetainFailedExecutions: true}
 
 		wfe = &workflowexecutionv1alpha1.WorkflowExecution{
 			Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
@@ -72,6 +72,7 @@ var _ = Describe("resolveSchemaMetadata (Issue #1661 Change 11e)", func() {
 			ConfigMaps: []models.ResourceDependency{{Name: "app-config"}},
 		}), "Dependencies must be converted from wfe.Spec.WorkflowRef.Dependencies, not fetched from the (forbidden) DS schema")
 		Expect(opts.DeclaredParameterNames).To(Equal(map[string]bool{"TARGET_POD": true, "NAMESPACE": true}))
+		Expect(opts.RetainFailedExecutions).To(BeTrue())
 	})
 
 	It("UT-WE-1661-006: builds nil CreateOptions.Dependencies when WorkflowRef.Dependencies is nil (no filtering, backward compatible)", func() {

--- a/internal/controller/workflowexecution/workflowexecution_retention_test.go
+++ b/internal/controller/workflowexecution/workflowexecution_retention_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflowexecution
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	workflowexecutionv1alpha1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
+)
+
+var _ = Describe("UT-WE-2392-RET: failed execution retention lifecycle (BR-WE-019, AU-11)", func() {
+	It("UT-WE-2392-RET-001: calculates remaining retention from terminal completion time", func() {
+		completedAt := metav1.NewTime(time.Now().Add(-30 * time.Second))
+		r := &WorkflowExecutionReconciler{
+			RetainFailedExecutions:   true,
+			FailedExecutionRetention: 2 * time.Minute,
+		}
+		wfe := &workflowexecutionv1alpha1.WorkflowExecution{
+			Status: workflowexecutionv1alpha1.WorkflowExecutionStatus{
+				Phase:          workflowexecutionv1alpha1.PhaseFailed,
+				CompletionTime: &completedAt,
+			},
+		}
+
+		remaining, retain := r.failedExecutionRetentionRemaining(wfe)
+
+		Expect(retain).To(BeTrue())
+		Expect(remaining).To(BeNumerically(">", 0))
+		Expect(remaining).To(BeNumerically("<", 2*time.Minute))
+	})
+
+	It("UT-WE-2392-RET-002: does not retain completed executions", func() {
+		r := &WorkflowExecutionReconciler{
+			RetainFailedExecutions:   true,
+			FailedExecutionRetention: 2 * time.Minute,
+		}
+		wfe := &workflowexecutionv1alpha1.WorkflowExecution{
+			Status: workflowexecutionv1alpha1.WorkflowExecutionStatus{
+				Phase: workflowexecutionv1alpha1.PhaseCompleted,
+			},
+		}
+
+		remaining, retain := r.failedExecutionRetentionRemaining(wfe)
+
+		Expect(retain).To(BeFalse())
+		Expect(remaining).To(Equal(time.Duration(0)))
+	})
+
+	It("UT-WE-2392-RET-003: retains a failed WFE being deleted when completion time is absent", func() {
+		deletedAt := metav1.NewTime(time.Now())
+		r := &WorkflowExecutionReconciler{
+			RetainFailedExecutions:   true,
+			FailedExecutionRetention: 2 * time.Minute,
+		}
+		wfe := &workflowexecutionv1alpha1.WorkflowExecution{
+			ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &deletedAt},
+			Status: workflowexecutionv1alpha1.WorkflowExecutionStatus{
+				Phase: workflowexecutionv1alpha1.PhaseFailed,
+			},
+		}
+
+		remaining, retain := r.failedExecutionRetentionRemaining(wfe)
+
+		Expect(retain).To(BeTrue())
+		Expect(remaining).To(BeNumerically(">", 0))
+	})
+
+	It("UT-WE-2392-RET-004: recognizes only failed terminal PipelineRuns for replacement", func() {
+		failed := &tektonv1.PipelineRun{Status: tektonv1.PipelineRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionFalse}}}}}
+		completed := &tektonv1.PipelineRun{Status: tektonv1.PipelineRunStatus{Status: duckv1.Status{Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue}}}}}
+
+		Expect(pipelineRunFailed(failed)).To(BeTrue())
+		Expect(pipelineRunFailed(completed)).To(BeFalse())
+	})
+})

--- a/pkg/workflowexecution/ansible_executor_test.go
+++ b/pkg/workflowexecution/ansible_executor_test.go
@@ -706,6 +706,34 @@ var _ = Describe("AnsibleExecutor dependencies.secrets injection (BR-WE-015)", f
 	})
 
 	Context("Cleanup with ephemeral credentials", func() {
+		It("UT-WE-2392-AWX-003 [BR-WE-015, AU-9]: deletes credentials without cancelling a retained failed AWX job", func() {
+			fakeClient = newFakeClient()
+			ansibleExec = executor.NewAnsibleExecutor(awxClient, fakeClient, nil, 1, ctrl.Log.WithName("test"))
+
+			var deletedCredIDs []int
+			awxClient.deleteCredentialFn = func(_ context.Context, credID int) error {
+				deletedCredIDs = append(deletedCredIDs, credID)
+				return nil
+			}
+			cancelCalled := false
+			awxClient.cancelFunc = func(_ context.Context, _ int) error {
+				cancelCalled = true
+				return nil
+			}
+
+			wfe := &workflowexecutionv1alpha1.WorkflowExecution{
+				ObjectMeta: metav1.ObjectMeta{Name: "retained-failed-awx", Namespace: "default"},
+				Status: workflowexecutionv1alpha1.WorkflowExecutionStatus{
+					EphemeralCredentialIDs: []int{42, 55},
+					ExecutionRef:           &corev1.LocalObjectReference{Name: "awx-job-99"},
+				},
+			}
+
+			Expect(ansibleExec.CleanupEphemeralResources(ctx, wfe, "default")).To(Succeed())
+			Expect(deletedCredIDs).To(ConsistOf(42, 55))
+			Expect(cancelCalled).To(BeFalse())
+		})
+
 		It("UT-WE-015-034: should delete ephemeral credentials from status before cancelling job", func() {
 			fakeClient = newFakeClient()
 			ansibleExec = executor.NewAnsibleExecutor(awxClient, fakeClient, nil, 1, ctrl.Log.WithName("test"))

--- a/pkg/workflowexecution/config/config.go
+++ b/pkg/workflowexecution/config/config.go
@@ -147,6 +147,20 @@ type ExecutionConfig struct {
 
 	// CooldownPeriod prevents redundant sequential workflows (DD-WE-001)
 	CooldownPeriod time.Duration `yaml:"cooldownPeriod" validate:"required,gt=0"`
+
+	// RetainFailedExecutions keeps failed execution resources available for
+	// bounded diagnosis (BR-WE-019, FedRAMP AU-11). Default is disabled.
+	RetainFailedExecutions bool `yaml:"retainFailedExecutions"`
+
+	// FailedExecutionRetentionSeconds is the bounded failed-resource retention
+	// period. It is validated when retention is enabled.
+	FailedExecutionRetentionSeconds int64 `yaml:"failedExecutionRetentionSeconds" validate:"gte=0,lte=604800"`
+}
+
+// FailedExecutionRetention returns the configured failed-resource retention
+// period (BR-WE-019, FedRAMP AU-11).
+func (c ExecutionConfig) FailedExecutionRetention() time.Duration {
+	return time.Duration(c.FailedExecutionRetentionSeconds) * time.Second
 }
 
 // ControllerConfig holds controller runtime settings.
@@ -176,8 +190,9 @@ type ControllerConfig struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Execution: ExecutionConfig{
-			Namespace:      "kubernaut-workflows",
-			CooldownPeriod: 5 * time.Minute,
+			Namespace:                       "kubernaut-workflows",
+			CooldownPeriod:                  5 * time.Minute,
+			FailedExecutionRetentionSeconds: 600,
 		},
 		DataStorage: sharedconfig.DefaultDataStorageConfig(),
 		Logging:     sharedconfig.DefaultLoggingConfig(),
@@ -239,6 +254,9 @@ func (c *Config) Validate() error {
 	validate := validator.New()
 	if err := validate.Struct(c); err != nil {
 		return err
+	}
+	if c.Execution.RetainFailedExecutions && c.Execution.FailedExecutionRetentionSeconds <= 0 {
+		return fmt.Errorf("failed execution retention seconds must be positive when retention is enabled")
 	}
 	// DataStorage uses shared validation (ADR-030)
 	if err := sharedconfig.ValidateDataStorageConfig(&c.DataStorage); err != nil {

--- a/pkg/workflowexecution/config/config_test.go
+++ b/pkg/workflowexecution/config/config_test.go
@@ -19,6 +19,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -129,5 +130,44 @@ fleet:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg.Fleet.OAuth2.Scopes).To(BeNil())
 		})
+	})
+})
+
+var _ = Describe("UT-WE-2392-CFG: failed execution retention configuration (BR-WE-014, AU-11, ASVS V5.1.x)", func() {
+	It("UT-WE-2392-CFG-001: defaults retention off with a bounded 600-second period", func() {
+		cfg := weconfig.DefaultConfig()
+
+		Expect(cfg.Execution.RetainFailedExecutions).To(BeFalse())
+		Expect(cfg.Execution.FailedExecutionRetentionSeconds).To(Equal(int64(600)))
+	})
+
+	It("UT-WE-2392-CFG-002: parses retention settings from YAML", func() {
+		yamlContent := `
+execution:
+  namespace: kubernaut-workflows
+  cooldownPeriod: 5m
+  retainFailedExecutions: true
+  failedExecutionRetentionSeconds: 900
+`
+		tmpDir, err := os.MkdirTemp("", "we-retention-cfg-*")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+		cfgPath := filepath.Join(tmpDir, "config.yaml")
+		Expect(os.WriteFile(cfgPath, []byte(yamlContent), 0o600)).To(Succeed())
+
+		cfg, err := weconfig.LoadFromFile(cfgPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Execution.RetainFailedExecutions).To(BeTrue())
+		Expect(cfg.Execution.FailedExecutionRetentionSeconds).To(Equal(int64(900)))
+		Expect(cfg.Execution.FailedExecutionRetention()).To(Equal(15 * time.Minute))
+	})
+
+	It("UT-WE-2392-CFG-003: rejects enabled retention with a non-positive period", func() {
+		cfg := weconfig.DefaultConfig()
+		cfg.Execution.RetainFailedExecutions = true
+		cfg.Execution.FailedExecutionRetentionSeconds = 0
+
+		Expect(cfg.Validate()).To(HaveOccurred())
 	})
 })

--- a/pkg/workflowexecution/executor/ansible.go
+++ b/pkg/workflowexecution/executor/ansible.go
@@ -766,13 +766,17 @@ func (a *AnsibleExecutor) GetStatus(
 	return MapAWXStatusToResult(status), nil
 }
 
-// Cleanup deletes ephemeral AWX credentials (if any) and cancels the AWX job.
+// Cleanup cancels the AWX job and deletes ephemeral credentials during WFE
+// finalization. Terminal failure retention uses CleanupEphemeralResources so
+// credentials do not outlive the retention policy.
 func (a *AnsibleExecutor) Cleanup(
 	ctx context.Context,
 	wfe *workflowexecutionv1alpha1.WorkflowExecution,
 	namespace string,
 ) error {
-	a.cleanupEphemeralCredentials(ctx, wfe)
+	if err := a.CleanupEphemeralResources(ctx, wfe, namespace); err != nil {
+		a.Logger.Error(err, "Failed to cleanup ephemeral AWX credentials during cleanup")
+	}
 
 	if wfe.Status.ExecutionRef == nil {
 		return nil
@@ -796,6 +800,17 @@ func (a *AnsibleExecutor) Cleanup(
 		a.Logger.Error(err, "Failed to cancel AWX job during cleanup (best-effort, not blocking finalizer)", "jobID", jobID)
 	}
 
+	return nil
+}
+
+// CleanupEphemeralResources deletes AWX credentials created for a WFE while
+// leaving its execution job untouched (BR-WE-015, FedRAMP AU-9).
+func (a *AnsibleExecutor) CleanupEphemeralResources(
+	ctx context.Context,
+	wfe *workflowexecutionv1alpha1.WorkflowExecution,
+	_ string,
+) error {
+	a.cleanupEphemeralCredentials(ctx, wfe)
 	return nil
 }
 

--- a/pkg/workflowexecution/executor/executor.go
+++ b/pkg/workflowexecution/executor/executor.go
@@ -36,6 +36,10 @@ import (
 type CreateOptions struct {
 	Dependencies *models.WorkflowDependencies
 
+	// RetainFailedExecutions disables backend-native cleanup that could remove
+	// failed diagnostics before the controller retention deadline (BR-WE-019).
+	RetainFailedExecutions bool
+
 	// DeclaredParameterNames is the set of parameter names declared in the
 	// workflow schema (from DS catalog). Used by executors to strip undeclared
 	// parameters before injecting them into execution resources.
@@ -94,6 +98,13 @@ type Executor interface {
 
 	// Engine returns the execution engine identifier ("tekton", "job", or "ansible")
 	Engine() string
+}
+
+// EphemeralResourceCleaner is an optional executor capability for deleting
+// short-lived supporting resources without deleting the execution resource
+// itself (BR-WE-015, ASVS V7.1.1).
+type EphemeralResourceCleaner interface {
+	CleanupEphemeralResources(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution, namespace string) error
 }
 
 // ExecutionResult represents the mapped status of an execution resource.

--- a/pkg/workflowexecution/executor/job.go
+++ b/pkg/workflowexecution/executor/job.go
@@ -451,6 +451,10 @@ func (j *JobExecutor) buildJob(ctx context.Context, wfe *workflowexecutionv1alph
 	var backoffLimit int32 = 0
 	var ttlSeconds int32 = 600
 	activeDeadlineSeconds := activeDeadlineSecondsFor(wfe)
+	var ttlSecondsAfterFinished *int32
+	if !opts.RetainFailedExecutions {
+		ttlSecondsAfterFinished = &ttlSeconds
+	}
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -469,7 +473,7 @@ func (j *JobExecutor) buildJob(ctx context.Context, wfe *workflowexecutionv1alph
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit:            &backoffLimit,
-			TTLSecondsAfterFinished: &ttlSeconds,
+			TTLSecondsAfterFinished: ttlSecondsAfterFinished,
 			ActiveDeadlineSeconds:   &activeDeadlineSeconds,
 			PodFailurePolicy:        jobPodFailurePolicy(),
 			Template: corev1.PodTemplateSpec{

--- a/pkg/workflowexecution/executor/job_test.go
+++ b/pkg/workflowexecution/executor/job_test.go
@@ -179,6 +179,37 @@ var _ = Describe("UT-WE-054-JOB: JobExecutor", func() {
 			Expect(envNames).To(ContainElement("TIMEOUT"))
 		})
 
+		It("UT-WE-2392-JOB-001 [BR-WE-014, AU-11]: omits Kubernetes TTL when failed execution retention is enabled", func() {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			factory := &mockClientFactory{client: fakeClient}
+			je := executor.NewJobExecutorWithFactory(factory)
+			wfe := newTestWFE("wfe-retention-enabled", "default/deployment/api", "")
+
+			result, err := je.Create(ctx, wfe, namespace, executor.CreateOptions{
+				RetainFailedExecutions: true,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			var job batchv1.Job
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: result.ResourceName, Namespace: namespace}, &job)).To(Succeed())
+			Expect(job.Spec.TTLSecondsAfterFinished).To(BeNil())
+		})
+
+		It("UT-WE-2392-JOB-002 [BR-WE-014]: preserves the existing TTL when retention is disabled", func() {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			factory := &mockClientFactory{client: fakeClient}
+			je := executor.NewJobExecutorWithFactory(factory)
+			wfe := newTestWFE("wfe-retention-disabled", "default/deployment/api", "")
+
+			result, err := je.Create(ctx, wfe, namespace, executor.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			var job batchv1.Job
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: result.ResourceName, Namespace: namespace}, &job)).To(Succeed())
+			Expect(job.Spec.TTLSecondsAfterFinished).ToNot(BeNil())
+			Expect(*job.Spec.TTLSecondsAfterFinished).To(Equal(int32(600)))
+		})
+
 		It("UT-WE-2390-001 [DD-WE-006, AC-6]: should mount secret and configmap dependencies read-only", func() {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			factory := &mockClientFactory{client: fakeClient}


### PR DESCRIPTION
## Summary
- Add bounded, opt-in retention for failed WorkflowExecution resources.
- Preserve failed Job, Tekton PipelineRun, and Ansible/AWX diagnostics during the configured window.
- Keep AWX ephemeral credential cleanup immediate while retaining the failed AWX job.
- Add ownership-safe Job/Tekton terminal replacement for separately authorized executions.
- Wire configuration through startup, Helm schema/templates, generated documentation, and tests.
- Document the implementation and control/test matrix in `docs/tests/2392/IMPLEMENTATION_PLAN.md`.

## Relationship
- Stacked on #2391 to consolidate related work and reduce GitHub resource usage.

## Validation
- `go build ./...` passed.
- Focused WorkflowExecution Go tests passed.
- Changed-package `golangci-lint` passed with 0 issues.
- `gofmt -l` returned no files.
- `git diff --check` passed.
- Local `make test-integration-workflowexecution` reached EnvTest CRD bootstrap and controller startup but exceeded the local timeout before feature assertions; full integration/E2E validation is intended for CI.

Closes #2392
